### PR TITLE
feat: Add pause/increment functionality to snapshot fetcher

### DIFF
--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -6,6 +6,7 @@
 aggregator-url = "https://aggregator.release-mainnet.api.mithril.network/aggregator"
 genesis-key = "5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"
 download = false
+pause-epoch = -1
 
 [module.upstream-chain-fetcher]
 sync-point = "snapshot"


### PR DESCRIPTION
This PR:
* Adds a `pause-epoch` config option in `omnibus.toml` to allow pausing chain synchronization at a specific epoch. 

While paused users can:
* Press Enter to increment one epoch at a time
* Press c + Enter to continue syncing to tip without further pauses. 

This is useful for debugging and inspecting REST state under historical conditions. 