### PR TITLE
#31 Encapsulate Cardano messages in a sub-enum

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 name = "acropolis_common"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Paul Clark <paul.clark@iohk.io>"]
 description = "Common types, messages and helpers for Acropolis"

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -16,9 +16,6 @@ pub use caryatid_module_rest_server::messages::{
 /// Block header message
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockHeaderMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Raw Data
     pub raw: Vec<u8>,
 }
@@ -26,9 +23,6 @@ pub struct BlockHeaderMessage {
 /// Block body message
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct BlockBodyMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Raw Data
     pub raw: Vec<u8>,
 }
@@ -43,9 +37,6 @@ pub struct SnapshotCompleteMessage {
 /// Transactions message
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct RawTxsMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Raw Data for each transaction
     pub txs: Vec<Vec<u8>>,
 }
@@ -60,9 +51,6 @@ pub struct GenesisCompleteMessage {
 /// Message encapsulating multiple UTXO deltas, in order
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct UTXODeltasMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Ordered set of deltas
     pub deltas: Vec<UTXODelta>
 }
@@ -70,9 +58,6 @@ pub struct UTXODeltasMessage {
 /// Message encapsulating multiple transaction certificates, in order
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TxCertificatesMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Ordered set of certificates
     pub certificates: Vec<TxCertificate>
 }
@@ -80,9 +65,6 @@ pub struct TxCertificatesMessage {
 /// Address deltas message
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct AddressDeltasMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Set of deltas
     pub deltas: Vec<AddressDelta>
 }
@@ -90,18 +72,12 @@ pub struct AddressDeltasMessage {
 /// Stake address part of address deltas message
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct StakeAddressDeltasMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Set of deltas
     pub deltas: Vec<StakeAddressDelta>
 }
 
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GovernanceProceduresMessage {
-    /// Block info
-    pub block: BlockInfo,
-
     /// Proposals
     pub proposal_procedures: Vec<ProposalProcedure>,
 
@@ -113,6 +89,24 @@ pub struct GovernanceProceduresMessage {
 pub struct DRepStakeDistributionMessage {
     // DRep stake distribution by ID
     pub data: Vec<(DRepCredential, Lovelace)>
+}
+
+/// Cardano message enum
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum CardanoMessage {
+    BlockHeader(BlockHeaderMessage),           // Block header available
+    BlockBody(BlockBodyMessage),               // Block body available
+    SnapshotComplete,                          // Mithril snapshot loaded
+    ReceivedTxs(RawTxsMessage),                // Transaction available
+    GenesisComplete(GenesisCompleteMessage),   // Genesis UTXOs done + genesis params
+    UTXODeltas(UTXODeltasMessage),             // UTXO deltas received
+    TxCertificates(TxCertificatesMessage),     // Transaction certificates received
+    AddressDeltas(AddressDeltasMessage),       // Address deltas received
+    GovernanceProcedures(GovernanceProceduresMessage), // Governance procedures received
+
+    // Stake distribution info
+    DRepStakeDistribution(DRepStakeDistributionMessage), // Info about drep stake
+    StakeAddressDeltas(StakeAddressDeltasMessage),       // Stake part of address deltas
 }
 
 // === Global message enum ===
@@ -129,20 +123,8 @@ pub enum Message {
     RESTRequest(RESTRequest),                  // REST request
     RESTResponse(RESTResponse),                // REST response
 
-    // Cardano messages
-    BlockHeader(BlockHeaderMessage),           // Block header available
-    BlockBody(BlockBodyMessage),               // Block body available
-    SnapshotComplete(SnapshotCompleteMessage), // Mithril snapshot loaded
-    ReceivedTxs(RawTxsMessage),                // Transaction available
-    GenesisComplete(GenesisCompleteMessage),   // Genesis UTXOs done + genesis params
-    UTXODeltas(UTXODeltasMessage),             // UTXO deltas received
-    TxCertificates(TxCertificatesMessage),     // Transaction certificates received
-    AddressDeltas(AddressDeltasMessage),       // Address deltas received
-    GovernanceProcedures(GovernanceProceduresMessage), // Governance procedures received
-
-    // Stake distribution info
-    DRepStakeDistribution(DRepStakeDistributionMessage), // Info about drep stake
-    StakeAddressDeltas(StakeAddressDeltasMessage),       // Stake part of address deltas
+    // Cardano messages with attached BlockInfo
+    Cardano((BlockInfo, CardanoMessage)),
 }
 
 impl Default for Message {

--- a/modules/drep_state/src/drep_state.rs
+++ b/modules/drep_state/src/drep_state.rs
@@ -2,7 +2,7 @@
 //! Accepts certificate events and derives the DRep State in memory
 
 use caryatid_sdk::{Context, Module, module, MessageBusExt};
-use acropolis_common::{messages::Message, DRepCredential};
+use acropolis_common::{messages::{Message, CardanoMessage}, DRepCredential};
 use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use config::Config;
@@ -86,9 +86,9 @@ impl DRepState
             let state = state1.clone();
             async move {
                 match message.as_ref() {
-                    Message::TxCertificates(tx_cert_msg) => {
+                    Message::Cardano((block_info, CardanoMessage::TxCertificates(tx_cert_msg))) => {
                         let mut state = state.lock().await;
-                        state.handle(tx_cert_msg)
+                        state.handle(block_info, tx_cert_msg)
                             .await
                             .inspect_err(|e| error!("Messaging handling error: {e}"))
                             .ok();

--- a/modules/drep_state/src/drep_voting_stake_publisher.rs
+++ b/modules/drep_state/src/drep_voting_stake_publisher.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use caryatid_sdk::Context;
-use acropolis_common::{DRepCredential, Lovelace};
-use acropolis_common::messages::{DRepStakeDistributionMessage, Message};
+use acropolis_common::{DRepCredential, Lovelace, BlockInfo};
+use acropolis_common::messages::{DRepStakeDistributionMessage, Message, CardanoMessage};
 
 pub struct DRepVotingStakePublisher {
     /// Module context
@@ -16,11 +16,16 @@ impl DRepVotingStakePublisher {
         Self { context, topic }
     }
 
-    pub async fn publish_stake(&mut self, s: Vec<(DRepCredential, Lovelace)>) -> anyhow::Result<()> {
+    pub async fn publish_stake(&mut self, block: &BlockInfo,
+                               s: Vec<(DRepCredential, Lovelace)>) -> anyhow::Result<()> {
         self.context.message_bus.publish(
             &self.topic,
-            Arc::new(Message::DRepStakeDistribution(DRepStakeDistributionMessage {
-                data: s
-            }))).await
+            Arc::new(Message::Cardano((
+                block.clone(),
+                CardanoMessage::DRepStakeDistribution(DRepStakeDistributionMessage {
+                    data: s
+                })
+            )))
+        ).await
     }
 }

--- a/modules/governance_state/src/governance_state.rs
+++ b/modules/governance_state/src/governance_state.rs
@@ -2,7 +2,7 @@
 //! Accepts certificate events and derives the Governance State in memory
 
 use caryatid_sdk::{Context, Module, module, MessageBusExt};
-use acropolis_common::messages::{Message, RESTResponse};
+use acropolis_common::messages::{Message, RESTResponse, CardanoMessage};
 use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use config::Config;
@@ -86,9 +86,9 @@ impl GovernanceState
 
             async move {
                 match message.as_ref() {
-                    Message::GovernanceProcedures(msg) => {
+                    Message::Cardano((block_info, CardanoMessage::GovernanceProcedures(msg))) => {
                         let mut state = state.lock().await;
-                        state.handle_governance(msg)
+                        state.handle_governance(block_info, msg)
                             .await
                             .inspect_err(|e| error!("Messaging handling error: {e}"))
                             .ok();
@@ -105,7 +105,7 @@ impl GovernanceState
 
             async move {
                 match message.as_ref() {
-                    Message::DRepStakeDistribution(msg) => {
+                    Message::Cardano((_block_info, CardanoMessage::DRepStakeDistribution(msg))) => {
                         let mut state = state.lock().await;
                         state.handle_drep_stake(msg)
                             .await
@@ -124,7 +124,7 @@ impl GovernanceState
 
             async move {
                 match message.as_ref() {
-                    Message::GenesisComplete(msg) => {
+                    Message::Cardano((_block_info, CardanoMessage::GenesisComplete(msg))) => {
                         let mut state = state.lock().await;
                         state.handle_genesis(msg)
                             .await

--- a/modules/spo_state/src/spo_state.rs
+++ b/modules/spo_state/src/spo_state.rs
@@ -3,7 +3,7 @@
 
 use caryatid_sdk::{Context, Module, module, MessageBusExt};
 use acropolis_common::{
-    messages::{Message, RESTResponse},
+    messages::{Message, RESTResponse, CardanoMessage},
 };
 use std::sync::Arc;
 use anyhow::Result;
@@ -50,9 +50,9 @@ impl SPOState
             let state = state_subscribe.clone();
             async move {
                 match message.as_ref() {
-                    Message::TxCertificates(tx_cert_msg) => {
+                    Message::Cardano((block_info, CardanoMessage::TxCertificates(tx_cert_msg))) => {
                         let mut state = state.lock().await;
-                        state.handle(tx_cert_msg)
+                        state.handle(block_info, tx_cert_msg)
                             .inspect_err(|e| error!("Messaging handling error: {e}"))
                             .ok();
                     }

--- a/modules/spo_state/src/state.rs
+++ b/modules/spo_state/src/state.rs
@@ -1,6 +1,7 @@
 //! Acropolis SPOState: State storage
 use acropolis_common::{
     messages::TxCertificatesMessage,
+    BlockInfo,
     PoolRegistration,
     TxCertificate,
     params::{SECURITY_PARAMETER_K, TECHNICAL_PARAMETER_POOL_RETIRE_MAX_EPOCH,},
@@ -118,11 +119,12 @@ impl State {
         }
     }
 
-    pub fn handle(&mut self, tx_cert_msg: &TxCertificatesMessage) -> Result<()> {
-        let mut current = self.get_previous_state(tx_cert_msg.block.number);
-        current.block = tx_cert_msg.block.number;
-        if tx_cert_msg.block.epoch > current.epoch {
-            current.epoch = tx_cert_msg.block.epoch;
+    pub fn handle(&mut self, block: &BlockInfo,
+                  tx_cert_msg: &TxCertificatesMessage) -> Result<()> {
+        let mut current = self.get_previous_state(block.number);
+        current.block = block.number;
+        if block.epoch > current.epoch {
+            current.epoch = block.epoch;
             let deregistrations = current.pending_deregistrations.remove(&current.epoch);
             match deregistrations {
                 Some(deregistrations) => {

--- a/modules/stake_delta_filter/src/stake_delta_filter.rs
+++ b/modules/stake_delta_filter/src/stake_delta_filter.rs
@@ -3,7 +3,7 @@
 
 use std::{path::Path, sync::Arc};
 use caryatid_sdk::{Context, Module, module, MessageBusExt};
-use acropolis_common::{messages::Message, AddressNetwork};
+use acropolis_common::{messages::{Message, CardanoMessage}, AddressNetwork};
 use anyhow::{anyhow, Result};
 use config::Config;
 use tokio::sync::Mutex;
@@ -113,10 +113,11 @@ impl StakeDeltaFilter {
 
             async move {
                 match message.as_ref() {
-                    Message::AddressDeltas(delta) => 
+                    Message::Cardano((block_info, CardanoMessage::AddressDeltas(delta))) =>
                         match process_message(&cache_copy, delta).await {
                             Err(e) => tracing::error!("Cannot decode and convert stake key for {delta:?}: {e}"),
-                            Ok(r) => publisher.publish(r).await.unwrap_or_else(|e| error!("Publish error: {e}"))
+                            Ok(r) => publisher.publish(block_info, r)
+                                .await.unwrap_or_else(|e| error!("Publish error: {e}"))
                         }
 
                     msg => error!("Unexpected message type for {}: {msg:?}", &params_copy.address_delta_topic)
@@ -142,9 +143,9 @@ impl StakeDeltaFilter {
             let state = state_certs.clone();
             async move {
                 match message.as_ref() {
-                    Message::TxCertificates(tx_cert_msg) => {
+                    Message::Cardano((block_info, CardanoMessage::TxCertificates(tx_cert_msg))) => {
                         let mut state = state.lock().await;
-                        state.handle_certs(tx_cert_msg)
+                        state.handle_certs(block_info, tx_cert_msg)
                             .await
                             .inspect_err(|e| error!("Messaging handling error: {e}"))
                             .ok();
@@ -161,9 +162,9 @@ impl StakeDeltaFilter {
             let params = params_d.clone();
             async move {
                 match message.as_ref() {
-                    Message::AddressDeltas(deltas) => {
+                    Message::Cardano((block_info, CardanoMessage::AddressDeltas(deltas))) => {
                         let mut state = state.lock().await;
-                        state.handle_deltas(deltas)
+                        state.handle_deltas(block_info, deltas)
                             .await
                             .inspect_err(|e| error!("Messaging handling error: {e}"))
                             .ok();

--- a/modules/stake_delta_filter/src/utils.rs
+++ b/modules/stake_delta_filter/src/utils.rs
@@ -1,6 +1,7 @@
 use std::{cmp::max, collections::HashMap, fs::File, io::BufReader, io::Write, sync::Arc};
 use anyhow::{anyhow, Result};
-use acropolis_common::{Address, ShelleyAddressDelegationPart, ShelleyAddressPointer, StakeAddress, StakeAddressDelta};
+use acropolis_common::{Address, ShelleyAddressDelegationPart, ShelleyAddressPointer,
+                       StakeAddress, StakeAddressDelta};
 use acropolis_common::messages::{AddressDeltasMessage, StakeAddressDeltasMessage};
 use serde_with::serde_as;
 
@@ -106,9 +107,9 @@ pub enum CacheMode {
 //}
 
 //pub async fn process_message(cache: &PointerCache, delta: &AddressDeltasMessage, tracker: Option<&mut dyn PointerTracker>) -> Result<StakeAddressDeltasMessage> {
-pub async fn process_message(cache: &PointerCache, delta: &AddressDeltasMessage) -> Result<StakeAddressDeltasMessage> {
+pub async fn process_message(cache: &PointerCache, delta: &AddressDeltasMessage)
+                             -> Result<StakeAddressDeltasMessage> {
     let mut result = StakeAddressDeltasMessage {
-        block: delta.block.clone(),
         deltas: Vec::new()
     };
 

--- a/modules/utxo_state/src/address_delta_publisher.rs
+++ b/modules/utxo_state/src/address_delta_publisher.rs
@@ -3,10 +3,10 @@ use caryatid_sdk::Context;
 use config::Config;
 use acropolis_common::{
     BlockInfo, AddressDelta, Address,
-        messages::{
+    messages::{
         AddressDeltasMessage,
-        Message,
-     },
+        Message, CardanoMessage,
+    },
 };
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -65,14 +65,17 @@ impl AddressDeltaObserver for AddressDeltaPublisher {
 
             let mut deltas = self.deltas.lock().await;
             let message = AddressDeltasMessage {
-                block: block.clone(),
                 deltas: std::mem::take(&mut *deltas),
             };
 
             let context = self.context.clone();
             let topic = topic.clone();
+            let block = block.clone();
             tokio::spawn(async move {
-                let message_enum = Message::AddressDeltas(message);
+                let message_enum = Message::Cardano((
+                    block,
+                    CardanoMessage::AddressDeltas(message)
+                ));
                 context.message_bus.publish(&topic,
                                             Arc::new(message_enum))
                     .await

--- a/modules/utxo_state/src/state.rs
+++ b/modules/utxo_state/src/state.rs
@@ -346,26 +346,26 @@ impl State {
     }
 
     /// Handle a message
-    pub async fn handle(&mut self, deltas: &UTXODeltasMessage) -> Result<()> {
+    pub async fn handle(&mut self, block: &BlockInfo, deltas: &UTXODeltasMessage) -> Result<()> {
 
         // Start the block for observer
         if let Some(observer) = self.address_delta_observer.as_mut() {
-            observer.start_block(&deltas.block).await;
+            observer.start_block(&block).await;
         }
 
         // Observe block for stats and rollbacks
-        self.observe_block(&deltas.block).await?;
+        self.observe_block(&block).await?;
 
         // Process the deltas
         for delta in &deltas.deltas {  // UTXODelta
 
            match delta {
                UTXODelta::Input(tx_input) => {
-                   self.observe_input(&tx_input, &deltas.block).await?;
+                   self.observe_input(&tx_input, &block).await?;
                },
 
                UTXODelta::Output(tx_output) => {
-                   self.observe_output(&tx_output, &deltas.block).await?;
+                   self.observe_output(&tx_output, &block).await?;
                },
 
                _ => {}
@@ -374,7 +374,7 @@ impl State {
 
         // End the block for observer
         if let Some(observer) = self.address_delta_observer.as_mut() {
-            observer.finalise_block(&deltas.block).await;
+            observer.finalise_block(&block).await;
         }
 
         Ok(())

--- a/modules/utxo_state/src/utxo_state.rs
+++ b/modules/utxo_state/src/utxo_state.rs
@@ -3,7 +3,7 @@
 
 use caryatid_sdk::{Context, Module, module, MessageBusExt};
 use acropolis_common::{
-    messages::{Message, RESTResponse},
+    messages::{Message, CardanoMessage, RESTResponse},
 };
 
 use anyhow::{Result, anyhow};
@@ -102,9 +102,9 @@ impl UTXOState
             let state = state1.clone();
             async move {
                 match message.as_ref() {
-                    Message::UTXODeltas(deltas_msg) => {
+                    Message::Cardano((block, CardanoMessage::UTXODeltas(deltas_msg))) => {
                         let mut state = state.lock().await;
-                        state.handle(deltas_msg)
+                        state.handle(block, deltas_msg)
                             .await
                             .inspect_err(|e| error!("Messaging handling error: {e}"))
                             .ok();


### PR DESCRIPTION
Moves BlockInfo into a common place which can be access for (e.g.) synchronisation