### PR TITLE
Prc/27 epoch activity counter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "modules/drep_state",              # DRep state
     "modules/governance_state",        # Governance state
     "modules/stake_delta_filter",      # Filters address deltas
+    "modules/epoch_activity_counter",  # Counts fees and block producers for rewards
 
     # Process builds
     "processes/omnibus",               # All-inclusive omnibus process

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ structure is highly subject to change:
 * [Tx Unpacker](modules/tx_unpacker) - parses transactions and generates UTXO
   changes
 * [UTXO State](modules/utxo_state) - watches UTXO changes and maintains a basic in-memory UTXO state
+* [SPO State](modules/spo_state) - matches SPO registrations and retirements
+* [Epoch Activity Counter](modules/epoch_activity_couinter) - counts fees and block production for rewards
 
 ```mermaid
 graph LR

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -14,7 +14,7 @@ pub use caryatid_module_rest_server::messages::{
 };
 
 /// Block header message
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockHeaderMessage {
     /// Block info
     pub block: BlockInfo,
@@ -24,7 +24,7 @@ pub struct BlockHeaderMessage {
 }
 
 /// Block body message
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockBodyMessage {
     /// Block info
     pub block: BlockInfo,
@@ -34,14 +34,14 @@ pub struct BlockBodyMessage {
 }
 
 /// Snapshot completion message
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct SnapshotCompleteMessage {
     /// Last block in snapshot data
     pub last_block: BlockInfo,
 }
 
 /// Transactions message
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RawTxsMessage {
     /// Block info
     pub block: BlockInfo,
@@ -51,14 +51,14 @@ pub struct RawTxsMessage {
 }
 
 /// Genesis completion message
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GenesisCompleteMessage {
     // Conway genesis block
     pub conway_genesis: Option<ConwayGenesisParams>,
 }
 
 /// Message encapsulating multiple UTXO deltas, in order
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UTXODeltasMessage {
     /// Block info
     pub block: BlockInfo,
@@ -68,7 +68,7 @@ pub struct UTXODeltasMessage {
 }
 
 /// Message encapsulating multiple transaction certificates, in order
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TxCertificatesMessage {
     /// Block info
     pub block: BlockInfo,
@@ -78,7 +78,7 @@ pub struct TxCertificatesMessage {
 }
 
 /// Address deltas message
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AddressDeltasMessage {
     /// Block info
     pub block: BlockInfo,
@@ -88,7 +88,7 @@ pub struct AddressDeltasMessage {
 }
 
 /// Stake address part of address deltas message
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StakeAddressDeltasMessage {
     /// Block info
     pub block: BlockInfo,
@@ -97,7 +97,7 @@ pub struct StakeAddressDeltasMessage {
     pub deltas: Vec<StakeAddressDelta>
 }
 
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GovernanceProceduresMessage {
     /// Block info
     pub block: BlockInfo,
@@ -109,7 +109,7 @@ pub struct GovernanceProceduresMessage {
     pub voting_procedures: Vec<(DataHash, VotingProcedures)>
 }
 
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DrepStakeDistributionMessage {
     // DRep stake distribution by ID
     pub data: Vec<(DRepCredential, Lovelace)>

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -107,6 +107,22 @@ pub struct BlockFeesMessage {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct EpochActivityMessage {
+    /// Block info (first block in next epoch)
+    pub block: BlockInfo,
+
+    /// Total blocks in this epoch
+    pub total_blocks: usize,
+
+    /// Total fees in this epoch
+    pub total_fees: u64,
+
+    /// List of all VRF vkeys used on blocks (SPO indicator) and
+    /// number of blocks produced
+    pub vrf_vkeys: Vec<(Vec<u8>, usize)>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GovernanceProceduresMessage {
     /// Block info
     pub block: BlockInfo,
@@ -148,6 +164,7 @@ pub enum Message {
     TxCertificates(TxCertificatesMessage),     // Transaction certificates received
     AddressDeltas(AddressDeltasMessage),       // Address deltas received
     BlockFees(BlockFeesMessage),               // Total fees for a block
+    EpochActivity(EpochActivityMessage),       // Total fees and VRF keys for an epoch
     GovernanceProcedures(GovernanceProceduresMessage), // Governance procedures received
 
     // Stake distribution info

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -98,6 +98,15 @@ pub struct StakeAddressDeltasMessage {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BlockFeesMessage {
+    /// Block info
+    pub block: BlockInfo,
+
+    /// Total fees
+    pub total_fees: u64,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GovernanceProceduresMessage {
     /// Block info
     pub block: BlockInfo,
@@ -138,6 +147,7 @@ pub enum Message {
     UTXODeltas(UTXODeltasMessage),             // UTXO deltas received
     TxCertificates(TxCertificatesMessage),     // Transaction certificates received
     AddressDeltas(AddressDeltasMessage),       // Address deltas received
+    BlockFees(BlockFeesMessage),               // Total fees for a block
     GovernanceProcedures(GovernanceProceduresMessage), // Governance procedures received
 
     // Stake distribution info

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -12,6 +12,19 @@ use hex::decode;
 use bitmask_enum::bitmask;
 use crate::rational_number::RationalNumber;
 
+/// Protocol era
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum Era
+{
+    Byron,
+    Shelley,
+    Allegra,
+    Mary,
+    Alonzo,
+    Babbage,
+    Conway,
+}
+
 /// Block status
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum BlockStatus
@@ -22,12 +35,8 @@ pub enum BlockStatus
     RolledBack,  // Volatile, restarted after rollback
 }
 
-impl Default for BlockStatus {
-    fn default() -> Self { Self::Immutable }
-}
-
 /// Block info, shared across multiple messages
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockInfo {
     /// Block status
     pub status: BlockStatus,
@@ -46,6 +55,9 @@ pub struct BlockInfo {
 
     /// Does this block start a new epoch?
     pub new_epoch: bool,
+
+    /// Protocol era
+    pub era: Era,
 }
 
 /// a Byron-era address

--- a/modules/README.md
+++ b/modules/README.md
@@ -16,6 +16,7 @@ compose the Acropolis Architecture
   changes
 * [UTXO State](utxo_state) - watches UTXO changes and maintains a basic in-memory UTXO state
 * [SPO State](spo_state) - matches SPO registrations and retirements
+* [Epoch Activity Counter](epoch_activity_couinter) - counts fees and block production for rewards
 
 ## How to add a new module
 

--- a/modules/epoch_activity_counter/Cargo.toml
+++ b/modules/epoch_activity_counter/Cargo.toml
@@ -1,0 +1,21 @@
+# Acropolis epoch activity counter module
+
+[package]
+name = "acropolis_module_epoch_activity_counter"
+version = "0.1.0"
+edition = "2021"
+authors = ["Paul Clark <paul.clark@iohk.io>"]
+description = "Epoch activity counter Caryatid module for Acropolis"
+license = "Apache-2.0"
+
+[dependencies]
+caryatid_sdk = "0.5.0"
+acropolis_common = { path = "../../common" }
+pallas = "0.32.0"
+anyhow = "1.0"
+tokio = { version = "1", features = ["full"] }
+config = "0.15.11"
+tracing = "0.1.40"
+
+[lib]
+path = "src/epoch_activity_counter.rs"

--- a/modules/epoch_activity_counter/README.md
+++ b/modules/epoch_activity_counter/README.md
@@ -1,0 +1,36 @@
+# Epoch activity counter module
+
+The epoch activity counter module accepts fee messages from the
+[TxUnpacker](../tx_unpacker) and totals up the fees on every
+transaction in every block across an epoch.  It also subscribes for
+block headers and records the KES keys for every block in the epoch,
+and sends a report at the end of the epoch that can be used by the
+reward calculator to allocate rewards to SPOs and thence to
+delegators.
+
+## Configuration
+
+The following is the default configuration - if the defaults are OK,
+everything except the section header can be left out.
+
+```toml
+[module.epoch-activity-counter]
+
+# Message topics
+subscribe-headers-topic = "cardano.block.headers"
+subscribe-fees-topic = "cardano.fees"
+publish-topic = "cardano.epoch.activity"
+
+```
+
+## Messages
+
+The epoch activity counter subscribes for BlockHeaderMessages on
+`cardano.block.header` (see the [Upstream Chain
+Fetcher](../upstream_chain_fetcher) module for details).
+
+TODO subscription for fees
+
+TODO what it sends
+
+

--- a/modules/epoch_activity_counter/src/state.rs
+++ b/modules/epoch_activity_counter/src/state.rs
@@ -1,13 +1,17 @@
 //! Acropolis epoch activity counter: state storage
 
-use std::collections::BTreeMap;
-use acropolis_common::BlockInfo;
+use acropolis_common::{BlockInfo, messages::{Message, EpochActivityMessage}};
+use std::sync::Arc;
 use tracing::info;
+use std::collections::HashMap;
 
 pub struct State {
 
-    // Map of block numbers to VRF vkeys (identifying SPOs)
-    vrf_vkeys: BTreeMap::<u64, Vec<u8>>,
+    // Map of counts by VRF keys
+    vrf_vkeys: HashMap<Vec<u8>, usize>,
+
+    // Total blocks seen this epoch
+    total_blocks: usize,
 
     // Total fees seen this epoch
     total_fees: u64,
@@ -17,14 +21,16 @@ impl State {
     // Constructor
     pub fn new() -> Self {
         Self {
-            vrf_vkeys: BTreeMap::new(),
+            vrf_vkeys: HashMap::new(),
+            total_blocks: 0,
             total_fees: 0,
         }
     }
 
     // Handle a block minting, taking the SPO's VRF vkey
-    pub fn handle_mint(&mut self, block: &BlockInfo, vrf_vkey: &[u8]) {
-        self.vrf_vkeys.insert(block.number, vrf_vkey.to_vec());
+    pub fn handle_mint(&mut self, _block: &BlockInfo, vrf_vkey: &[u8]) {
+        self.total_blocks += 1;
+        *(self.vrf_vkeys.entry(vrf_vkey.to_vec()).or_insert(0)) += 1;
     }
 
     // Handle block fees
@@ -32,11 +38,22 @@ impl State {
         self.total_fees += total_fees;
     }
 
-    // Handle end of epoch
-    pub fn end_epoch(&mut self, block: &BlockInfo) {
-        info!("End of epoch {} - {} blocks captured, total fees {}",
-              block.epoch-1, self.vrf_vkeys.len(), self.total_fees);
-        self.vrf_vkeys.clear();
+    // Handle end of epoch, returns message to be published
+    pub fn end_epoch(&mut self, block: &BlockInfo) -> Arc<Message> {
+        info!("End of epoch {} - {} total blocks, {} unique SPOs, total fees {}",
+              block.epoch-1, self.total_blocks, self.vrf_vkeys.len(),
+              self.total_fees);
+
+        let message = Arc::new(Message::EpochActivity(EpochActivityMessage {
+            block: block.clone(),
+            total_blocks: self.total_blocks,
+            total_fees: self.total_fees,
+            vrf_vkeys: self.vrf_vkeys.drain().collect(),
+        }));
+
+        self.total_blocks = 0;
         self.total_fees = 0;
+
+        message
     }
 }

--- a/modules/epoch_activity_counter/src/state.rs
+++ b/modules/epoch_activity_counter/src/state.rs
@@ -1,0 +1,32 @@
+//! Acropolis epoch activity counter: state storage
+
+use std::collections::BTreeMap;
+use acropolis_common::BlockInfo;
+use tracing::info;
+
+pub struct State {
+
+    // Map of block numbers to VRF vkeys (identifying SPOs)
+    vrf_vkeys: BTreeMap::<u64, Vec<u8>>,
+
+}
+
+impl State {
+    // Constructor
+    pub fn new() -> Self {
+        Self {
+            vrf_vkeys: BTreeMap::new(),
+        }
+    }
+
+    // Handle a block minting, taking the SPO's VRF vkey
+    pub fn handle_mint(&mut self, block: &BlockInfo, vrf_vkey: &[u8]) {
+        self.vrf_vkeys.insert(block.number, vrf_vkey.to_vec());
+    }
+
+    // Handle end of epoch
+    pub fn end_epoch(&mut self, block: &BlockInfo) {
+        info!("End of epoch {} - {} blocks captured", block.epoch-1, self.vrf_vkeys.len());
+        self.vrf_vkeys.clear();
+    }
+}

--- a/modules/epoch_activity_counter/src/state.rs
+++ b/modules/epoch_activity_counter/src/state.rs
@@ -40,7 +40,7 @@ impl State {
 
     // Handle end of epoch, returns message to be published
     pub fn end_epoch(&mut self, block: &BlockInfo) -> Arc<Message> {
-        info!("End of epoch {} - {} total blocks, {} unique SPOs, total fees {}",
+        info!("End of epoch {} - {} total blocks, {} unique VRF keys, total fees {}",
               block.epoch-1, self.total_blocks, self.vrf_vkeys.len(),
               self.total_fees);
 

--- a/modules/epoch_activity_counter/src/state.rs
+++ b/modules/epoch_activity_counter/src/state.rs
@@ -9,6 +9,8 @@ pub struct State {
     // Map of block numbers to VRF vkeys (identifying SPOs)
     vrf_vkeys: BTreeMap::<u64, Vec<u8>>,
 
+    // Total fees seen this epoch
+    total_fees: u64,
 }
 
 impl State {
@@ -16,6 +18,7 @@ impl State {
     pub fn new() -> Self {
         Self {
             vrf_vkeys: BTreeMap::new(),
+            total_fees: 0,
         }
     }
 
@@ -24,9 +27,16 @@ impl State {
         self.vrf_vkeys.insert(block.number, vrf_vkey.to_vec());
     }
 
+    // Handle block fees
+    pub fn handle_fees(&mut self, _block: &BlockInfo, total_fees: u64) {
+        self.total_fees += total_fees;
+    }
+
     // Handle end of epoch
     pub fn end_epoch(&mut self, block: &BlockInfo) {
-        info!("End of epoch {} - {} blocks captured", block.epoch-1, self.vrf_vkeys.len());
+        info!("End of epoch {} - {} blocks captured, total fees {}",
+              block.epoch-1, self.vrf_vkeys.len(), self.total_fees);
         self.vrf_vkeys.clear();
+        self.total_fees = 0;
     }
 }

--- a/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
+++ b/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
@@ -9,7 +9,7 @@ use acropolis_common::{
     },
     Address, Anchor, BlockInfo, BlockStatus, ByronAddress,
     Committee, Constitution, ConwayGenesisParams, Credential,
-    DRepVotingThresholds, PoolVotingThresholds,
+    DRepVotingThresholds, Era, PoolVotingThresholds,
     TxOutput, UTXODelta,
 };
 use hex::decode;
@@ -178,7 +178,8 @@ impl GenesisBootstrapper
                             number: 0,
                             hash: Vec::new(),
                             epoch: 0,
-                            new_epoch: false
+                            new_epoch: false,
+                            era: Era::Byron,
                         },
                         deltas: Vec::new(),
                     };

--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -6,7 +6,7 @@ use acropolis_common::{
     calculations::slot_to_epoch, messages::{
         BlockBodyMessage, BlockHeaderMessage, Message,
         SnapshotCompleteMessage
-    }, BlockInfo, BlockStatus
+    }, Era, BlockInfo, BlockStatus
 };
 use std::sync::Arc;
 use tokio::{join, sync::Mutex};
@@ -26,7 +26,7 @@ use std::path::Path;
 use std::thread::sleep;
 use std::time::Duration;
 use pallas::{
-    ledger::traverse::MultiEraBlock,
+    ledger::traverse::{Era as PallasEra, MultiEraBlock},
     storage::hardano,
 };
 
@@ -219,6 +219,16 @@ impl MithrilSnapshotFetcher
                         info!(epoch, number, slot, "New epoch");
                     }
 
+                    let era = match block.era() {
+                        PallasEra::Byron => Era::Byron,
+                        PallasEra::Shelley => Era::Shelley,
+                        PallasEra::Allegra => Era::Allegra,
+                        PallasEra::Mary => Era::Mary,
+                        PallasEra::Alonzo => Era::Alonzo,
+                        PallasEra::Babbage => Era::Babbage,
+                        _ => Era::Conway,
+                    };
+
                     let block_info = BlockInfo {
                         status: BlockStatus::Immutable,
                         slot,
@@ -226,6 +236,7 @@ impl MithrilSnapshotFetcher
                         hash: block.hash().to_vec(),
                         epoch,
                         new_epoch,
+                        era,
                     };
 
                     // Send the block header message

--- a/modules/tx_unpacker/Cargo.toml
+++ b/modules/tx_unpacker/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "acropolis_module_tx_unpacker"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Paul Clark <paul.clark@iohk.io>"]
 description = "Transaction unpacker Caryatid module for Acropolis"

--- a/processes/omnibus/Cargo.toml
+++ b/processes/omnibus/Cargo.toml
@@ -28,6 +28,7 @@ acropolis_module_spo_state = { path = "../../modules/spo_state" }
 acropolis_module_drep_state = { path = "../../modules/drep_state" }
 acropolis_module_governance_state = { path = "../../modules/governance_state" }
 acropolis_module_stake_delta_filter = { path = "../../modules/stake_delta_filter" }
+acropolis_module_epoch_activity_counter = { path = "../../modules/epoch_activity_counter" }
 
 anyhow = "1.0"
 config = "0.15.11"

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -17,6 +17,7 @@ magic-number = 764824073
 [module.tx-unpacker]
 publish-utxo-deltas-topic = "cardano.utxo.deltas"
 publish-certificates-topic = "cardano.certificates"
+publish-fees-topic = "cardano.block.fees"
 
 [module.utxo-state]
 store = "memory" # "memory", "dashmap", "fjall", "fjall-async", "sled", "sled-async", "fake"

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -30,6 +30,8 @@ address-delta-topic = "cardano.address.delta"
 
 [module.stake-delta-filter]
 
+[module.epoch-activity-counter]
+
 [module.clock]
 
 [module.rest-server]

--- a/processes/omnibus/src/main.rs
+++ b/processes/omnibus/src/main.rs
@@ -19,6 +19,7 @@ use acropolis_module_spo_state::SPOState;
 use acropolis_module_drep_state::DRepState;
 use acropolis_module_governance_state::GovernanceState;
 use acropolis_module_stake_delta_filter::StakeDeltaFilter;
+use acropolis_module_epoch_activity_counter::EpochActivityCounter;
 
 use caryatid_module_clock::Clock;
 use caryatid_module_rest_server::RESTServer;
@@ -54,6 +55,7 @@ pub async fn main() -> Result<()> {
     DRepState::register(&mut process);
     GovernanceState::register(&mut process);
     StakeDeltaFilter::register(&mut process);
+    EpochActivityCounter::register(&mut process);
 
     Clock::<Message>::register(&mut process);
     RESTServer::<Message>::register(&mut process);


### PR DESCRIPTION
Epoch Activity Counter (#27) - counts total fees and which SPOs (by VRF key at this stage) successfully minted blocks.

Note rollbacks are not yet handled and there is a race between the two subscriptions - fees should be processed first, because the headers trigger the epoch event.  Useful test case on how to resolve generally.
