### PR TITLE
chore: bump pallas to v0.32.1

### DIFF
--- a/modules/block_unpacker/Cargo.toml
+++ b/modules/block_unpacker/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.0"
+pallas = "0.32.1"
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 config = "0.15.11"

--- a/modules/epoch_activity_counter/Cargo.toml
+++ b/modules/epoch_activity_counter/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.0"
+pallas = "0.32.1"
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 config = "0.15.11"

--- a/modules/genesis_bootstrapper/Cargo.toml
+++ b/modules/genesis_bootstrapper/Cargo.toml
@@ -15,7 +15,7 @@ anyhow = "1.0"
 caryatid_sdk = "0.12"
 config = "0.15.11"
 hex = "0.4"
-pallas = "0.32.0"
+pallas = "0.32.1"
 serde_json = "1.0.138"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"

--- a/modules/parameters_state/Cargo.toml
+++ b/modules/parameters_state/Cargo.toml
@@ -16,7 +16,7 @@ async-trait = "0.1"
 caryatid_sdk = "0.12"
 config = "0.15.11"
 hex = "0.4.3"
-pallas = "0.32.0"
+pallas = "0.32.1"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.12.0", features = ["hex"] }

--- a/modules/tx_unpacker/Cargo.toml
+++ b/modules/tx_unpacker/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.0"
+pallas = "0.32.1"
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 config = "0.15.11"

--- a/modules/upstream_chain_fetcher/Cargo.toml
+++ b/modules/upstream_chain_fetcher/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 [dependencies]
 caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.0"
+pallas = "0.32.1"
 anyhow = "1.0"
 tokio = { version = "1", features = ["full"] }
 config = "0.15.11"


### PR DESCRIPTION
Pallas v0.32.1 introduces compatibility with NodeToNode handshake version 14. This PR updates all relevant Acropolis modules to use v0.32.1 to align with the latest upstream changes.

I tested this functionality using the omnibus process, which calls `upstream_chain_fetcher` to ensure `PeerClient::connect` works as intended with NodeToNode handshake version 14.