### PR TITLE
DRep Delegation Distribution

### DIFF
--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -115,8 +115,17 @@ pub struct DRepStateMessage {
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct DRepStakeDistributionMessage {
-    /// DRep stake distribution by ID, if None then no changes
-    pub data: Option<Vec<(DRepCredential, Lovelace)>>,
+    /// Epoch which has ended
+    pub epoch: u64,
+
+    /// DRep stake assigned to the special "abstain" DRep.
+    pub abstain: Lovelace,
+
+    /// DRep stake assigned to the special "no confidence" DRep
+    pub no_confidence: Lovelace,
+
+    /// DRep stake distribution by ID
+    pub dreps: Vec<(DRepCredential, Lovelace)>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -188,6 +188,13 @@ impl Credential {
         }
     }
 
+    pub fn to_json_string(&self) -> String {
+        match self {
+            Self::ScriptHash(hash) => format!("scriptHash-{}", hex::encode(hash)),
+            Self::AddrKeyHash(hash) => format!("keyHash-{}", hex::encode(hash)),
+        }
+    }
+
     pub fn get_hash(&self) -> KeyHash {
         match self {
             Self::AddrKeyHash(hash) => hash,

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -123,10 +123,9 @@ impl AccountsState {
                     Message::Cardano((block_info, CardanoMessage::DRepState(dreps_msg))) => {
                         state.handle_drep_state(&dreps_msg);
 
-                        if let Err(e) = publisher
-                            .publish_stake(block_info, Some(dreps_msg.dreps.clone()))
-                            .await
-                        {
+                        let drdd = state.generate_drdd();
+
+                        if let Err(e) = publisher.publish_stake(block_info, drdd).await {
                             tracing::error!("Error publishing drep voting stake distribution: {e}")
                         }
                     }

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -5,9 +5,9 @@ use acropolis_common::{
     messages::{CardanoMessage, Message, RESTResponse},
     rest_helper::{handle_rest, handle_rest_with_parameter},
     state_history::StateHistory,
-    Address, BlockInfo, BlockStatus, StakeAddress, StakeAddressPayload,
+    Address, BlockInfo, BlockStatus, Lovelace, StakeAddress, StakeAddressPayload,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use caryatid_sdk::{message_bus::Subscription, module, Context, Module};
 use config::Config;
 use serde_json;
@@ -27,6 +27,7 @@ const DEFAULT_TX_CERTIFICATES_TOPIC: &str = "cardano.certificates";
 const DEFAULT_STAKE_DELTAS_TOPIC: &str = "cardano.stake.deltas";
 const DEFAULT_HANDLE_STAKE_TOPIC: &str = "rest.get.stake";
 const DEFAULT_HANDLE_SPDD_TOPIC: &str = "rest.get.spdd";
+const DEFAULT_HANDLE_DRDD_TOPIC: &str = "rest.get.drdd";
 const DEFAULT_DREP_STATE_TOPIC: &str = "cardano.drep.state";
 const DEFAULT_DREP_DISTRIBUTION_TOPIC: &str = "cardano.drep.distribution";
 
@@ -120,7 +121,8 @@ impl AccountsState {
                 let (_, message) = dreps_message_f.await?;
                 match message.as_ref() {
                     Message::Cardano((block_info, CardanoMessage::DRepState(dreps_msg))) => {
-                        // TODO: update our list of dreps
+                        state.handle_drep_state(&dreps_msg);
+
                         if let Err(e) = publisher
                             .publish_stake(block_info, Some(dreps_msg.dreps.clone()))
                             .await
@@ -219,6 +221,11 @@ impl AccountsState {
             .unwrap_or(DEFAULT_HANDLE_SPDD_TOPIC.to_string());
         info!("Creating request handler on '{handle_spdd_topic}'");
 
+        let handle_drdd_topic = config
+            .get_string("handle-drdd-topic")
+            .unwrap_or(DEFAULT_HANDLE_DRDD_TOPIC.to_string());
+        info!("Creating request handler on '{handle_drdd_topic}'");
+
         let drep_state_topic = config
             .get_string("drep-state-topic")
             .unwrap_or(DEFAULT_DREP_STATE_TOPIC.to_string());
@@ -232,6 +239,7 @@ impl AccountsState {
         let history_stake = history.clone();
         let history_stake_single = history.clone();
         let history_spdd = history.clone();
+        let history_drdd = history.clone();
         let history_tick = history.clone();
 
         // Handle requests for full state
@@ -297,6 +305,32 @@ impl AccountsState {
             }
         });
 
+        // Handle requests for DRDD
+        handle_rest(context.clone(), &handle_drdd_topic, move || {
+            let history = history_drdd.clone();
+            async move {
+                let drdd = history
+                    .lock()
+                    .await
+                    .current()
+                    .map(|state| state.generate_drdd())
+                    .unwrap_or_default();
+                let drdd = APIDRepDelegationDistribution {
+                    abstain: drdd.abstain,
+                    no_confidence: drdd.no_confidence,
+                    dreps: drdd
+                        .dreps
+                        .into_iter()
+                        .map(|(cred, amount)| (cred.to_json_string(), amount))
+                        .collect(),
+                };
+                match serde_json::to_string(&drdd) {
+                    Ok(body) => Ok(RESTResponse::with_json(200, &body)),
+                    Err(error) => bail!("{:?}", error),
+                }
+            }
+        });
+
         // Ticker to log stats
         let mut tick_subscription = context.subscribe("clock.tick").await?;
         context.clone().run(async move {
@@ -344,4 +378,11 @@ impl AccountsState {
 
         Ok(())
     }
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct APIDRepDelegationDistribution {
+    pub abstain: Lovelace,
+    pub no_confidence: Lovelace,
+    pub dreps: Vec<(String, u64)>,
 }

--- a/modules/accounts_state/src/drep_distribution_publisher.rs
+++ b/modules/accounts_state/src/drep_distribution_publisher.rs
@@ -1,7 +1,9 @@
 use acropolis_common::messages::{CardanoMessage, DRepStakeDistributionMessage, Message};
-use acropolis_common::{BlockInfo, DRepCredential, Lovelace};
+use acropolis_common::BlockInfo;
 use caryatid_sdk::Context;
 use std::sync::Arc;
+
+use crate::state::DRepDelegationDistribution;
 
 pub struct DRepDistributionPublisher {
     /// Module context
@@ -19,7 +21,7 @@ impl DRepDistributionPublisher {
     pub async fn publish_stake(
         &mut self,
         block: &BlockInfo,
-        s: Option<Vec<(DRepCredential, Lovelace)>>,
+        s: DRepDelegationDistribution,
     ) -> anyhow::Result<()> {
         self.context
             .message_bus
@@ -27,7 +29,12 @@ impl DRepDistributionPublisher {
                 &self.topic,
                 Arc::new(Message::Cardano((
                     block.clone(),
-                    CardanoMessage::DRepStakeDistribution(DRepStakeDistributionMessage { data: s }),
+                    CardanoMessage::DRepStakeDistribution(DRepStakeDistributionMessage {
+                        epoch: block.epoch,
+                        abstain: s.abstain,
+                        no_confidence: s.no_confidence,
+                        dreps: s.dreps,
+                    }),
                 ))),
             )
             .await

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -141,7 +141,8 @@ impl State {
                 DRepChoice::Abstain => &abstain,
                 DRepChoice::NoConfidence => &no_confidence,
             };
-            total.fetch_add(state.utxo_value, std::sync::atomic::Ordering::Relaxed);
+            let stake = state.utxo_value + state.rewards;
+            total.fetch_add(stake, std::sync::atomic::Ordering::Relaxed);
         }
         let abstain = abstain.load(std::sync::atomic::Ordering::Relaxed);
         let no_confidence = no_confidence.load(std::sync::atomic::Ordering::Relaxed);
@@ -306,9 +307,8 @@ mod tests {
     use super::*;
     use acropolis_common::{
         AddressNetwork, Credential, Registration, StakeAddress, StakeAddressDelta,
-        StakeAddressPayload, StakeAndVoteDelegation, StakeCredentialWithPos,
-        StakeRegistrationAndStakeAndVoteDelegation, StakeRegistrationAndVoteDelegation,
-        VoteDelegation,
+        StakeAddressPayload, StakeAndVoteDelegation, StakeRegistrationAndStakeAndVoteDelegation,
+        StakeRegistrationAndVoteDelegation, VoteDelegation,
     };
 
     const STAKE_KEY_HASH: [u8; 3] = [0x99, 0x0f, 0x00];

--- a/modules/governance_state/src/governance_state.rs
+++ b/modules/governance_state/src/governance_state.rs
@@ -227,9 +227,7 @@ impl GovernanceState {
             if blk_g != blk_drep {
                 error!("Governance {blk_g:?} and DRep distribution {blk_drep:?} are out of sync");
             }
-            if distr.data.is_some() {
-                state.lock().await.handle_drep_stake(&distr).await?
-            }
+            state.lock().await.handle_drep_stake(&distr).await?
         }
     }
 

--- a/modules/governance_state/src/state.rs
+++ b/modules/governance_state/src/state.rs
@@ -93,9 +93,7 @@ impl State {
         message: &DRepStakeDistributionMessage,
     ) -> Result<()> {
         self.drep_stake_messages_count += 1;
-        if let Some(ref vec) = message.data {
-            self.drep_stake = HashMap::from_iter(vec.iter().cloned());
-        }
+        self.drep_stake = HashMap::from_iter(message.dreps.iter().cloned());
         Ok(())
     }
 


### PR DESCRIPTION
Compute drep delegation distribution in the account state module. Every epoch, we generate the DRDD and yeet it to whoever's listening. We also have a REST endpoint which exposes it.

Closes #41 