### PR TITLE
feat: Update `handle_rest_with_parameter` to extract REST params dynamically

### DIFF
--- a/common/src/rest_helper.rs
+++ b/common/src/rest_helper.rs
@@ -49,23 +49,30 @@ pub fn handle_rest_with_parameter<F, Fut>(
     handler: F,
 ) -> JoinHandle<()>
 where
-    F: Fn(&str) -> Fut + Send + Sync + Clone + 'static,
+    F: Fn(&[&str]) -> Fut + Send + Sync + Clone + 'static,
     Fut: Future<Output = Result<RESTResponse>> + Send + 'static,
 {
+    let topic_owned = topic.to_string();
     context.handle(topic, move |message: Arc<Message>| {
         let handler = handler.clone();
+        let topic_owned = topic_owned.clone();
         async move {
             let response = match message.as_ref() {
                 Message::RESTRequest(request) => {
                     info!("REST received {} {}", request.method, request.path);
-                    match request.path_elements.get(1) {
-                        Some(param) => match handler(param).await {
+                    let params_vec =
+                        extract_params_from_topic_and_path(&topic_owned, &request.path_elements);
+                    let params_slice: Vec<&str> = params_vec.iter().map(|s| s.as_str()).collect();
+
+                    if params_slice.is_empty() {
+                        RESTResponse::with_text(400, "Parameters must be provided")
+                    } else {
+                        match handler(&params_slice).await {
                             Ok(response) => response,
                             Err(error) => {
                                 RESTResponse::with_text(500, &format!("{error:?}").to_string())
                             }
-                        },
-                        None => RESTResponse::with_text(400, "Parameter must be provided"),
+                        }
                     }
                 }
                 _ => {
@@ -77,4 +84,25 @@ where
             Arc::new(Message::RESTResponse(response))
         }
     })
+}
+
+/// Extract parameters from the request path based on the topic pattern.
+/// Skips the first 3 parts of the topic as these are never parameters
+fn extract_params_from_topic_and_path(topic: &str, path_elements: &[String]) -> Vec<String> {
+    let topic_parts: Vec<&str> = topic.split('.').collect();
+
+    // Find indexes of '*' in topic
+    let param_positions: Vec<usize> = topic_parts
+        .iter()
+        .enumerate()
+        .filter_map(|(i, &part)| if part == "*" { Some(i) } else { None })
+        .collect();
+
+    let offset = 2;
+
+    // Map topic '*' positions to corresponding path elements
+    param_positions
+        .iter()
+        .filter_map(|&pos| pos.checked_sub(offset).and_then(|idx| path_elements.get(idx)).cloned())
+        .collect()
 }

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -375,7 +375,7 @@ impl AccountsState {
         // Handle requests for single reward state based on stake address
         handle_rest_with_parameter(context.clone(), &handle_single_stake_topic, move |param| {
             let history = history_stake_single.clone();
-            let param = param.to_string();
+            let param = param[0].to_string();
 
             async move {
                 match Address::from_string(&param) {
@@ -392,7 +392,10 @@ impl AccountsState {
                         },
                         None => Err(anyhow!("No state")),
                     },
-                    _ => Ok(RESTResponse::with_text(400, "Not a stake address")),
+                    _ => Ok(RESTResponse::with_text(
+                        400,
+                        &format!("Not a stake address. Provided address: {}", param),
+                    )),
                 }
             }
         });
@@ -474,10 +477,9 @@ impl AccountsState {
             }
         });
 
-        let drep_publisher = DRepDistributionPublisher::new(context.clone(),
-                                                            drep_distribution_topic);
-        let spo_publisher = SPODistributionPublisher::new(context.clone(),
-                                                          spo_distribution_topic);
+        let drep_publisher =
+            DRepDistributionPublisher::new(context.clone(), drep_distribution_topic);
+        let spo_publisher = SPODistributionPublisher::new(context.clone(), spo_distribution_topic);
 
         // Subscribe
         let spos_subscription = context.subscribe(&spo_state_topic).await?;

--- a/modules/spo_state/src/spo_state.rs
+++ b/modules/spo_state/src/spo_state.rs
@@ -2,8 +2,10 @@
 //! Accepts certificate events and derives the SPO state in memory
 
 use acropolis_common::{
-    messages::{CardanoMessage, Message, RESTResponse, SnapshotDumpMessage, SnapshotMessage,
-    SnapshotStateMessage},
+    messages::{
+        CardanoMessage, Message, RESTResponse, SnapshotDumpMessage, SnapshotMessage,
+        SnapshotStateMessage,
+    },
     rest_helper::{handle_rest, handle_rest_with_parameter},
 };
 use anyhow::Result;
@@ -153,7 +155,7 @@ impl SPOState {
         let handle_topic_single = format!("{handle_topic}.*");
         let state_handle_single = state.clone();
         handle_rest_with_parameter(context.clone(), &handle_topic_single, move |param| {
-            let param = param.to_string();
+            let param = param[0].to_string();
             let state = state_handle_single.clone();
             async move {
                 let pool_id = match hex::decode(param) {

--- a/modules/utxo_state/src/utxo_state.rs
+++ b/modules/utxo_state/src/utxo_state.rs
@@ -125,7 +125,7 @@ impl UTXOState {
 
         // Handle REST requests for utxo.<tx_hash>:<index>
         handle_rest_with_parameter(context.clone(), &rest_topic, move |param| {
-            let param = param.to_string();
+            let param = param[0].to_string();
             let state = state.clone();
             async move {
                 // Parse "<tx_hash>:<index>"
@@ -134,7 +134,10 @@ impl UTXOState {
                     None => {
                         return Ok(RESTResponse::with_text(
                             400,
-                            "Parameter must be in <tx_hash>:<index> format",
+                            &format!(
+                                "Parameter must be in <tx_hash>:<index> format. Provided param: {}",
+                                param
+                            ),
                         ));
                     }
                 };
@@ -166,7 +169,10 @@ impl UTXOState {
 
                                     Ok(RESTResponse::with_json(200, &json_response.to_string()))
                                 }
-                                Ok(None) => Ok(RESTResponse::with_text(404, "UTXO not found")),
+                                Ok(None) => Ok(RESTResponse::with_text(
+                                    404,
+                                    &format!("UTxO not found. Provided UTxO: {}", param),
+                                )),
                                 Err(error) => Err(anyhow!("{:?}", error)),
                             }
                         }


### PR DESCRIPTION
This PR:
* Adds `extract_params_from_topic_and_path` to dynamically extract parameters by matching `*` positions in the topic, replacing hardcoded parameter positions.
* Updates existing REST endpoints to work with the new `&[&str]` parameter type of `handle_rest_with_parameter`.