### PR TITLE
Generate SPDD, REST handler helpers

### DIFF
--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = "1.0"
 serde_with = { version = "3.12.0", features = ["hex"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
+futures = "0.3.31"
 
 [lib]
 crate-type = ["rlib"]

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -7,6 +7,7 @@ pub mod crypto;
 pub mod messages;
 pub mod params;
 pub mod rational_number;
+pub mod rest_helper;
 pub mod serialization;
 pub mod state_history;
 pub mod types;

--- a/common/src/rest_helper.rs
+++ b/common/src/rest_helper.rs
@@ -1,0 +1,79 @@
+//! Helper functions for REST handlers
+
+use crate::messages::{Message, RESTResponse};
+use anyhow::Result;
+use caryatid_sdk::{Context, MessageBusExt};
+use futures::future::Future;
+use std::sync::Arc;
+use tracing::{error, info};
+
+/// Handle a simple REST request with no parameters
+pub fn handle_rest<F, Fut>(context: Arc<Context<Message>>, topic: &str, handler: F) -> Result<()>
+where
+    F: Fn() -> Fut + Send + Sync + Clone + 'static,
+    Fut: Future<Output = Result<RESTResponse>> + Send + 'static,
+{
+    context
+        .message_bus
+        .handle(topic, move |message: Arc<Message>| {
+            let handler = handler.clone();
+            async move {
+                let response = match message.as_ref() {
+                    Message::RESTRequest(request) => {
+                        info!("REST received {} {}", request.method, request.path);
+                        match handler().await {
+                            Ok(response) => response,
+                            Err(error) => {
+                                RESTResponse::with_text(500, &format!("{error:?}").to_string())
+                            }
+                        }
+                    }
+                    _ => {
+                        error!("Unexpected message type {:?}", message);
+                        RESTResponse::with_text(500, "Unexpected message in REST request")
+                    }
+                };
+
+                Arc::new(Message::RESTResponse(response))
+            }
+        })
+}
+
+/// Handle a simple REST request with one path parameter
+pub fn handle_rest_with_parameter<F, Fut>(
+    context: Arc<Context<Message>>,
+    topic: &str,
+    handler: F,
+) -> Result<()>
+where
+    F: Fn(&str) -> Fut + Send + Sync + Clone + 'static,
+    Fut: Future<Output = Result<RESTResponse>> + Send + 'static,
+{
+    context
+        .message_bus
+        .handle(topic, move |message: Arc<Message>| {
+            let handler = handler.clone();
+            async move {
+                let response = match message.as_ref() {
+                    Message::RESTRequest(request) => {
+                        info!("REST received {} {}", request.method, request.path);
+                        match request.path_elements.get(1) {
+                            Some(param) => match handler(param).await {
+                                Ok(response) => response,
+                                Err(error) => {
+                                    RESTResponse::with_text(500, &format!("{error:?}").to_string())
+                                }
+                            },
+                            None => RESTResponse::with_text(400, "Parameter must be provided"),
+                        }
+                    }
+                    _ => {
+                        error!("Unexpected message type {:?}", message);
+                        RESTResponse::with_text(500, "Unexpected message in REST request")
+                    }
+                };
+
+                Arc::new(Message::RESTResponse(response))
+            }
+        })
+}

--- a/modules/accounts_state/Cargo.toml
+++ b/modules/accounts_state/Cargo.toml
@@ -20,6 +20,8 @@ serde_json = "1.0.132"
 serde_with = { version = "3.12.0", features = ["hex"] }
 hex = "0.4.3"
 imbl = { version = "5.0.0", features = ["serde"] }
+rayon = "1.10.0"
+dashmap = "6.1.0"
 
 [lib]
 path = "src/accounts_state.rs"

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -3,10 +3,11 @@
 
 use acropolis_common::{
     messages::{CardanoMessage, Message, RESTResponse},
+    rest_helper::{handle_rest, handle_rest_with_parameter},
     state_history::StateHistory,
     Address, BlockInfo, BlockStatus, StakeAddress, StakeAddressPayload,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use caryatid_sdk::{message_bus::Subscription, module, Context, MessageBusExt, Module};
 use config::Config;
 use serde_json;
@@ -202,117 +203,62 @@ impl AccountsState {
         let history_tick = history.clone();
 
         // Handle requests for full state
-        context
-            .message_bus
-            .handle(&handle_stake_topic, move |message: Arc<Message>| {
-                let history = history_stake.clone();
-                async move {
-                    let response = match message.as_ref() {
-                        Message::RESTRequest(request) => {
-                            info!("REST received {} {}", request.method, request.path);
-                            if let Some(state) = history.lock().await.current().clone() {
-                                match serde_json::to_string(state) {
-                                    Ok(body) => RESTResponse::with_json(200, &body),
-                                    Err(error) => RESTResponse::with_text(
-                                        500,
-                                        &format!("{error:?}").to_string(),
-                                    ),
-                                }
-                            } else {
-                                RESTResponse::with_json(200, "{}")
-                            }
-                        }
-                        _ => {
-                            error!("Unexpected message type {:?}", message);
-                            RESTResponse::with_text(500, "Unexpected message in REST request")
-                        }
-                    };
-
-                    Arc::new(Message::RESTResponse(response))
+        handle_rest(context.clone(), &handle_stake_topic, move || {
+            let history = history_stake.clone();
+            async move {
+                if let Some(state) = history.lock().await.current().clone() {
+                    match serde_json::to_string(state) {
+                        Ok(body) => Ok(RESTResponse::with_json(200, &body)),
+                        Err(error) => Err(anyhow!("{:?}", error)),
+                    }
+                } else {
+                    Ok(RESTResponse::with_json(200, "{}"))
                 }
-            })?;
+            }
+        })?;
 
         let handle_single_stake_topic = handle_stake_topic + ".*";
 
         // Handle requests for single reward state based on stake address
-        context
-            .message_bus
-            .handle(&handle_single_stake_topic, move |message: Arc<Message>| {
-                let history = history_stake_single.clone();
-                async move {
-                    let response = match message.as_ref() {
-                        Message::RESTRequest(request) => {
-                            info!("REST received {} {}", request.method, request.path);
-                            match request.path_elements.get(1) {
-                                Some(addr) => match Address::from_string(addr) {
-                                    Ok(Address::Stake(StakeAddress {
-                                        payload: StakeAddressPayload::StakeKeyHash(hash),
-                                        ..
-                                    })) => match history.lock().await.current() {
-                                        Some(state) => match state.get_stake_state(&hash) {
-                                            Some(stake) => match serde_json::to_string(&stake) {
-                                                Ok(body) => RESTResponse::with_json(200, &body),
-                                                Err(error) => RESTResponse::with_text(
-                                                    500,
-                                                    &format!("{error:?}").to_string(),
-                                                ),
-                                            },
-                                            None => RESTResponse::with_text(
-                                                404,
-                                                "Stake address not found",
-                                            ),
-                                        },
+        handle_rest_with_parameter(context.clone(), &handle_single_stake_topic, move |param| {
+            let history = history_stake_single.clone();
+            let param = param.to_string();
 
-                                        None => RESTResponse::with_text(500, "No state"),
-                                    },
-                                    _ => RESTResponse::with_text(400, "Not a stake address"),
-                                },
-                                None => {
-                                    RESTResponse::with_text(400, "Stake address must be provided")
-                                }
-                            }
-                        }
-                        _ => {
-                            error!("Unexpected message type {:?}", message);
-                            RESTResponse::with_text(500, "Unexpected message in REST request")
-                        }
-                    };
-
-                    Arc::new(Message::RESTResponse(response))
+            async move {
+                match Address::from_string(&param) {
+                    Ok(Address::Stake(StakeAddress {
+                        payload: StakeAddressPayload::StakeKeyHash(hash),
+                        ..
+                    })) => match history.lock().await.current() {
+                        Some(state) => match state.get_stake_state(&hash) {
+                            Some(stake) => match serde_json::to_string(&stake) {
+                                Ok(body) => Ok(RESTResponse::with_json(200, &body)),
+                                Err(error) => Err(anyhow!("{:?}", error)),
+                            },
+                            None => Ok(RESTResponse::with_text(404, "Stake address not found")),
+                        },
+                        None => Err(anyhow!("No state")),
+                    },
+                    _ => Ok(RESTResponse::with_text(400, "Not a stake address")),
                 }
-            })?;
+            }
+        })?;
 
         // Handle requests for SPDD
-        context
-            .message_bus
-            .handle(&handle_spdd_topic, move |message: Arc<Message>| {
-                let history = history_spdd.clone();
-                async move {
-                    let response = match message.as_ref() {
-                        Message::RESTRequest(request) => {
-                            info!("REST received {} {}", request.method, request.path);
-                            if let Some(state) = history.lock().await.current() {
-                                let spdd = state.generate_spdd();
-                                match serde_json::to_string(&spdd) {
-                                    Ok(body) => RESTResponse::with_json(200, &body),
-                                    Err(error) => RESTResponse::with_text(
-                                        500,
-                                        &format!("{error:?}").to_string(),
-                                    ),
-                                }
-                            } else {
-                                RESTResponse::with_json(200, "{}")
-                            }
-                        }
-                        _ => {
-                            error!("Unexpected message type {:?}", message);
-                            RESTResponse::with_text(500, "Unexpected message in REST request")
-                        }
-                    };
-
-                    Arc::new(Message::RESTResponse(response))
+        handle_rest(context.clone(), &handle_spdd_topic, move || {
+            let history = history_spdd.clone();
+            async move {
+                if let Some(state) = history.lock().await.current() {
+                    let spdd = state.generate_spdd();
+                    match serde_json::to_string(&spdd) {
+                        Ok(body) => Ok(RESTResponse::with_json(200, &body)),
+                        Err(error) => Err(anyhow!("{:?}", error)),
+                    }
+                } else {
+                    Ok(RESTResponse::with_json(200, "{}"))
                 }
-            })?;
+            }
+        })?;
 
         // Ticker to log stats
         let mut tick_subscription = context.message_bus.register("clock.tick").await?;

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -10,6 +10,9 @@ use anyhow::Result;
 use imbl::HashMap;
 use serde_with::{hex::Hex, serde_as};
 use tracing::{error, info};
+use dashmap::DashMap;
+use rayon::prelude::*;
+use std::sync::Arc;
 
 /// State of an individual stake address
 #[serde_as]
@@ -57,6 +60,37 @@ impl State {
     pub async fn tick(&self) -> Result<()> {
         self.log_stats();
         Ok(())
+    }
+
+    /// Derive the Stake Pool Delegation Distribution (SPDD) - a map of total stake value
+    /// (including both UTXO stake addresses and rewards) for each active SPO
+    /// Key of returned map is the SPO 'operator' ID
+    pub fn generate_spdd(&self) -> HashMap<KeyHash, u64> {
+
+        // Shareable Dashmap with referenced keys
+        let spo_stakes = Arc::new(DashMap::<&KeyHash, u64>::new());
+
+        // Total stake across all addresses in parallel, first collecting into a vector
+        // because imbl::HashMap doesn't work in Rayon
+        self
+            .stake_addresses
+            .values()
+            .collect::<Vec<_>>() // Vec<&StakeAddressState>
+            .par_iter()          // Rayon multi-threaded iterator
+            .for_each_init(|| Arc::clone(&spo_stakes), |map, sas| {
+                if let Some(spo) = sas.delegated_spo.as_ref() {
+                    let stake = sas.utxo_value + sas.rewards;
+                    map.entry(spo)
+                        .and_modify(|v| *v += stake)
+                        .or_insert(stake);
+                }
+            });
+
+        // Collect into a plain HashMap
+        spo_stakes
+            .iter()
+            .map(|entry| ((**entry.key()).clone(), *entry.value()))
+            .collect()
     }
 
     /// Handle an EpochActivityMessage giving total fees and block counts by VRF key for


### PR DESCRIPTION
Generate Stake Pool Delegation Distribution and provide REST server for it - but be aware rewards aren't yet calculated, so it will be wrong!

The REST request currently generates it dynamically, which is a moderately large bit of work.  Once it is used in the reward calculation it should only be generated once per epoch and captured for return in the REST request.

PR now to allow it to be used in #8.  Reviewers mostly FYI but comments appreciated.


