### PR TITLE
Shd/rational migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,9 +22,10 @@ dependencies = [
  "hex",
  "lf-queue",
  "minicbor 0.26.5",
+ "num-rational",
  "serde",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "tokio",
  "tracing",
 ]
@@ -43,7 +44,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "tokio",
  "tracing",
 ]
@@ -72,7 +73,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "tokio",
  "tracing",
 ]
@@ -118,7 +119,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "tokio",
  "tracing",
 ]
@@ -150,11 +151,12 @@ dependencies = [
  "caryatid_sdk",
  "config",
  "hex",
+ "num-rational",
  "pallas",
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "tokio",
  "tracing",
 ]
@@ -187,7 +189,7 @@ dependencies = [
  "imbl",
  "serde",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "tokio",
  "tracing",
 ]
@@ -208,7 +210,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_any_key",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "tokio",
  "tracing",
 ]
@@ -517,7 +519,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -529,7 +531,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -546,9 +548,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.24"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d615619615a650c571269c00dca41db04b9210037fa76ed8239f70404ab56985"
+checksum = "40f6024f3f856663b45fd0c9b6f2024034a702f453549449e0d84a305900dad4"
 dependencies = [
  "brotli",
  "flate2",
@@ -678,7 +680,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -695,7 +697,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -706,9 +708,9 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -834,9 +836,9 @@ dependencies = [
 
 [[package]]
 name = "bip39"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33415e24172c1b7d6066f6d999545375ab8e1d95421d6784bdfff9496f292387"
+checksum = "43d193de1f7487df1914d3a568b772458861d33f9c54249612cc2893d6915054"
 dependencies = [
  "bitcoin_hashes",
  "rand_core 0.6.4",
@@ -888,7 +890,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6cbbb8f56245b5a479b30a62cdc86d26e2f35c2b9f594bc4671654b03851380"
 dependencies = [
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -986,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
@@ -1144,9 +1146,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "d487aa071b5f64da6f19a3e848e3578944b726ee5a4854b82172f02aa876bfdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1393,9 +1395,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1447,7 +1449,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1471,7 +1473,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1482,7 +1484,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1540,7 +1542,7 @@ checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1590,7 +1592,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1613,6 +1615,12 @@ name = "double-ended-peekable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0d05e1c0dbad51b52c38bda7adceef61b9efc2baf04acfe8726a8c4630a6f57"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "ed25519"
@@ -1673,7 +1681,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1694,12 +1702,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1791,9 +1799,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "fjall"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13279146a877c2060f668bc4c477af8ef5aa42732c58dca32fcb4aff40edc5b4"
+checksum = "f5cb653019268f6dc8de3b254b633a2d233a775054349b804b9cfbf18bbe3426"
 dependencies = [
  "byteorder",
  "byteview",
@@ -1974,7 +1982,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2054,7 +2062,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -2110,7 +2118,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2119,9 +2127,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
+checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2129,7 +2137,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.3.1",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2196,9 +2204,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2322,7 +2330,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
@@ -2578,9 +2586,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -2633,6 +2641,17 @@ dependencies = [
  "hermit-abi 0.3.9",
  "libc",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2771,13 +2790,13 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "1580801010e535496706ba011c15f8532df6b42297d2e471fec38ceadd8c0638"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
 ]
 
 [[package]]
@@ -2829,9 +2848,9 @@ dependencies = [
 
 [[package]]
 name = "lsm-tree"
-version = "2.10.0"
+version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0d03b764a7e3009cc4d314bfce42ce28b4a2c458fc7149b57817cbed7898f43"
+checksum = "1d2bd4cdc451a8dcf11329190afb9b78eb8988bed07a3da29b8d73d2e0c731ff"
 dependencies = [
  "byteorder",
  "crossbeam-skiplist",
@@ -2874,9 +2893,9 @@ checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -2912,7 +2931,7 @@ checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2923,7 +2942,7 @@ checksum = "a9882ef5c56df184b8ffc107fc6c61e33ee3a654b021961d790a78571bb9d67a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2948,15 +2967,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "mithril-build-script"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73f07a9234f37f6014e8e81db78e22358a9e431a0ec705433cd841ecc8d694f3"
+checksum = "1f19b291f31d73c8a4c6a57adb5469cc6b87395973023b6c33abfc844bf6050d"
 dependencies = [
  "semver",
  "serde_json",
@@ -2965,9 +2984,9 @@ dependencies = [
 
 [[package]]
 name = "mithril-client"
-version = "0.12.2"
+version = "0.12.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee06cf25db2bc6bcff892893adf5809e663ef4d8326cf022c22b6c1a2be2efac"
+checksum = "fe7b677e2797ce8554553bd4998ec79f141a7d1bec1c2944c16dddcf57d6b568"
 dependencies = [
  "anyhow",
  "async-recursion",
@@ -2978,7 +2997,7 @@ dependencies = [
  "futures",
  "getrandom 0.2.16",
  "mithril-common",
- "reqwest 0.12.19",
+ "reqwest 0.12.22",
  "semver",
  "serde",
  "serde_json",
@@ -2993,9 +3012,9 @@ dependencies = [
 
 [[package]]
 name = "mithril-common"
-version = "0.5.27"
+version = "0.5.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3377e855390a51c95ec1d093bd5f760e0a0b9cf9ae022584fb158636aa2108c1"
+checksum = "0253a5237371e7795495e740766f49d6da85e736127239bee067020ac0f0a629"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3024,7 +3043,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
  "sha2",
  "slog",
  "strum",
@@ -3037,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "mithril-stm"
-version = "0.3.45"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09af2ae3fc4d30ddb5b55b10e44ce3f10b44274746da43b51a5640c6cc1bb02"
+checksum = "351d0de77ce721870b97df7be20cb0903f26854fcc689e874c502c9ae8e4f6d2"
 dependencies = [
  "blake2 0.10.6",
  "blst",
@@ -3183,6 +3202,7 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
+ "serde",
 ]
 
 [[package]]
@@ -3200,7 +3220,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -3257,7 +3277,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3393,7 +3413,7 @@ dependencies = [
  "pallas-primitives",
  "serde",
  "serde_json",
- "serde_with 3.12.0",
+ "serde_with 3.14.0",
 ]
 
 [[package]]
@@ -3573,7 +3593,7 @@ checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.12",
+ "redox_syscall 0.5.13",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -3672,9 +3692,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
  "thiserror 2.0.12",
@@ -3683,9 +3703,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -3693,24 +3713,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -3722,7 +3741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
 dependencies = [
  "fixedbitset",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
 ]
 
 [[package]]
@@ -3742,7 +3761,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3850,7 +3869,7 @@ checksum = "b53a684391ad002dd6a596ceb6c74fd004fdce75f4be2e3f615068abbea5fd50"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.0.7",
  "tracing",
@@ -3883,12 +3902,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.33"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3926,7 +3945,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.102",
+ "syn 2.0.104",
  "tempfile",
 ]
 
@@ -3940,7 +3959,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3973,9 +3992,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -4102,11 +4121,31 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "0d04b7d0ee6b4a0207a0a7adb104d23ecb0b47d6beae7152d0fa34b692b29fd6"
 dependencies = [
  "bitflags 2.9.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4195,9 +4234,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.19"
+version = "0.12.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
+checksum = "cbc931937e6ca3a06e3b6c0aa7841849b160a90351d6ab467a8b9b9959767531"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -4205,7 +4244,7 @@ dependencies = [
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.4.10",
+ "h2 0.4.11",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -4213,12 +4252,10 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "rustls-pki-types",
@@ -4279,13 +4316,12 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.21.1"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e310ef0e1b6eeb79169a1171daf9abcb87a2e17c03bee2c4bb100b55c75409f"
+checksum = "e7295b7ce3bf4806b419dc3420745998b447178b7005e2011947b38fc5aa6791"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
- "trim-in-place",
 ]
 
 [[package]]
@@ -4347,9 +4383,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.27"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "once_cell",
  "ring",
@@ -4463,6 +4499,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1375ba8ef45a6f15d83fa8748f1079428295d403d6ea991d09ab100155fbc06d"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4556,7 +4616,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4630,19 +4690,21 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
+checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
+ "schemars 0.9.0",
+ "schemars 1.0.3",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_with_macros 3.12.0",
+ "serde_with_macros 3.14.0",
  "time",
 ]
 
@@ -4655,19 +4717,19 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.12.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
+checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4676,7 +4738,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "itoa",
  "ryu",
  "serde",
@@ -4740,12 +4802,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
 
 [[package]]
 name = "sled"
@@ -4851,7 +4910,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4873,9 +4932,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4905,7 +4964,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5018,7 +5077,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5029,17 +5088,16 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -5118,17 +5176,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "1140bb80481756a8cbe10541f37433b459c5aa1e727b4c020fbfebdc25bf3ec4"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot 0.12.4",
  "pin-project-lite",
  "signal-hook-registry",
+ "slab",
  "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -5153,7 +5213,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5227,7 +5287,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5330,13 +5390,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5379,12 +5439,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "trim-in-place"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343e926fc669bc8cde4fa3129ab681c63671bae288b1f1081ceee6d9d37904fc"
-
-[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5423,7 +5477,7 @@ checksum = "35f5380909ffc31b4de4f4bdf96b877175a016aa2ca98cee39fcfd8c4d53d952"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5440,9 +5494,9 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
@@ -5577,9 +5631,9 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -5612,7 +5666,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -5647,7 +5701,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5745,7 +5799,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5756,20 +5810,20 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-registry"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bab093bdd303a1240bb99b8aba8ea8a69ee19d34c9e2ef9594e708a4878820"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link",
  "windows-result",
@@ -5822,6 +5876,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.2",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5845,11 +5908,27 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -5865,6 +5944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5875,6 +5960,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5889,10 +5980,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5907,6 +6010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5917,6 +6026,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5931,6 +6046,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5943,10 +6064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.10"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74c7b26e3480b707944fc872477815d29a8e429d2f93a1ce000f5fa84a15cbcd"
 dependencies = [
  "memchr",
 ]
@@ -6006,9 +6133,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+checksum = "af3a19837351dc82ba89f8a125e22a3c475f05aba604acc023d62b2739ae2909"
 dependencies = [
  "libc",
  "rustix 1.0.7",
@@ -6051,28 +6178,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6092,7 +6219,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
  "synstructure",
 ]
 
@@ -6113,7 +6240,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6146,7 +6273,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,9 +536,9 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+checksum = "16c74e56284d2188cabb6ad99603d1ace887a5d7e7b695d01b728155ed9ed427"
 dependencies = [
  "concurrent-queue",
  "event-listener-strategy",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -23,6 +23,7 @@ gcd = "2.3"
 fraction = "0.15"
 hex = "0.4"
 lf-queue = "0.1.0"
+num-rational = { version = "0.4.2", features = ["serde"] }
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.12.0", features = ["hex"] }

--- a/common/src/rational_number.rs
+++ b/common/src/rational_number.rs
@@ -1,128 +1,30 @@
-use anyhow::{anyhow, Error, Result};
-use fraction::Fraction;
-use gcd::Gcd;
-use std::cmp::Ordering;
+use anyhow::{anyhow, Result};
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
-pub struct RationalNumber {
-    pub numerator: u64,
-    pub denominator: u64,
-}
+pub type RationalNumber = num_rational::Ratio<u64>;
 
-impl RationalNumber {
-    pub fn new(numerator: u64, denominator: u64) -> anyhow::Result<Self> {
-        if denominator == 0 {
-            Err(anyhow!(
-                "{numerator}/{denominator}: denominator cannot be zero"
-            ))
-        } else {
-            Ok(Self {
-                numerator,
-                denominator,
-            })
-        }
-    }
-
-    pub fn new_with_zero(numerator: u64, denominator: u64) -> anyhow::Result<Self> {
-        if numerator == 0 {
-            Ok(Self::ZERO.clone())
-        } else {
-            Self::new(numerator, denominator)
-        }
-    }
-
-    pub const ZERO: Self = Self {
-        numerator: 0,
-        denominator: 1,
-    };
-    pub const ONE: Self = Self {
-        numerator: 1,
-        denominator: 1,
-    };
-
-    pub fn proportion_of(&self, value: u64) -> anyhow::Result<Self> {
-        let gcd = Gcd::gcd(self.denominator, value);
-        let value_gcd: u64 = value / gcd;
-        let new_numerator = value_gcd
-            .checked_mul(self.numerator)
-            .ok_or_else(|| anyhow!("u64 overflow in {} * {}", value_gcd, self.numerator))?;
-        Self::new(new_numerator, self.denominator / gcd)
-    }
-
-    pub fn round_up(&self) -> u64 {
-        let quot = self.numerator / self.denominator;
-        let rem = self.numerator % self.denominator;
-
-        if rem != 0 {
-            quot + 1
-        } else {
-            quot
-        }
-    }
-}
-
-impl From<u64> for RationalNumber {
-    fn from(value: u64) -> Self {
-        Self {
-            numerator: value,
-            denominator: 1,
-        }
-    }
-}
-
-impl TryFrom<f32> for RationalNumber {
-    type Error = Error;
-    fn try_from(value: f32) -> Result<RationalNumber> {
-        if value.is_sign_negative() {
-            return Err(anyhow!("Value {} must be greater than 0", value));
-        }
-        let fract = Fraction::from(value);
-        Ok(RationalNumber {
-            numerator: *fract
-                .numer()
-                .ok_or_else(|| anyhow!("Cannot get numerator for {}", value))?,
-            denominator: *fract
-                .denom()
-                .ok_or_else(|| anyhow!("Cannot get denominator for {}", value))?,
-        })
-    }
-}
-
-impl PartialOrd for RationalNumber {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(u64::cmp(
-            &(self.numerator * other.denominator),
-            &(self.denominator * other.numerator),
-        ))
-    }
-}
-
-impl Ord for RationalNumber {
-    fn cmp(&self, other: &Self) -> Ordering {
-        u64::cmp(
-            &(self.numerator * other.denominator),
-            &(self.denominator * other.numerator),
-        )
-    }
+pub fn rational_number_from_f32(f: f32) -> Result<RationalNumber> {
+    RationalNumber::approximate_float_unsigned(f)
+        .ok_or_else(|| anyhow!("Cannot convert {f} to Rational"))
 }
 
 #[cfg(test)]
 mod tests {
     use crate::rational_number::RationalNumber;
+    use crate::rational_number::rational_number_from_f32;
 
     #[test]
     fn test_fractions() -> Result<(), anyhow::Error> {
         assert_eq!(
-            RationalNumber::try_from(0.51)?,
-            RationalNumber::new(51, 100)?
+            rational_number_from_f32(0.51)?,
+            RationalNumber::new(51, 100)
         );
         assert_eq!(
-            RationalNumber::try_from(0.67)?,
-            RationalNumber::new(67, 100)?
+            rational_number_from_f32(0.67)?,
+            RationalNumber::new(67, 100)
         );
-        assert_eq!(RationalNumber::try_from(0.6)?, RationalNumber::new(3, 5)?);
-        assert_eq!(RationalNumber::try_from(0.75)?, RationalNumber::new(3, 4)?);
-        assert_eq!(RationalNumber::try_from(0.5)?, RationalNumber::new(1, 2)?);
+        assert_eq!(rational_number_from_f32(0.6)?, RationalNumber::new(3, 5));
+        assert_eq!(rational_number_from_f32(0.75)?, RationalNumber::new(3, 4));
+        assert_eq!(rational_number_from_f32(0.5)?, RationalNumber::new(1, 2));
         Ok(())
     }
 }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -2,8 +2,8 @@
 // We don't use these types in the acropolis_common crate itself
 #![allow(dead_code)]
 
-use crate::address::{Address, StakeAddress};
-use crate::rational_number::RationalNumber;
+use crate::{address::{Address, StakeAddress}, rational_number::RationalNumber};
+
 use anyhow::anyhow;
 use bech32::{Bech32, Hrp};
 use bitmask_enum::bitmask;
@@ -602,8 +602,6 @@ pub struct ExUnitPrices {
     pub step_price: RationalNumber,
 }
 
-pub type UnitInterval = RationalNumber;
-
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct GovActionId {
     pub transaction_id: DataHash,
@@ -647,25 +645,25 @@ pub struct CostModels {
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct PoolVotingThresholds {
-    pub motion_no_confidence: UnitInterval,
-    pub committee_normal: UnitInterval,
-    pub committee_no_confidence: UnitInterval,
-    pub hard_fork_initiation: UnitInterval,
-    pub security_voting_threshold: UnitInterval,
+    pub motion_no_confidence: RationalNumber,
+    pub committee_normal: RationalNumber,
+    pub committee_no_confidence: RationalNumber,
+    pub hard_fork_initiation: RationalNumber,
+    pub security_voting_threshold: RationalNumber,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct DRepVotingThresholds {
-    pub motion_no_confidence: UnitInterval,
-    pub committee_normal: UnitInterval,
-    pub committee_no_confidence: UnitInterval,
-    pub update_constitution: UnitInterval,
-    pub hard_fork_initiation: UnitInterval,
-    pub pp_network_group: UnitInterval,
-    pub pp_economic_group: UnitInterval,
-    pub pp_technical_group: UnitInterval,
-    pub pp_governance_group: UnitInterval,
-    pub treasury_withdrawal: UnitInterval,
+    pub motion_no_confidence: RationalNumber,
+    pub committee_normal: RationalNumber,
+    pub committee_no_confidence: RationalNumber,
+    pub update_constitution: RationalNumber,
+    pub hard_fork_initiation: RationalNumber,
+    pub pp_network_group: RationalNumber,
+    pub pp_economic_group: RationalNumber,
+    pub pp_technical_group: RationalNumber,
+    pub pp_governance_group: RationalNumber,
+    pub treasury_withdrawal: RationalNumber,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -869,10 +867,10 @@ pub struct ProtocolParamUpdate {
     pub pool_pledge_influence: Option<RationalNumber>,
 
     /// AKA rho, monetary_expansion (Shelley)
-    pub expansion_rate: Option<UnitInterval>,
+    pub expansion_rate: Option<RationalNumber>,
 
     /// AKA tau, treasury_cut (Shelley)
-    pub treasury_growth_rate: Option<UnitInterval>,
+    pub treasury_growth_rate: Option<RationalNumber>,
 
     /// (Shelley)
     pub min_pool_cost: Option<Lovelace>,
@@ -929,7 +927,7 @@ pub struct ProtocolParamUpdate {
     pub drep_inactivity_period: Option<u64>,
 
     /// AKA min_fee_ref_script_cost_per_byte (Conway)
-    pub minfee_refscript_cost_per_byte: Option<UnitInterval>,
+    pub minfee_refscript_cost_per_byte: Option<RationalNumber>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -979,7 +977,7 @@ pub struct CommitteeChange {
     pub removed_committee_members: HashSet<CommitteeCredential>,
     #[serde_as(as = "Vec<(_, _)>")]
     pub new_committee_members: HashMap<CommitteeCredential, u64>,
-    pub terms: UnitInterval,
+    pub terms: RationalNumber,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -484,7 +484,7 @@ mod tests {
         ConwayParams, Credential, DRepVotingThresholds, PoolVotingThresholds, Pot, PotDelta,
         ProtocolParams, Registration, StakeAddress, StakeAddressDelta, StakeAddressPayload,
         StakeAndVoteDelegation, StakeRegistrationAndStakeAndVoteDelegation,
-        StakeRegistrationAndVoteDelegation, UnitInterval, VoteDelegation, Withdrawal,
+        StakeRegistrationAndVoteDelegation, VoteDelegation, Withdrawal,
     };
 
     const STAKE_KEY_HASH: [u8; 3] = [0x99, 0x0f, 0x00];
@@ -886,23 +886,23 @@ mod tests {
         let params = ProtocolParams {
             conway: Some(ConwayParams {
                 pool_voting_thresholds: PoolVotingThresholds {
-                    motion_no_confidence: UnitInterval::ONE,
-                    committee_normal: UnitInterval::ZERO,
-                    committee_no_confidence: UnitInterval::ZERO,
-                    hard_fork_initiation: UnitInterval::ONE,
-                    security_voting_threshold: UnitInterval::ZERO,
+                    motion_no_confidence: RationalNumber::ONE,
+                    committee_normal: RationalNumber::ZERO,
+                    committee_no_confidence: RationalNumber::ZERO,
+                    hard_fork_initiation: RationalNumber::ONE,
+                    security_voting_threshold: RationalNumber::ZERO,
                 },
                 d_rep_voting_thresholds: DRepVotingThresholds {
-                    motion_no_confidence: UnitInterval::ONE,
-                    committee_normal: UnitInterval::ZERO,
-                    committee_no_confidence: UnitInterval::ZERO,
-                    update_constitution: UnitInterval::ONE,
-                    hard_fork_initiation: UnitInterval::ZERO,
-                    pp_network_group: UnitInterval::ZERO,
-                    pp_economic_group: UnitInterval::ZERO,
-                    pp_technical_group: UnitInterval::ZERO,
-                    pp_governance_group: UnitInterval::ZERO,
-                    treasury_withdrawal: UnitInterval::ONE,
+                    motion_no_confidence: RationalNumber::ONE,
+                    committee_normal: RationalNumber::ZERO,
+                    committee_no_confidence: RationalNumber::ZERO,
+                    update_constitution: RationalNumber::ONE,
+                    hard_fork_initiation: RationalNumber::ZERO,
+                    pp_network_group: RationalNumber::ZERO,
+                    pp_economic_group: RationalNumber::ZERO,
+                    pp_technical_group: RationalNumber::ZERO,
+                    pp_governance_group: RationalNumber::ZERO,
+                    treasury_withdrawal: RationalNumber::ONE,
                 },
                 committee_min_size: 42,
                 committee_max_term_length: 3,
@@ -910,7 +910,7 @@ mod tests {
                 gov_action_deposit: 500_000_000,
                 d_rep_deposit: 100_000_000,
                 d_rep_activity: 27,
-                min_fee_ref_script_cost_per_byte: RationalNumber::new(1, 42).unwrap(),
+                min_fee_ref_script_cost_per_byte: RationalNumber::new(1, 42),
                 plutus_v3_cost_model: Vec::new(),
                 constitution: Constitution {
                     anchor: Anchor {
@@ -921,7 +921,7 @@ mod tests {
                 },
                 committee: Committee {
                     members: std::collections::HashMap::new(),
-                    threshold: RationalNumber::new(5, 32).unwrap(),
+                    threshold: RationalNumber::new(5, 32),
                 },
             }),
 

--- a/modules/governance_state/src/state.rs
+++ b/modules/governance_state/src/state.rs
@@ -187,8 +187,8 @@ impl State {
         drep: &RationalNumber,
         comm: &RationalNumber,
     ) -> Result<(u64, u64)> {
-        let d = drep.proportion_of(self.voting_state.registered_dreps)?.round_up();
-        let c = comm.proportion_of(self.voting_state.committee_size)?.round_up();
+        let d = (drep * self.voting_state.registered_dreps).ceil().to_integer();
+        let c = (comm * self.voting_state.committee_size).ceil().to_integer();
         Ok((d, c))
     }
 
@@ -199,7 +199,7 @@ impl State {
         comm: &RationalNumber,
     ) -> Result<VotesCount> {
         let mut votes = VotesCount::zero();
-        votes.pool = pool.proportion_of(self.voting_state.registered_spos)?.round_up();
+        votes.pool = (pool * self.voting_state.registered_spos).ceil().to_integer();
         (votes.drep, votes.committee) = self.proportional_count_drep_comm(drep, comm)?;
         Ok(votes)
     }
@@ -211,7 +211,7 @@ impl State {
         comm: &RationalNumber,
     ) -> Result<VotesCount> {
         let mut votes = VotesCount::zero();
-        votes.pool = pool.proportion_of(self.voting_state.total_spos)?.round_up();
+        votes.pool = (pool * self.voting_state.total_spos).ceil().to_integer();
         (votes.drep, votes.committee) = self.proportional_count_drep_comm(drep, comm)?;
         Ok(votes)
     }

--- a/modules/parameters_state/Cargo.toml
+++ b/modules/parameters_state/Cargo.toml
@@ -16,6 +16,7 @@ async-trait = "0.1"
 caryatid_sdk = "0.12"
 config = "0.15.11"
 hex = "0.4.3"
+num-rational = "0.4.2"
 pallas = "0.32.1"
 serde = { version = "1.0.214", features = ["derive"] }
 serde_json = "1.0"

--- a/modules/parameters_state/src/genesis_params.rs
+++ b/modules/parameters_state/src/genesis_params.rs
@@ -1,5 +1,6 @@
 use acropolis_common::{
-    rational_number::RationalNumber, AlonzoParams, Anchor, BlockVersionData, ByronParams,
+    rational_number::{RationalNumber, rational_number_from_f32},
+    AlonzoParams, Anchor, BlockVersionData, ByronParams,
     Committee, Constitution, ConwayParams, Credential, DRepVotingThresholds, Era, ExUnitPrices,
     ExUnits, NetworkId, Nonce, NonceVariant, PoolVotingThresholds, ProtocolConsts, ProtocolVersion,
     ShelleyParams, ShelleyProtocolParams, SoftForkRule, TxFeePolicy,
@@ -50,34 +51,31 @@ fn map_anchor(anchor: &conway::Anchor) -> Result<Anchor> {
 }
 
 pub fn map_fraction(fraction: &conway::Fraction) -> RationalNumber {
-    RationalNumber {
-        numerator: fraction.numerator,
-        denominator: fraction.denominator,
-    }
+    RationalNumber::new(fraction.numerator, fraction.denominator)
 }
 
 fn map_pool_thresholds(thresholds: &conway::PoolVotingThresholds) -> Result<PoolVotingThresholds> {
     Ok(PoolVotingThresholds {
-        motion_no_confidence: RationalNumber::try_from(thresholds.motion_no_confidence)?,
-        committee_normal: RationalNumber::try_from(thresholds.committee_normal)?,
-        committee_no_confidence: RationalNumber::try_from(thresholds.committee_no_confidence)?,
-        hard_fork_initiation: RationalNumber::try_from(thresholds.hard_fork_initiation)?,
-        security_voting_threshold: RationalNumber::try_from(thresholds.pp_security_group)?,
+        motion_no_confidence: rational_number_from_f32(thresholds.motion_no_confidence)?,
+        committee_normal: rational_number_from_f32(thresholds.committee_normal)?,
+        committee_no_confidence: rational_number_from_f32(thresholds.committee_no_confidence)?,
+        hard_fork_initiation: rational_number_from_f32(thresholds.hard_fork_initiation)?,
+        security_voting_threshold: rational_number_from_f32(thresholds.pp_security_group)?,
     })
 }
 
 fn map_drep_thresholds(thresholds: &conway::DRepVotingThresholds) -> Result<DRepVotingThresholds> {
     Ok(DRepVotingThresholds {
-        motion_no_confidence: RationalNumber::try_from(thresholds.motion_no_confidence)?,
-        committee_normal: RationalNumber::try_from(thresholds.committee_normal)?,
-        committee_no_confidence: RationalNumber::try_from(thresholds.committee_normal)?,
-        update_constitution: RationalNumber::try_from(thresholds.update_to_constitution)?,
-        hard_fork_initiation: RationalNumber::try_from(thresholds.hard_fork_initiation)?,
-        pp_network_group: RationalNumber::try_from(thresholds.pp_network_group)?,
-        pp_economic_group: RationalNumber::try_from(thresholds.pp_economic_group)?,
-        pp_technical_group: RationalNumber::try_from(thresholds.pp_technical_group)?,
-        pp_governance_group: RationalNumber::try_from(thresholds.pp_gov_group)?,
-        treasury_withdrawal: RationalNumber::try_from(thresholds.treasury_withdrawal)?,
+        motion_no_confidence: rational_number_from_f32(thresholds.motion_no_confidence)?,
+        committee_normal: rational_number_from_f32(thresholds.committee_normal)?,
+        committee_no_confidence: rational_number_from_f32(thresholds.committee_normal)?,
+        update_constitution: rational_number_from_f32(thresholds.update_to_constitution)?,
+        hard_fork_initiation: rational_number_from_f32(thresholds.hard_fork_initiation)?,
+        pp_network_group: rational_number_from_f32(thresholds.pp_network_group)?,
+        pp_economic_group: rational_number_from_f32(thresholds.pp_economic_group)?,
+        pp_technical_group: rational_number_from_f32(thresholds.pp_technical_group)?,
+        pp_governance_group: rational_number_from_f32(thresholds.pp_gov_group)?,
+        treasury_withdrawal: rational_number_from_f32(thresholds.treasury_withdrawal)?,
     })
 }
 
@@ -128,7 +126,7 @@ fn map_ex_units(e: &alonzo::ExUnits) -> Result<ExUnits> {
 }
 
 fn map_alonzo_fraction(fr: &alonzo::Fraction) -> Result<RationalNumber> {
-    RationalNumber::new(fr.numerator, fr.denominator)
+    Ok(RationalNumber::new(fr.numerator, fr.denominator))
 }
 
 fn map_execution_prices(e: &alonzo::ExecutionPrices) -> Result<ExUnitPrices> {
@@ -165,10 +163,7 @@ fn map_alonzo(genesis: &alonzo::GenesisFile) -> Result<AlonzoParams> {
 }
 
 pub fn map_pallas_rational(r: &primitives::RationalNumber) -> RationalNumber {
-    RationalNumber {
-        numerator: r.numerator,
-        denominator: r.denominator,
-    }
+    RationalNumber::new(r.numerator, r.denominator)
 }
 
 fn map_network_id(id: &str) -> Result<NetworkId> {

--- a/modules/tx_unpacker/src/tx_unpacker.rs
+++ b/modules/tx_unpacker/src/tx_unpacker.rs
@@ -2,6 +2,7 @@
 //! Unpacks transaction bodies into UTXO events
 
 use acropolis_common::{
+    rational_number::RationalNumber,
     messages::{
         BlockFeesMessage, CardanoMessage, GovernanceProceduresMessage, Message,
         TxCertificatesMessage, UTXODeltasMessage, WithdrawalsMessage,
@@ -472,11 +473,8 @@ impl TxUnpacker {
         }
     }
 
-    fn map_unit_interval(pallas_interval: &conway::UnitInterval) -> UnitInterval {
-        UnitInterval {
-            numerator: pallas_interval.numerator,
-            denominator: pallas_interval.denominator,
-        }
+    fn map_unit_interval(pallas_interval: &conway::UnitInterval) -> RationalNumber {
+        RationalNumber::new(pallas_interval.numerator, pallas_interval.denominator)
     }
 
     fn map_ex_units(pallas_units: &conway::ExUnits) -> ExUnits {


### PR DESCRIPTION
Changed RationalNumber from custom implementation to standard Rust (num_rational::Ratio<u64>)

The file rational_number was left in place, it still has some functionality: it contains type definition, conversion function definition, and some tests.