### PR TITLE
feat: Add protocol parameter REST endpoints with optional historical storage (WIP)

### DIFF
--- a/API/openapi.yaml
+++ b/API/openapi.yaml
@@ -19,6 +19,8 @@ tags:
     description: Endpoints related to DRep state.
   - name: UTxOs
     description: Endpoints related to UTxO state.
+  - name: Epochs
+    description: Endpoints related to epoch activity state.
 
 paths:
   /accounts/{stake_address}:
@@ -40,45 +42,14 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  utxo_value:
-                    type: integer
-                    format: uint64
-                    description: Combined Lovelace amount of all UTXOs
-                  rewards:
-                    type: integer
-                    format: uint64
-                    description: Lovelace amount in reward account
-                  delegated_spo:
-                    type: string
-                    nullable: true
-                    description: Hex-encoded pool id, if any
-                  delegated_drep:
-                    type: object
-                    nullable: true
-                    description: Selected DRep choice, if any
-                    properties:
-                      type:
-                        type: string
-                        enum: ["Key", "Script", "Abstain", "NoConfidence"]
-                        description: Type of DRep delegation
-                      value:
-                        type: string
-                        nullable: true
-                        description: Bech32-encoded DRep KeyHash if applicable; omitted for Abstain/NoConfidence
-                    required:
-                      - type
-                required:
-                  - utxo_value
-                  - rewards
-                example:
-                  utxo_value: 4200000
-                  rewards: 1337000
-                  delegated_spo: "pool1xyzabc..."
-                  delegated_drep:
-                    type: "Key"
-                    value: "drep1abcd..."
+                $ref: '#/components/schemas/AccountState'
+              example:
+                utxo_value: 4200000
+                rewards: 1337000
+                delegated_spo: "pool1xyzabc..."
+                delegated_drep:
+                  type: "Key"
+                  value: "drep1abcd..."
         "400":
           description: Invalid Bech32 stake address
           content:
@@ -140,34 +111,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  abstain:
-                    type: integer
-                    format: uint64
-                    description: Total Lovelace delegated to abstain
-                  no_confidence:
-                    type: integer
-                    format: uint64
-                    description: Total Lovelace delegated to no confidence
-                  dreps:
-                    type: array
-                    description: Array of [bech32_drep_id, delegated_lovelace] pairs
-                    items:
-                      type: array
-                      minItems: 2
-                      maxItems: 2
-                      items:
-                        anyOf:
-                          - type: string
-                            description: Bech32 drep id
-                          - type: integer
-                            format: uint64
-                            description: Delegated Lovelace to this DRep
-                required:
-                  - abstain
-                  - no_confidence
-                  - dreps
+                 $ref: '#/components/schemas/DRepDelegationDistribution'
               example:
                 abstain: 2577998401882324
                 no_confidence: 198933961819408
@@ -193,24 +137,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  reserves:
-                    type: integer
-                    format: uint64
-                    description: Current reserves pot balance in Lovelace
-                  treasury:
-                    type: integer
-                    format: uint64
-                    description: Current treasury pot balance in Lovelace
-                  deposits:
-                    type: integer
-                    format: uint64
-                    description: Current deposits pot balance in Lovelace
-                required:
-                  - reserves
-                  - treasury
-                  - deposits
+                $ref: '#/components/schemas/PotBalances'
               example:
                 reserves: 46635632000000
                 treasury: 98635632000000
@@ -234,10 +161,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
-                  description: Bech32-encoded DRep ID (`drep1...`)
+                $ref: '#/components/schemas/ActiveDReps'
               example:
                 - "drep1un3p8ygx8n5sng0p7s8cya7u5gfn8ducgfury89c9nl57k9wj7e"
                 - "drep_script1un3p8ygx8n5sng0p7s8cya7u5gfn8dccg08hry89c9nl57k9wj7e"
@@ -270,28 +194,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  deposit:
-                    type: integer
-                    format: uint64
-                    description: Lovelace deposit amount associated with the DRep
-                  anchor:
-                    type: object
-                    nullable: true
-                    description: Anchor information associated with the DRep, or null if not provided
-                    properties:
-                      url:
-                        type: string
-                        description: IPFS or HTTP(S) URL containing the anchor data
-                      data_hash:
-                        type: string
-                        description: Hex-encoded hash of the anchor data
-                    required:
-                      - url
-                      - data_hash
-                required:
-                  - deposit
+                $ref: '#/components/schemas/DRepInfo'
               example:
                 deposit: 500000000
                 anchor:
@@ -330,10 +233,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: string
-                  description: Bech32-encoded governance action ID (`gov_action1...`)
+                $ref: '#/components/schemas/ActiveGovernanceActions'
               example:
                 - gov_action1n5sn54mgf47a7men2ryq6ppx88ktq9wvenz2qkl4f9v6ppje8easqxwm88m
                 - gov_action1vrkk4dpuss8l3z9g4uc2rmf8ks0f7j5klvz9v4k85dlc54wa3zsqq68rx0
@@ -445,37 +345,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties:
-                  type: object
-                  properties:
-                    transaction:
-                      type: string
-                      description: Transaction hash of the vote
-                    voting_procedure:
-                      type: object
-                      properties:
-                        vote:
-                          type: string
-                          enum: ["Yes", "No", "Abstain"]
-                          description: The vote cast for this proposal
-                        anchor:
-                          type: object
-                          nullable: true
-                          description: Anchor data with URL and hash, or null if not provided
-                          properties:
-                            url:
-                              type: string
-                              description: URL to additional voting context (IPFS or HTTP(S))
-                            data_hash:
-                              type: string
-                              description: Hex-encoded hash of the anchor data
-                          required:
-                            - url
-                            - data_hash
-                      required:
-                        - vote
-                        - anchor
+                $ref: '#/components/schemas/GovernanceProposal'
               example:
                 drep1xyz789...:
                   transaction: "5cc79d5cbe76e46160ce9611117ab3da9c2a3b37e81bc4b1ee10ab70d6765991"
@@ -510,7 +380,6 @@ paths:
               schema:
                 type: string
                 example: "Internal server error while retrieving proposal votes"
-
   /pools:
     get:
       tags:
@@ -523,35 +392,16 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties:
-                  type: object
-                  properties:
-                    margin:
-                      type: number
-                      format: float
-                      description: Pool margin as a decimal (e.g., 0.03 for 3%)
-                    pledge:
-                      type: integer
-                      format: int64
-                      description: Pledge amount in lovelace
-                    fixed_cost:
-                      type: integer
-                      format: int64
-                      description: Fixed cost in lovelace  
-                  required:
-                    - margin
-                    - pledge
-                    - fixed_cost
-                example:
-                  "pool1xyzabcde1234567890":
-                    margin: 0.03
-                    pledge: 500000000000
-                    fixed_cost: 340000000
-                  "pool1fghijklm9876543210":
-                    margin: 0.05
-                    pledge: 1000000000000
-                    fixed_cost: 400000000
+                $ref: '#/components/schemas/PoolSummaryMap'
+              example:
+                "pool1xyzabcde1234567890":
+                  margin: 0.03
+                  pledge: 500000000000
+                  fixed_cost: 340000000
+                "pool1fghijklm9876543210":
+                  margin: 0.05
+                  pledge: 1000000000000
+                  fixed_cost: 400000000
         "500":
           description: Internal server error
           content:
@@ -578,99 +428,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  vrf_key_hash:
-                    type: string
-                    description: Hex-encoded VRF key hash
-                  pledge:
-                    type: integer
-                    format: uint64
-                    description: Pledge amount in Lovelace
-                  cost:
-                    type: integer
-                    format: uint64
-                    description: Fixed pool cost per epoch in Lovelace
-                  margin:
-                    type: number
-                    format: float
-                    description: Pool margin as a decimal (e.g., 0.03 for 3%)
-                  reward_account:
-                    type: string
-                    description: Bech32-encoded reward stake address
-                  pool_owners:
-                    type: array
-                    description: List of Bech32-encoded pool owner stake addresses
-                    items:
-                      type: string
-                  relays:
-                    type: array
-                    description: List of pool relay information
-                    items:
-                      oneOf:
-                        - type: object
-                          properties:
-                            SingleHostAddr:
-                              type: object
-                              properties:
-                                port:
-                                  type: integer
-                                  description: Optional port number
-                                  nullable: true
-                                ipv4:
-                                  type: string
-                                  description: Optional IPv4 address (formatted as string)
-                                  nullable: true
-                                ipv6:
-                                  type: string
-                                  description: Optional IPv6 address (formatted as string)
-                                  nullable: true
-                        - type: object
-                          properties:
-                            SingleHostName:
-                              type: object
-                              properties:
-                                port:
-                                  type: integer
-                                  description: Optional port number
-                                  nullable: true
-                                dns_name:
-                                  type: string
-                                  description: DNS name of the relay
-                              required:
-                                - dns_name
-                        - type: object
-                          properties:
-                            MultiHostName:
-                              type: object
-                              properties:
-                                dns_name:
-                                  type: string
-                                  description: DNS name of the relay
-                              required:
-                                - dns_name
-                  pool_metadata:
-                    type: object
-                    nullable: true
-                    description: Pool metadata URL and hash
-                    properties:
-                      url:
-                        type: string
-                        description: URL to the pool metadata JSON
-                      hash:
-                        type: string
-                        description: Hex-encoded hash of the pool metadata JSON
-                    required:
-                      - url
-                      - hash
-                required:
-                  - vrf_key_hash
-                  - pledge
-                  - cost
-                  - margin
-                  - reward_account
-                  - pool_owners
-                  - relays
+                $ref: '#/components/schemas/PoolInfo'
               example:
                 vrf_key_hash: "d9223c6cdaace93d896bc383020d4a1e32d5c65103b06fb0d2d3e787e8762858"
                 pledge: 500000000
@@ -729,18 +487,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  address:
-                    type: string
-                    description: Bech32-encoded Cardano address holding the UTxO
-                  value:
-                    type: integer
-                    format: uint64
-                    description: Lovelace amount in the UTxO
-                required:
-                  - address
-                  - value
+                $ref: '#/components/schemas/UTxO'
               example:
                 address: "addr1v8cwarljkvlwmwdegq5s0nkaut58bvrv8u0ugph3243pr9ge9ksyt"
                 value: 2000000    
@@ -765,3 +512,1041 @@ paths:
               schema:
                 type: string
                 example: "Internal server error while retrieving UTxO"
+  /epoch:
+    get:
+      tags:
+        - Epochs
+      summary: Current epoch info
+      description: Returns information about the current epoch including total blocks, fees, and VRF key counts.
+      responses:
+        "200":
+          description: JSON object containing the current epoch and block statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EpochActivity'
+              example:
+                epoch: 312
+                total_blocks: 21556
+                total_fees: 10670212208
+                vrf_vkey_hashes:
+                  - vrf_key_hash: "aba81e764b71006c515986bf7b37a72fbb5554f78e6775f08e384dbd572a4b32"
+                    block_count: 3079
+                  - vrf_key_hash: "63ef48bc5355f3e7973100c371d6a095251c80ceb40559f4750aa7014a6fb6db"
+                    block_count: 3080
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Internal server error while retrieving current epoch"
+  /epoch/parameters:
+    get:
+      tags: 
+        - Epochs
+      summary: Current protocol parameters
+      description: Returns the current protocol parameters by era.
+      responses: 
+        "200":
+          description: JSON object containing protocol parameters and the epoch they were enacted.
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ProtocolParameters'
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Internal server error while retrieving parameters for current epoch"
+  /epochs/{epoch_number}:
+    get:
+      tags:
+        - Epochs
+      summary: Historical epoch info
+      description: Returns information about the specified epoch including total blocks, fees, and VRF key counts.
+      parameters:
+        - name: epoch_number
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: uint64
+          description: The epoch number to query.
+      responses:
+        "200":
+          description: JSON object containing the specified epoch and block statistics.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EpochActivity'
+              example:
+                epoch: 210
+                total_blocks: 21556
+                total_fees: 10670212208
+                vrf_vkey_hashes:
+                  - vrf_key_hash: "aba81e764b71006c515986bf7b37a72fbb5554f78e6775f08e384dbd572a4b32"
+                    block_count: 3079
+                  - vrf_key_hash: "63ef48bc5355f3e7973100c371d6a095251c80ceb40559f4750aa7014a6fb6db"
+                    block_count: 3080
+        "400":
+          description: Invalid epoch number
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Invalid epoch number: -1"
+        "404":
+          description: Epoch not found
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Epoch 724 not found"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Internal server error while retrieving epoch 204"
+        "501":
+          description: Not enabled
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Historical epoch storage not enabled"
+  /epochs/{epoch_number}/parameters:
+    get:
+      tags: 
+        - Epochs
+      summary: Historical protocol parameters
+      description: Returns the protocol active at the specified epoch.
+      parameters:
+        - name: epoch_number
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: uint64
+          description: The epoch number to query.
+      responses: 
+        "200":
+          description: JSON object containing protocol parameters and the epoch they were enacted.
+          content:
+            application/json:
+                schema:
+                  $ref: '#/components/schemas/ProtocolParameters'
+        "400":
+          description: Invalid epoch number
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Invalid epoch number: -1"
+        "500":
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Internal server error while retrieving parameters for epoch 8"
+        "501":
+          description: Not enabled
+          content:
+            application/json:
+              schema:
+                type: string
+                example: "Historical parameter storage not enabled"
+components:
+  schemas:
+    DelegatedDRep:
+      type: object
+      nullable: true
+      description: Selected DRep choice, if any
+      properties:
+        type:
+          type: string
+          enum: ["Key", "Script", "Abstain", "NoConfidence"]
+          description: Type of DRep delegation
+        value:
+          type: string
+          nullable: true
+          description: Bech32-encoded DRep KeyHash if applicable; omitted for Abstain/NoConfidence
+      required:
+        - type
+    AccountState:
+      type: object
+      description: JSON-encoded stake account state
+      properties:
+        utxo_value:
+          type: integer
+          format: uint64
+          description: Combined Lovelace amount of all UTXOs
+        rewards:
+          type: integer
+          format: uint64
+          description: Lovelace amount in reward account
+        delegated_spo:
+          type: string
+          nullable: true
+          description: Hex-encoded pool id, if any
+        delegated_drep:
+          $ref: '#/components/schemas/DelegatedDRep'
+      required:
+        - utxo_value
+        - rewards
+    PoolDelegationDistribution:
+      type: object
+      description: Mapping of Bech32 pool IDs to live delegated stake in Lovelace
+      additionalProperties:
+        type: integer
+        format: uint64
+        description: Total Lovelace delegated to the SPO
+    DRepDelegationDistribution:
+      type: object
+      properties:
+        abstain:
+          type: integer
+          format: uint64
+          description: Total Lovelace delegated to abstain
+        no_confidence:
+          type: integer
+          format: uint64
+          description: Total Lovelace delegated to no confidence
+        dreps:
+          type: array
+          description: Array of [bech32_drep_id, delegated_lovelace] pairs
+          items:
+            type: array
+            minItems: 2
+            maxItems: 2
+            items:
+              anyOf:
+                - type: string
+                  description: Bech32 DRep ID
+                - type: integer
+                  format: uint64
+                  description: Lovelace delegated to the DRep
+      required:
+        - abstain
+        - no_confidence
+        - dreps
+    PotBalances:
+      type: object
+      description: Current treasury, reserve, and deposit pot balances in Lovelace
+      properties:
+        reserves:
+          type: integer
+          format: uint64
+          description: Current reserves pot balance in Lovelace
+        treasury:
+          type: integer
+          format: uint64
+          description: Current treasury pot balance in Lovelace
+        deposits:
+          type: integer
+          format: uint64
+          description: Current deposits pot balance in Lovelace
+      required:
+        - reserves
+        - treasury
+        - deposits
+    ActiveDReps:
+      type: array
+      description: List of Bech32-encoded active DRep IDs
+      items:
+        type: string
+        description: Bech32-encoded DRep ID (`drep1...`)
+    Anchor:
+      type: object
+      description: Anchor information (reference URL and data hash)
+      properties:
+        url:
+          type: string
+          description: IPFS or HTTP(S) URL containing anchor data
+        data_hash:
+          type: string
+          description: Hex-encoded hash of the anchor data
+      required: [url, data_hash]
+    DRepInfo:
+      type: object
+      description: Information about a DRep
+      properties:
+        deposit:
+          type: integer
+          format: uint64
+          description: Lovelace deposit amount associated with the DRep
+        anchor:
+          $ref: '#/components/schemas/Anchor'
+      required:
+        - deposit
+    ActiveGovernanceActions:
+      type: array
+      description: List of Bech32-encoded active governance action IDs
+      items:
+        type: string
+        description: Bech32-encoded governance action ID (`gov_action1...`)
+    GovernanceProposal:
+      type: object
+      description: Detailed information about a specific governance proposal
+      properties:
+        deposit:
+          type: integer
+          format: uint64
+          description: Lovelace deposit amount associated with the proposal
+        reward_account:
+          type: string
+          description: Bech32-encoded stake address of the proposer
+        gov_action_id:
+          type: string
+          description: Bech32-encoded governance action ID (`gov_action1...`)
+        gov_action:
+          type: string
+          description: Governance action type
+        anchor:
+          $ref: '#/components/schemas/Anchor'
+      required:
+        - deposit
+        - reward_account
+        - gov_action_id
+        - gov_action
+        - anchor
+    PoolSummary:
+      type: object
+      description: Summary of a stake pool’s basic financial parameters
+      properties:
+        margin:
+          type: number
+          format: float
+          description: Pool margin as a decimal (e.g., 0.03 for 3%)
+        pledge:
+          type: integer
+          format: int64
+          description: Pledge amount in Lovelace
+        fixed_cost:
+          type: integer
+          format: int64
+          description: Fixed cost in Lovelace
+      required: [margin, pledge, fixed_cost]
+    PoolSummaryMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/PoolSummary'
+      description: Mapping of Bech32 pool IDs to their basic financial information
+    Relay:
+      type: object
+      description: Pool relay information
+      oneOf:
+        - type: object
+          properties:
+            SingleHostAddr:
+              type: object
+              properties:
+                port:
+                  type: integer
+                  nullable: true
+                ipv4:
+                  type: string
+                  nullable: true
+                ipv6:
+                  type: string
+                  nullable: true
+        - type: object
+          properties:
+            SingleHostName:
+              type: object
+              properties:
+                port:
+                  type: integer
+                  nullable: true
+                dns_name:
+                  type: string
+              required: [dns_name]
+        - type: object
+          properties:
+            MultiHostName:
+              type: object
+              properties:
+                dns_name:
+                  type: string
+              required: [dns_name]
+    PoolMetadata:
+      type: object
+      nullable: true
+      properties:
+        url:
+          type: string
+        hash:
+          type: string
+      required: [url, hash]
+    PoolInfo:
+      type: object
+      description: Detailed information about a specific stake pool
+      properties:
+        vrf_key_hash:
+          type: string
+        pledge:
+          type: integer
+          format: uint64
+        cost:
+          type: integer
+          format: uint64
+        margin:
+          type: number
+          format: float
+        reward_account:
+          type: string
+        pool_owners:
+          type: array
+          items:
+            type: string
+        relays:
+          type: array
+          items:
+            $ref: '#/components/schemas/Relay'
+        pool_metadata:
+          $ref: '#/components/schemas/PoolMetadata'
+      required:
+        - vrf_key_hash
+        - pledge
+        - cost
+        - margin
+        - reward_account
+        - pool_owners
+        - relays
+    UTxO:
+      type: object
+      description: Basic UTxO information including address and value.
+      properties:
+        address:
+          type: string
+          description: Bech32-encoded Cardano address holding the UTxO
+        value:
+          type: integer
+          format: uint64
+          description: Lovelace amount in the UTxO
+      required:
+        - address
+        - value
+    VRFKeyCount:
+      type: object
+      description: VRF verification key and block count
+      properties:
+        vrf_key_hash:
+          type: string
+          description: Hex-encoded VRF verification key hash
+        block_count:
+          type: integer
+          description: Number of blocks minted by this VRF key
+      required:
+        - vrf_key_hash
+        - block_count
+    EpochActivity:
+      type: object
+      description: Current or historical epoch statistics
+      properties:
+        epoch:
+          type: integer
+          format: uint64
+          description: Epoch number
+        total_blocks:
+          type: integer
+          description: Total number of blocks in this epoch
+        total_fees:
+          type: integer
+          format: uint64
+          description: Total fees collected in Lovelace
+        vrf_vkey_hashes:
+          type: array
+          description: List of VRF key hashes and their block counts
+          items:
+            $ref: '#/components/schemas/VRFKeyCount'
+      required:
+        - epoch
+        - total_blocks
+        - total_fees
+        - vrf_vkey_hashes
+    ProtocolParameters:
+      type: object
+      description: Protocol parameters along with the epoch they became effective
+      properties:
+        active_epoch:
+          type: integer
+          format: uint64
+          description: Epoch in which these parameters became active
+        params:
+          type: object
+          description: Protocol parameters split by Cardano era
+          properties:
+            byron:
+              type: object
+              description: Protocol parameters from the Byron era
+              nullable: true
+              properties:
+                block_version_data:
+                  type: object
+                  description: Byron era block version parameters defining size limits, fees, and thresholds
+                  properties:
+                    script_version:
+                      type: integer
+                      format: uint16
+                      description: Plutus script version used in the Byron era
+                    heavy_del_thd:
+                      type: integer
+                      format: uint64
+                      description: Heavy delegation threshold
+                    max_block_size:
+                      type: integer
+                      format: uint64
+                      description: Maximum block size
+                    max_header_size:
+                      type: integer
+                      format: uint64
+                      description: Maximum block header size
+                    max_proposal_size:
+                      type: integer
+                      format: uint64
+                      description: Maximum proposal update size
+                    max_tx_size:
+                      type: integer
+                      format: uint64
+                      description: Maximum transaction size
+                    mpc_thd:
+                      type: integer
+                      format: uint64
+                      description: Multi-party computation (MPC) threshold
+                    slot_duration:
+                      type: integer
+                      format: uint64
+                      description: Slot duration
+                    softfork_rule:
+                      type: object
+                      description: Softfork adoption threshold configuration
+                      properties:
+                        init_thd:
+                          type: integer
+                          format: uint64
+                          description: Initial threshold for softfork adoption
+                        min_thd:
+                          type: integer
+                          format: uint64
+                          description: Minimum threshold for softfork adoption
+                        thd_decrement:
+                          type: integer
+                          format: uint64
+                          description: Decrement step for the softfork threshold
+                    tx_fee_policy:
+                      type: object
+                      description: Transaction fee calculation policy
+                      properties:
+                        multiplier:
+                          type: integer
+                          format: uint64
+                          description: Multiplier coefficient in transaction fee calculation
+                        summand:
+                          type: integer
+                          format: uint64
+                          description: Constant summand in transaction fee calculation
+                    unlock_stake_epoch:
+                      type: integer
+                      format: uint64
+                      description: Epoch after which locked stake becomes available
+                    update_implicit:
+                      type: integer
+                      format: uint64
+                      description: Implicit period in slots for update proposals
+                    update_proposal_thd:
+                      type: integer
+                      format: uint64
+                      description: Threshold required to submit an update proposal
+                    update_vote_thd:
+                      type: integer
+                      format: uint64
+                      description: Threshold required to vote on an update proposal
+                fts_seed:
+                  type: string
+                  description: Hex-encoded FTS seed used in Byron consensus
+                protocol_consts:
+                  type: object
+                  description: Byron protocol constants
+                  properties:
+                    k:
+                      type: integer
+                      description: Security parameter k, defining the maximum number of blocks that can be rolled back
+                    protocol_magic:
+                      type: integer
+                      description: Protocol magic number identifying the network
+                    vss_max_ttl:
+                      type: integer
+                      description: Maximum ttl for VSS certificates in epochs
+                      nullable: true
+                    vss_min_ttl:
+                      type: integer
+                      description: Minimum ttl for VSS certificates in epochs
+                      nullable: true
+                start_time:
+                  type: integer
+                  format: uint64
+                  description: Genesis start time (UNIX timestamp)
+            shelley:
+              type: object
+              description: Protocol parameters from the Shelley era
+              nullable: true
+              properties:
+                active_slots_coeff:
+                  type: number
+                  format: float
+                  description: The proportion of slots in which blocks should be issued
+                epoch_length:
+                  type: integer
+                  description: Number of slots in an epoch
+                max_kes_evolutions:
+                  type: integer
+                  description: The maximum number of time a KES key can be evolved before a pool operator must create a new operational certificate
+                max_lovelace_supply:
+                  type: integer
+                  format: uint64
+                  description: The total number of lovelace in the system
+                network_id:
+                  type: string
+                  description: Network identifier string
+                  enum:
+                    - mainnet
+                    - testnet
+                network_magic:
+                  type: integer
+                  description: Network identifier integer
+                protocol_params:
+                  type: object
+                  description: Protocol parameter details for Shelley
+                  properties:
+                    protocol_version:
+                      type: object
+                      description: Protocol version with major and minor numbers
+                      properties:
+                        major:
+                          type: integer
+                          format: uint64
+                          description: Accepted protocol major version
+                        minor:
+                          type: integer
+                          format: uint64
+                          description: Accepted protocol minor version
+                      required:
+                        - major
+                        - minor
+                    max_tx_size:
+                      type: integer
+                      description: Maximum transaction size
+                    max_block_body_size:
+                      type: integer
+                      description: Maximum block body size
+                    max_block_header_size:
+                      type: integer
+                      description: Maximum block header size
+                    key_deposit:
+                      type: integer
+                      format: uint64
+                      description: The amount of a key registration deposit in Lovelaces
+                    min_utxo_value:
+                      type: integer
+                      format: uint64
+                      description: Minimum UTXO value. Use `lovelace_per_utxo_word` for Alonzo and later eras
+                      deprecated: true
+                    minfee_a:
+                      type: integer
+                      description: The linear factor for the minimum fee calculation
+                    minfee_b:
+                      type: integer
+                      description: The constant factor for the minimum fee calculation
+                    pool_deposit:
+                      type: integer
+                      format: uint64
+                      description: The amount of a pool registration deposit in Lovelaces
+                    stake_pool_target_num:
+                      type: integer
+                      description: Desired number of pools, n_opt (k)
+                    min_pool_cost:
+                      type: integer
+                      format: uint64
+                      description: Minimum fixed pool fee
+                    pool_retire_max_epoch:
+                      type: integer
+                      format: uint64
+                      description: Epoch bound on pool retirement
+                    extra_entropy:
+                      type: object
+                      description: Extra entropy nonce used in protocol randomness
+                      properties:
+                        tag:
+                          type: string
+                          enum:
+                            - NeutralNonce
+                            - Nonce
+                          description: Indicates whether the nonce contains additional entropy
+                        hash:
+                          type: string
+                          format: byte
+                          nullable: true
+                          description: Hex-encoded hash associated with the nonce
+                    decentralisation_param:
+                      type: number
+                      format: float
+                      description: Percentage of blocks produced by federated nodes
+                    monetary_expansion:
+                      type: number
+                      format: float
+                      description: Monetary expansion rate (rho)
+                    treasury_cut:
+                      type: number
+                      format: float
+                      description: Fraction of rewards allocated to treasury (tau)
+                    pool_pledge_influence:
+                      type: number
+                      format: float
+                      description: Influence of pool pledge on rewards (a0)
+                security_param:
+                  type: integer
+                  description: Maximum rollback depth in blocks
+                slot_length:
+                  type: integer
+                  description: Duration of a slot in seconds
+                slots_per_kes_period:
+                  type: integer
+                  description: Number of slots per KES period
+                system_start:
+                  type: integer
+                  format: uint64
+                  description: System start timestamp (UNIX)
+                update_quorum:
+                  type: integer
+                  description: Required number of votes for protocol updates
+            alonzo:
+              type: object
+              description: Protocol parameters from the Alonzo era
+              nullable: true
+              properties:
+                lovelace_per_utxo_word:
+                  type: integer
+                  format: uint64
+                  description: Lovelace per UTxO word
+                execution_prices:
+                  type: object
+                  description: Cost per execution unit for Plutus scripts
+                  properties:
+                    mem_price:
+                      type: number
+                      format: float
+                      description: The cost per word of script memory usage
+                    step_price:
+                      type: number
+                      format: float
+                      description: The cost of script execution step usage
+                    max_tx_ex_units:
+                      type: object
+                      description: "Execution unit limits specifying memory and computational steps"
+                      properties:
+                        mem:
+                          type: integer
+                          format: uint64
+                          description: Memory units
+                        steps:
+                          type: integer
+                          format: uint64
+                          description: Computation steps
+                      required:
+                        - mem
+                        - steps
+                    max_block_ex_units:
+                      type: object
+                      description: "Execution unit limits specifying memory and computational steps"
+                      properties:
+                        mem:
+                          type: integer
+                          format: uint64
+                          description: Memory units
+                        steps:
+                          type: integer
+                          format: uint64
+                          description: Computation steps
+                      required:
+                        - mem
+                        - steps
+                max_value_size:
+                  type: integer
+                  description: Maximum size of a transaction output Value, including Lovelaces and all multi-assets
+                collateral_percentage:
+                  type: integer
+                  description: The percentage of the transactions fee which must be provided as collateral when including non-native scripts
+                max_collateral_inputs:
+                  type: integer
+                  description: The maximum number of collateral inputs allowed in a transaction
+                plutus_v1_cost_model:
+                  type: array
+                  description: Cost model coefficients for Plutus V1 scripts, in canonical order
+                  nullable: true
+                  items:
+                    type: integer
+                    format: int64
+                plutus_v2_cost_model:
+                  type: array
+                  description: Cost model coefficients for Plutus V2 scripts, in canonical order
+                  nullable: true
+                  items:
+                    type: integer
+                    format: int64
+            conway:
+              type: object
+              description: Protocol parameters from the Conway era
+              nullable: true
+              properties:
+                pool_voting_thresholds:
+                  type: object
+                  description: Pool voting thresholds for governance actions
+                  properties:
+                    motion_no_confidence:
+                      type: number
+                      format: float
+                      description: Pool voting threshold for motion of no-confidence
+                    committee_normal:
+                      type: number
+                      format: float
+                      description: Pool voting threshold for new committee/threshold (normal state)
+                    committee_no_confidence:
+                      type: number
+                      format: float
+                      description: Pool voting threshold for new committee/threshold (state of no-confidence)
+                    hard_fork_initiation:
+                      type: number
+                      format: float
+                      description: Pool voting threshold for hard-fork initiation
+                    security_voting_threshold:
+                      type: number
+                      format: float
+                      description: Pool voting threshold for security-related governance votes
+                d_rep_voting_thresholds:
+                  type: object
+                  description: DRep voting thresholds for governance actions
+                  properties:
+                    motion_no_confidence:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for motion of no-confidence
+                    committee_normal:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for new committee/threshold (normal state)
+                    committee_no_confidence:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for new committee/threshold (state of no-confidence)
+                    update_constitution:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for updating on-chain constitution
+                    hard_fork_initiation:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for hardfork initiation
+                    pp_network_group:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for updating network protocol parameters
+                    pp_economic_group:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for updating economic protocol parameters
+                    pp_technical_group:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for updating technical protocol parameters
+                    pp_governance_group:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for updating governance protocol parameters
+                    treasury_withdrawal:
+                      type: number
+                      format: float
+                      description: DRep voting threshold for approving treasury withdrawals
+                committee_min_size:
+                  type: integer
+                  format: uint64
+                  description: Minimum constitutional committee size
+                committee_max_term_length:
+                  type: integer
+                  description: Maximum constitutional committee term length in epochs
+                gov_action_lifetime:
+                  type: integer
+                  description: Number of epochs a governance action remains active
+                gov_action_deposit:
+                  type: integer
+                  format: uint64
+                  description: Deposit required to propose a governance action in Lovelaces
+                d_rep_deposit:
+                  type: integer
+                  format: uint64
+                  description: Deposit required to register as a DRep in Lovelaces
+                d_rep_activity:
+                  type: integer
+                  description: Number of epochs before an inactive DRep is no longer counted toward active voting stake
+                min_fee_ref_script_cost_per_byte:
+                  type: number
+                  format: float
+                  description: Minimum fee for reference script storage
+                plutus_v3_cost_model:
+                  type: array
+                  description: Cost model coefficients for Plutus V3 scripts, in canonical order
+                  nullable: true
+                  items:
+                    type: integer
+                    format: int64
+                constitution:
+                  type: object
+                  description: Current constitution reference and optional guardrail script
+                  properties:
+                    anchor:
+                      $ref: '#/components/schemas/Anchor'
+                    guardrail_script:
+                      type: string
+                      description: Hex-encoded Plutus script hash that enforces guardrails on governance actions
+                      nullable: true
+                committee:
+                  type: object
+                  description: Current constitutional committee members and voting threshold as defined in CIP-1694.
+                  properties:
+                    members:
+                      type: object
+                      description: Mapping of constitutional committee member identifiers to their voting power
+                      additionalProperties:
+                        type: integer
+                        format: uint64
+                    threshold:
+                      type: number
+                      format: float
+                      description: Constitutional committee voting threshold for governance actions
+      example:
+        active_epoch: 541
+        params:
+          byron:
+            block_version_data:
+              script_version: 0
+              heavy_del_thd: 300000000000
+              max_block_size: 2000000
+              max_header_size: 2000000
+              max_proposal_size: 700
+              max_tx_size: 4096
+              mpc_thd: 20000000000000
+              slot_duration: 20000
+              softfork_rule:
+                init_thd: 900000000000000
+                min_thd: 600000000000000
+                thd_decrement: 50000000000000
+              tx_fee_policy:
+                multiplier: 43946000000
+                summand: 155381000000000
+              unlock_stake_epoch: 18446744073709551615
+              update_implicit: 10000
+              update_proposal_thd: 100000000000000
+              update_vote_thd: 1000000000000
+            fts_seed: "76617361206f7061736120736b6f766f726f64612047677572646120626f726f64612070726f766f6461"
+            protocol_consts:
+              k: 2160
+              protocol_magic: 764824073
+              vss_max_ttl: 6
+              vss_min_ttl: 2
+            start_time: 1506203091
+          shelley:
+            active_slots_coeff: 0.05
+            epoch_length: 432000
+            max_kes_evolutions: 62
+            max_lovelace_supply: 45000000000000000
+            network_id: "mainnet"
+            network_magic: 764824073
+            protocol_params:
+              protocol_version:
+                minor: 0
+                major: 2
+              max_tx_size: 16384
+              max_block_body_size: 65536
+              max_block_header_size: 1100
+              key_deposit: 2000000
+              min_utxo_value: 1000000
+              minfee_a: 44
+              minfee_b: 155381
+              pool_deposit: 500000000
+              stake_pool_target_num: 150
+              min_pool_cost: 340000000
+              pool_retire_max_epoch: 18
+              extra_entropy:
+                tag: "NeutralNonce"
+                hash: null
+              decentralisation_param: 1.0
+              monetary_expansion: 0.003000000026077032
+              treasury_cut: 0.20000000298023224
+              pool_pledge_influence: 0.30000001192092896
+            security_param: 2160
+            slot_length: 1
+            slots_per_kes_period: 129600
+            system_start: 1506203091
+            update_quorum: 5
+          alonzo:
+            lovelace_per_utxo_word: 34482
+            execution_prices:
+              mem_price: 0.0577
+              step_price: 0.0000721
+            max_tx_ex_units:
+              mem: 10000000
+              steps: 10000000000
+            max_block_ex_units:
+              mem: 50000000
+              steps: 40000000000
+            max_value_size: 5000
+            collateral_percentage: 150
+            max_collateral_inputs: 3
+            plutus_v1_cost_model: [0, 82363, 29773, 32, 100, 150000, 148000, 2477736, 497, 100, 150000, 248, 1, 32, 100, 100, 425507, 247, 150000, 112536, 4, 32, 1, 29773, 150000, 179690, 1, 32, 0, 425507, 150000, 150000, 32, 150000, 32, 0, 1000, 4, 150000, 145276, 197209, 1, 1, 2477736, 32, 150000, 148000, 1, 29773, 8, 100, 0, 150000, 29773, 0, 1000, 32, 103599, 150000, 0, 248, 425507, 150000, 150000, 0, 118, 4, 1, 1, 32, 100, 32, 150000, 150000, 1, 1, 150000, 0, 4, 148000, 1000, 32, 1, 150000, 0, 150000, 1, 29175, 1326, 3345831, 150000, 150000, 29773, 150000, 150000, 1, 118, 32, 1, 1000, 1, 1, 32, 1, 148000, 150000, 136542, 1, 1, 103599, 32, 1, 1000, 1, 0, 0, 1, 150000, 150000, 8, 150000, 150000, 150000, 1366, 32, 150000, 150000, 32, 0, 10000, 32, 29175, 32, 1, 1, 1, 197209, 32, 118, 621, 1, 0, 1, 11218, 100, 396231, 1000, 61516, 100, 1, 5000, 425507, 1, 150000, 32, 29773, 118, 32, 32, 150000, 29773, 100, 0, 150000, 32, 1]
+            plutus_v2_cost_model: null
+          conway:
+            pool_voting_thresholds:
+              motion_no_confidence: 0.51
+              committee_normal: 0.51
+              committee_no_confidence: 0.51
+              hard_fork_initiation: 0.51
+              security_voting_threshold: 0.51
+            d_rep_voting_thresholds:
+              motion_no_confidence: 0.67
+              committee_normal: 0.67
+              committee_no_confidence: 0.67
+              update_constitution: 0.75
+              hard_fork_initiation: 0.6
+              pp_network_group: 0.67
+              pp_economic_group: 0.67
+              pp_technical_group: 0.67
+              pp_governance_group: 0.75
+              treasury_withdrawal: 0.67
+            committee_min_size: 7
+            committee_max_term_length: 146
+            gov_action_lifetime: 6
+            gov_action_deposit: 100000000000
+            d_rep_deposit: 500000000
+            d_rep_activity: 20
+            min_fee_ref_script_cost_per_byte: 15.0
+            plutus_v3_cost_model: [100788, 420, 1, 1, 1000, 173, 0, 1, 1000, 59957, 4, 1, 11183, 32, 201305, 8356, 4, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 16000, 100, 100, 100, 16000, 100, 94375, 32, 132994, 32, 61462, 4, 72010, 178, 0, 1, 22151, 32, 91189, 769, 4, 2, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1, 1, 1000, 42921, 4, 2, 24548, 29498, 38, 1, 898148, 27279, 1, 51775, 558, 1, 39184, 1000, 60594, 1, 141895, 32, 83150, 32, 15299, 32, 76049, 1, 13169, 4, 22100, 10, 28999, 74, 1, 28999, 74, 1, 43285, 552, 1, 44749, 541, 1, 33852, 32, 68246, 32, 72362, 32, 7243, 32, 7391, 32, 11546, 32, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1, 90434, 519, 0, 1, 74433, 32, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1, 1, 85848, 123203, 7305, -900, 1716, 549, 57, 85848, 0, 1, 955506, 213312, 0, 2, 270652, 22588, 4, 1457325, 64566, 4, 20467, 1, 4, 0, 141992, 32, 100788, 420, 1, 1, 81663, 32, 59498, 32, 20142, 32, 24588, 32, 20744, 32, 25933, 32, 24623, 32, 43053543, 10, 53384111, 14333, 10, 43574283, 26308, 10, 16000, 100, 16000, 100, 962335, 18, 2780678, 6, 442008, 1, 52538055, 3756, 18, 267929, 18, 76433006, 8868, 18, 52948122, 18, 1995836, 36, 3227919, 12, 901022, 1, 166917843, 4307, 36, 284546, 36, 158221314, 26549, 36, 74698472, 36, 333849714, 1, 254006273, 72, 2174038, 72, 2261318, 64571, 4, 207616, 8310, 4, 1293828, 28716, 63, 0, 1, 1006041, 43623, 251, 0, 1, 100181, 726, 719, 0, 1, 100181, 726, 719, 0, 1, 100181, 726, 719, 0, 1, 107878, 680, 0, 1, 95336, 1, 281145, 18848, 0, 1, 180194, 159, 1, 1, 158519, 8942, 0, 1, 159378, 8813, 0, 1, 107490, 3298, 1, 106057, 655, 1, 1964219, 24520, 3]
+            constitution:
+                anchor:
+                  url: "ipfs://bafkreiazhhawe7sjwuthcfgl3mmv2swec7sukvclu3oli7qdyz4uhhuvmy"
+                  data_hash: "2a61e2f4b63442978140c77a70daab3961b22b12b63b13949a390c097214d1c5"
+                guardrail_script: "fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64"
+            committee:
+              members:
+                scriptHash-84aebcfd3e00d0f87af918fc4b5e00135f407e379893df7e7d392c6a: 580
+                scriptHash-f0dc2c00d92a45521267be2d5de1c485f6f9d14466d7e16062897cf7: 580
+                scriptHash-df0e83bde65416dade5b1f97e7f115cc1ff999550ad968850783fe50: 580
+                scriptHash-e8165b3328027ee0d74b1f07298cb092fd99aa7697a1436f5997f625: 580
+                scriptHash-b6012034ba0a7e4afbbf2c7a1432f8824aee5299a48e38e41a952686: 580
+                scriptHash-ce8b37a72b178a37bbd3236daa7b2c158c9d3604e7aa667e6c6004b7: 580
+                scriptHash-349e55f83e9af24813e6cb368df6a80d38951b2a334dfcdf26815558: 580
+              threshold: 0.6666666666666666

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,7 @@ dependencies = [
  "lf-queue",
  "minicbor 0.26.5",
  "num-rational",
+ "num-traits",
  "serde",
  "serde_json",
  "serde_with 3.14.0",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -31,7 +31,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
 futures = "0.3.31"
 minicbor = { version = "0.26.0", features = ["std", "half", "derive"] }
-
+num-traits = "0.2"
 
 [lib]
 crate-type = ["rlib"]

--- a/common/src/rest_helper.rs
+++ b/common/src/rest_helper.rs
@@ -1,9 +1,10 @@
 //! Helper functions for REST handlers
 
 use crate::messages::{Message, RESTResponse};
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use caryatid_sdk::Context;
 use futures::future::Future;
+use num_traits::ToPrimitive;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tracing::{error, info};
@@ -105,4 +106,14 @@ fn extract_params_from_topic_and_path(topic: &str, path_elements: &[String]) -> 
         .iter()
         .filter_map(|&pos| pos.checked_sub(offset).and_then(|idx| path_elements.get(idx)).cloned())
         .collect()
+}
+
+pub trait ToCheckedF64 {
+    fn to_checked_f64(&self, name: &str) -> Result<f64>;
+}
+
+impl<T: ToPrimitive> ToCheckedF64 for T {
+    fn to_checked_f64(&self, name: &str) -> Result<f64> {
+        self.to_f64().ok_or_else(|| anyhow!("Failed to convert {name} to f64"))
+    }
 }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -772,20 +772,20 @@ pub struct DRepVotingThresholds {
     pub treasury_withdrawal: RationalNumber,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct SoftForkRule {
     pub init_thd: u64,
     pub min_thd: u64,
     pub thd_decrement: u64,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct TxFeePolicy {
     pub multiplier: u64,
     pub summand: u64,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct BlockVersionData {
     pub script_version: u16,
     pub heavy_del_thd: u64,
@@ -805,7 +805,7 @@ pub struct BlockVersionData {
     pub update_vote_thd: u64,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ProtocolConsts {
     pub k: usize,
     pub protocol_magic: u32,
@@ -813,25 +813,25 @@ pub struct ProtocolConsts {
     pub vss_min_ttl: Option<u32>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ProtocolVersion {
     pub minor: u64,
     pub major: u64,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub enum NonceVariant {
     NeutralNonce,
     Nonce,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct Nonce {
     pub tag: NonceVariant,
     pub hash: Option<Vec<u8>>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ShelleyProtocolParams {
     pub protocol_version: ProtocolVersion,
     pub max_tx_size: u32,
@@ -863,7 +863,7 @@ pub struct ShelleyProtocolParams {
     pub pool_pledge_influence: RationalNumber,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct AlonzoParams {
     pub lovelace_per_utxo_word: u64,
     pub execution_prices: ExUnitPrices,
@@ -876,7 +876,7 @@ pub struct AlonzoParams {
     pub plutus_v2_cost_model: Option<CostModel>,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ByronParams {
     pub block_version_data: BlockVersionData,
     pub fts_seed: Option<Vec<u8>>,
@@ -884,13 +884,14 @@ pub struct ByronParams {
     pub start_time: u64,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
 pub enum NetworkId {
     Testnet,
     Mainnet,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ShelleyParams {
     pub active_slots_coeff: f32,
     pub epoch_length: u32,
@@ -906,7 +907,7 @@ pub struct ShelleyParams {
     pub update_quorum: u32,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ConwayParams {
     pub pool_voting_thresholds: PoolVotingThresholds,
     pub d_rep_voting_thresholds: DRepVotingThresholds,
@@ -922,7 +923,7 @@ pub struct ConwayParams {
     pub committee: Committee,
 }
 
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct ProtocolParams {
     pub alonzo: Option<AlonzoParams>,
     pub byron: Option<ByronParams>,
@@ -1036,14 +1037,14 @@ pub struct ProtocolParamUpdate {
     pub minfee_refscript_cost_per_byte: Option<RationalNumber>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, PartialEq, Deserialize, Debug, Clone)]
 pub struct Constitution {
     pub anchor: Anchor,
     pub guardrail_script: Option<ScriptHash>,
 }
 
 #[serde_as]
-#[derive(Serialize, Debug, Deserialize, Clone)]
+#[derive(Serialize, PartialEq, Debug, Deserialize, Clone)]
 pub struct Committee {
     #[serde_as(as = "Vec<(_, _)>")]
     pub members: HashMap<CommitteeCredential, u64>,

--- a/modules/parameters_state/src/parameters_state.rs
+++ b/modules/parameters_state/src/parameters_state.rs
@@ -2,7 +2,8 @@
 //! Accepts certificate events and derives the Governance State in memory
 
 use acropolis_common::{
-    messages::{CardanoMessage, Message, ProtocolParamsMessage, RESTResponse},
+    messages::{CardanoMessage, Message, ProtocolParamsMessage},
+    rest_helper::{handle_rest, handle_rest_with_parameter},
     BlockInfo,
 };
 use anyhow::Result;
@@ -14,16 +15,26 @@ use tracing::{error, info};
 
 mod genesis_params;
 mod parameters_updater;
+mod rest;
 mod state;
 
 use parameters_updater::ParametersUpdater;
+use rest::handle_current;
 use state::State;
 
+use crate::rest::handle_historical;
+
 const DEFAULT_ENACT_STATE_TOPIC: (&str, &str) = ("enact-state-topic", "cardano.enact.state");
-const DEFAULT_HANDLE_TOPIC: (&str, &str) = ("handle-topic", "rest.get.parameters-state.*");
+const DEFAULT_HANDLE_CURRENT_TOPIC: (&str, &str) =
+    ("handle-current-params-topic", "rest.get.epoch.parameters");
+const DEFAULT_HANDLE_HISTORICAL_TOPIC: (&str, &str) = (
+    "handle-historical-params-topic",
+    "rest.get.epochs.*.parameters",
+);
 const DEFAULT_PROTOCOL_PARAMETERS_TOPIC: (&str, &str) =
     ("publish-parameters-topic", "cardano.protocol.parameters");
 const DEFAULT_NETWORK_NAME: (&str, &str) = ("network-name", "mainnet");
+const DEFAULT_STORE_HISTORY: (&str, bool) = ("store-history", false);
 
 /// Parameters State module
 #[module(
@@ -37,8 +48,10 @@ struct ParametersStateConfig {
     pub context: Arc<Context<Message>>,
     pub network_name: String,
     pub enact_state_topic: String,
-    pub handle_topic: String,
+    pub handle_current_topic: String,
+    pub handle_historical_topic: String,
     pub protocol_parameters_topic: String,
+    pub store_history: bool,
 }
 
 impl ParametersStateConfig {
@@ -48,13 +61,21 @@ impl ParametersStateConfig {
         actual
     }
 
+    fn conf_bool(config: &Arc<Config>, keydef: (&str, bool)) -> bool {
+        let actual = config.get_bool(keydef.0).unwrap_or(keydef.1);
+        info!("Parameter value '{}' for {}", actual, keydef.0);
+        actual
+    }
+
     pub fn new(context: Arc<Context<Message>>, config: &Arc<Config>) -> Arc<Self> {
         Arc::new(Self {
             context,
             network_name: Self::conf(config, DEFAULT_NETWORK_NAME),
             enact_state_topic: Self::conf(config, DEFAULT_ENACT_STATE_TOPIC),
-            handle_topic: Self::conf(config, DEFAULT_HANDLE_TOPIC),
+            handle_current_topic: Self::conf(config, DEFAULT_HANDLE_CURRENT_TOPIC),
+            handle_historical_topic: Self::conf(config, DEFAULT_HANDLE_HISTORICAL_TOPIC),
             protocol_parameters_topic: Self::conf(config, DEFAULT_PROTOCOL_PARAMETERS_TOPIC),
+            store_history: Self::conf_bool(config, DEFAULT_STORE_HISTORY),
         })
     }
 }
@@ -84,40 +105,9 @@ impl ParametersState {
 
     async fn run(
         config: Arc<ParametersStateConfig>,
+        state: Arc<Mutex<State>>,
         mut enact_s: Box<dyn Subscription<Message>>,
     ) -> Result<()> {
-        let state = Arc::new(Mutex::new(State::new(config.network_name.clone())));
-        let state_handle = state.clone();
-
-        config.context.handle(&config.handle_topic, move |message: Arc<Message>| {
-            let _state = state_handle.clone();
-            async move {
-                let response = match message.as_ref() {
-                    Message::RESTRequest(request) => {
-                        info!("REST received {} {}", request.method, request.path);
-                        RESTResponse::with_text(200, "Ok")
-                        /*
-                        let lock = state.lock().await;
-
-                        match perform_rest_request(&lock, &request.path) {
-                            Ok(response) => RESTResponse::with_text(200, &response),
-                            Err(error) => {
-                                error!("Governance State REST request error: {error:?}");
-                                RESTResponse::with_text(400, &format!("{error:?}"))
-                            }
-                        }
-                        */
-                    }
-                    _ => {
-                        error!("Unexpected message type: {message:?}");
-                        RESTResponse::with_text(500, &format!("Unexpected message type"))
-                    }
-                };
-
-                Arc::new(Message::RESTResponse(response))
-            }
-        });
-
         loop {
             match enact_s.read().await?.1.as_ref() {
                 Message::Cardano((block, CardanoMessage::GovernanceOutcomes(gov))) => {
@@ -133,10 +123,26 @@ impl ParametersState {
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         let cfg = ParametersStateConfig::new(context.clone(), &config);
         let enact = cfg.context.subscribe(&cfg.enact_state_topic).await?;
+        let state = Arc::new(Mutex::new(State::new(
+            cfg.network_name.clone(),
+            cfg.store_history,
+        )));
+
+        let state_handle_current = state.clone();
+        handle_rest(cfg.context.clone(), &cfg.handle_current_topic, move || {
+            handle_current(state_handle_current.clone())
+        });
+
+        let state_handle_historical = state.clone();
+        handle_rest_with_parameter(
+            cfg.context.clone(),
+            &cfg.handle_historical_topic,
+            move |param| handle_historical(state_handle_historical.clone(), param[0].to_string()),
+        );
 
         // Start run task
         tokio::spawn(async move {
-            Self::run(cfg, enact).await.unwrap_or_else(|e| error!("Failed: {e}"));
+            Self::run(cfg, state, enact).await.unwrap_or_else(|e| error!("Failed: {e}"));
         });
 
         Ok(())

--- a/modules/parameters_state/src/rest.rs
+++ b/modules/parameters_state/src/rest.rs
@@ -1,0 +1,466 @@
+//! REST handlers for Acropolis Parameters State module
+use crate::state::State;
+use acropolis_common::{
+    messages::RESTResponse, rest_helper::ToCheckedF64, AlonzoParams, Anchor, BlockVersionData,
+    ByronParams, Committee, Constitution, ConwayParams, DRepVotingThresholds, ExUnitPrices,
+    ExUnits, NetworkId, Nonce, PoolVotingThresholds, ProtocolConsts, ProtocolParams,
+    ProtocolVersion, ShelleyParams, ShelleyProtocolParams,
+};
+use anyhow::Result;
+use pallas::ledger::primitives::CostModel;
+use serde::Serialize;
+use std::{collections::HashMap, sync::Arc};
+use tokio::sync::Mutex;
+
+/// REST response structure for protocol parameters
+#[derive(Serialize)]
+pub struct ProtocolParametersRest {
+    /// Epoch these parameters became effective
+    pub active_epoch: u64,
+
+    /// Protocol parameters grouped by era.
+    pub params: EraParametersRest,
+}
+
+#[derive(Serialize)]
+pub struct EraParametersRest {
+    pub byron: Option<ByronParamsRest>,
+    pub shelley: Option<ShelleyParamsRest>,
+    pub alonzo: Option<AlonzoParamsRest>,
+    pub conway: Option<ConwayParamsRest>,
+}
+
+#[derive(Serialize)]
+pub struct ByronParamsRest {
+    pub block_version_data: BlockVersionData,
+    /// fts_seed hex encoded
+    pub fts_seed: String,
+    pub protocol_consts: ProtocolConsts,
+    pub start_time: u64,
+}
+
+#[derive(Serialize)]
+pub struct ShelleyParamsRest {
+    pub active_slots_coeff: f32,
+    pub epoch_length: u32,
+    pub max_kes_evolutions: u32,
+    pub max_lovelace_supply: u64,
+    pub network_id: NetworkId,
+    pub network_magic: u32,
+    /// uses ShelleyProtocolParamsRest
+    pub protocol_params: ShelleyProtocolParamsRest,
+    pub security_param: u32,
+    pub slot_length: u32,
+    pub slots_per_kes_period: u32,
+    /// UNIX timestamp
+    pub system_start: u64,
+    pub update_quorum: u32,
+}
+
+#[derive(Serialize)]
+pub struct ShelleyProtocolParamsRest {
+    pub protocol_version: ProtocolVersion,
+    pub max_tx_size: u32,
+    pub max_block_body_size: u32,
+    pub max_block_header_size: u32,
+    pub key_deposit: u64,
+    pub min_utxo_value: u64,
+
+    pub minfee_a: u32,
+    pub minfee_b: u32,
+    pub pool_deposit: u64,
+
+    pub stake_pool_target_num: u32,
+    pub min_pool_cost: u64,
+
+    pub pool_retire_max_epoch: u64,
+    pub extra_entropy: Nonce,
+    /// decentralisation_param as float
+    pub decentralisation_param: f64,
+
+    /// monetary_expansion as float
+    pub monetary_expansion: f64,
+
+    /// treasury_cut as float
+    pub treasury_cut: f64,
+
+    /// pool_pledge_influence as float
+    pub pool_pledge_influence: f64,
+}
+
+#[derive(Serialize)]
+pub struct AlonzoParamsRest {
+    pub lovelace_per_utxo_word: u64,
+    /// uses ExUnitPricesRest
+    pub execution_prices: ExUnitPricesRest,
+    pub max_tx_ex_units: ExUnits,
+    pub max_block_ex_units: ExUnits,
+    pub max_value_size: u32,
+    pub collateral_percentage: u32,
+    pub max_collateral_inputs: u32,
+    pub plutus_v1_cost_model: Option<CostModel>,
+    pub plutus_v2_cost_model: Option<CostModel>,
+}
+
+#[derive(Serialize)]
+pub struct ExUnitPricesRest {
+    /// mem_price as float
+    pub mem_price: f64,
+    /// step_price as float
+    pub step_price: f64,
+}
+
+#[derive(Serialize)]
+pub struct ConwayParamsRest {
+    /// Uses PoolVotingThresholdsRest
+    pub pool_voting_thresholds: PoolVotingThresholdsRest,
+    /// Uses DRepVotingThresholdsRest
+    pub d_rep_voting_thresholds: DRepVotingThresholdsRest,
+    pub committee_min_size: u64,
+    pub committee_max_term_length: u32,
+    pub gov_action_lifetime: u32,
+    pub gov_action_deposit: u64,
+    pub d_rep_deposit: u64,
+    pub d_rep_activity: u32,
+    /// min_fee_ref_script_cost_per_byte as float
+    pub min_fee_ref_script_cost_per_byte: f64,
+    pub plutus_v3_cost_model: CostModel,
+    /// Uses ConstitutionRest
+    pub constitution: ConstitutionRest,
+    /// Uses CommitteeRest
+    pub committee: CommitteeRest,
+}
+
+#[derive(serde::Serialize)]
+pub struct PoolVotingThresholdsRest {
+    // All fields as float
+    pub motion_no_confidence: f64,
+    pub committee_normal: f64,
+    pub committee_no_confidence: f64,
+    pub hard_fork_initiation: f64,
+    pub security_voting_threshold: f64,
+}
+
+#[derive(serde::Serialize)]
+pub struct DRepVotingThresholdsRest {
+    // All fields as float
+    pub motion_no_confidence: f64,
+    pub committee_normal: f64,
+    pub committee_no_confidence: f64,
+    pub update_constitution: f64,
+    pub hard_fork_initiation: f64,
+    pub pp_network_group: f64,
+    pub pp_economic_group: f64,
+    pub pp_technical_group: f64,
+    pub pp_governance_group: f64,
+    pub treasury_withdrawal: f64,
+}
+
+#[derive(serde::Serialize)]
+pub struct ConstitutionRest {
+    pub anchor: Anchor,
+    /// guardrail_script hex encoded
+    pub guardrail_script: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+pub struct CommitteeRest {
+    /// members key expresses as string
+    pub members: HashMap<String, u64>,
+    /// threshold as float
+    pub threshold: f64,
+}
+
+/// REST handler for /epoch/parameters — returns current live protocol parameters
+pub async fn handle_current(state: Arc<Mutex<State>>) -> Result<RESTResponse> {
+    let lock = state.lock().await;
+    let params = lock.current_params.get_params();
+    let active_epoch = lock.active_epoch;
+
+    let response = match ProtocolParametersRest::try_from((&active_epoch, &params)) {
+        Ok(r) => r,
+        Err(e) => {
+            return Ok(RESTResponse::with_text(
+                500,
+                &format!(
+                    "Internal server error while retrieving parameters for current epoch: {e}"
+                ),
+            ))
+        }
+    };
+
+    let json = match serde_json::to_string(&response) {
+        Ok(j) => j,
+        Err(e) => {
+            return Ok(RESTResponse::with_text(
+                500,
+                &format!(
+                    "Internal server error while retrieving parameters for current epoch: {e}"
+                ),
+            ))
+        }
+    };
+
+    Ok(RESTResponse::with_json(200, &json))
+}
+
+/// REST handler for /epochs/{epoch_number}/parameters — returns parameters for the closest prior epoch
+pub async fn handle_historical(state: Arc<Mutex<State>>, epoch: String) -> Result<RESTResponse> {
+    let parsed_epoch = match epoch.parse::<u64>() {
+        Ok(v) => v,
+        Err(_) => {
+            return Ok(RESTResponse::with_text(
+                400,
+                &format!("Invalid epoch number: {epoch}"),
+            ));
+        }
+    };
+
+    let lock = state.lock().await;
+
+    match &lock.parameter_history {
+        Some(history) => match history.range(..=parsed_epoch).next_back() {
+            Some((epoch_found, msg)) => match ProtocolParametersRest::try_from((epoch_found, &msg.params)) {
+                Ok(response) => match serde_json::to_string(&response) {
+                    Ok(json) => Ok(RESTResponse::with_json(200, &json)),
+                    Err(e) => Ok(RESTResponse::with_text(
+                        500,
+                        &format!("Internal server error while serializing parameters for epoch {epoch_found}: {e}"),
+                    )),
+                },
+                Err(e) => Ok(RESTResponse::with_text(
+                    500,
+                    &format!("Internal server error while converting parameters for epoch {epoch_found}: {e}"),
+                )),
+            },
+            None => Ok(RESTResponse::with_text(404, "Epoch not found")),
+        },
+        None => Ok(RESTResponse::with_text(
+            501,
+            "Parameter history not enabled",
+        )),
+    }
+}
+
+/// ProtocolParametersRest helper functions
+impl TryFrom<(&u64, &ProtocolParams)> for ProtocolParametersRest {
+    type Error = anyhow::Error;
+
+    fn try_from((epoch, params): (&u64, &ProtocolParams)) -> Result<Self> {
+        Ok(Self {
+            active_epoch: *epoch,
+            params: EraParametersRest::try_from(params)?,
+        })
+    }
+}
+
+impl TryFrom<&ProtocolParams> for EraParametersRest {
+    type Error = anyhow::Error;
+
+    fn try_from(params: &ProtocolParams) -> Result<Self> {
+        Ok(Self {
+            byron: params.byron.as_ref().map(ByronParamsRest::from),
+            shelley: match &params.shelley {
+                Some(shelley) => Some(ShelleyParamsRest::try_from(shelley)?),
+                None => None,
+            },
+            alonzo: match &params.alonzo {
+                Some(alonzo) => Some(AlonzoParamsRest::try_from(alonzo)?),
+                None => None,
+            },
+            conway: match &params.conway {
+                Some(conway) => Some(ConwayParamsRest::try_from(conway)?),
+                None => None,
+            },
+        })
+    }
+}
+
+/// Conversions from stored objects to REST objects
+impl From<&ByronParams> for ByronParamsRest {
+    fn from(params: &ByronParams) -> Self {
+        Self {
+            block_version_data: params.block_version_data.clone(),
+            fts_seed: hex::encode(params.fts_seed.as_ref().unwrap_or(&vec![])),
+            protocol_consts: params.protocol_consts.clone(),
+            start_time: params.start_time,
+        }
+    }
+}
+
+impl TryFrom<&ShelleyParams> for ShelleyParamsRest {
+    type Error = anyhow::Error;
+
+    fn try_from(params: &ShelleyParams) -> Result<Self> {
+        Ok(Self {
+            active_slots_coeff: params.active_slots_coeff,
+            epoch_length: params.epoch_length,
+            max_kes_evolutions: params.max_kes_evolutions,
+            max_lovelace_supply: params.max_lovelace_supply,
+            network_id: params.network_id.clone(),
+            network_magic: params.network_magic,
+            protocol_params: (&params.protocol_params).try_into()?,
+            security_param: params.security_param,
+            slot_length: params.slot_length,
+            slots_per_kes_period: params.slots_per_kes_period,
+            system_start: params.system_start.timestamp() as u64,
+            update_quorum: params.update_quorum,
+        })
+    }
+}
+
+impl TryFrom<&ShelleyProtocolParams> for ShelleyProtocolParamsRest {
+    type Error = anyhow::Error;
+
+    fn try_from(params: &ShelleyProtocolParams) -> Result<Self> {
+        Ok(Self {
+            protocol_version: params.protocol_version.clone(),
+            max_tx_size: params.max_tx_size,
+            max_block_body_size: params.max_block_body_size,
+            max_block_header_size: params.max_block_header_size,
+            key_deposit: params.key_deposit,
+            min_utxo_value: params.min_utxo_value,
+            minfee_a: params.minfee_a,
+            minfee_b: params.minfee_b,
+            pool_deposit: params.pool_deposit,
+            stake_pool_target_num: params.stake_pool_target_num,
+            min_pool_cost: params.min_pool_cost,
+            pool_retire_max_epoch: params.pool_retire_max_epoch,
+            extra_entropy: params.extra_entropy.clone(),
+            decentralisation_param: params
+                .decentralisation_param
+                .to_checked_f64("decentralisation_param")?,
+            monetary_expansion: params.monetary_expansion.to_checked_f64("monetary_expansion")?,
+            treasury_cut: params.treasury_cut.to_checked_f64("treasury_cut")?,
+            pool_pledge_influence: params
+                .pool_pledge_influence
+                .to_checked_f64("pool_pledge_influence")?,
+        })
+    }
+}
+
+impl TryFrom<&AlonzoParams> for AlonzoParamsRest {
+    type Error = anyhow::Error;
+
+    fn try_from(src: &AlonzoParams) -> Result<Self> {
+        Ok(Self {
+            lovelace_per_utxo_word: src.lovelace_per_utxo_word,
+            execution_prices: (&src.execution_prices).try_into()?,
+            max_tx_ex_units: src.max_tx_ex_units.clone(),
+            max_block_ex_units: src.max_block_ex_units.clone(),
+            max_value_size: src.max_value_size,
+            collateral_percentage: src.collateral_percentage,
+            max_collateral_inputs: src.max_collateral_inputs,
+            plutus_v1_cost_model: src.plutus_v1_cost_model.clone(),
+            plutus_v2_cost_model: src.plutus_v2_cost_model.clone(),
+        })
+    }
+}
+
+impl TryFrom<&ExUnitPrices> for ExUnitPricesRest {
+    type Error = anyhow::Error;
+
+    fn try_from(src: &ExUnitPrices) -> Result<Self> {
+        Ok(Self {
+            mem_price: src.mem_price.to_checked_f64("mem_price")?,
+            step_price: src.step_price.to_checked_f64("step_price")?,
+        })
+    }
+}
+
+impl TryFrom<&ConwayParams> for ConwayParamsRest {
+    type Error = anyhow::Error;
+
+    fn try_from(src: &ConwayParams) -> Result<Self> {
+        Ok(Self {
+            pool_voting_thresholds: (&src.pool_voting_thresholds).try_into()?,
+            d_rep_voting_thresholds: (&src.d_rep_voting_thresholds).try_into()?,
+            committee_min_size: src.committee_min_size,
+            committee_max_term_length: src.committee_max_term_length,
+            gov_action_lifetime: src.gov_action_lifetime,
+            gov_action_deposit: src.gov_action_deposit,
+            d_rep_deposit: src.d_rep_deposit,
+            d_rep_activity: src.d_rep_activity,
+            min_fee_ref_script_cost_per_byte: src
+                .min_fee_ref_script_cost_per_byte
+                .to_checked_f64("min_fee_ref_script_cost_per_byte")?,
+            plutus_v3_cost_model: src.plutus_v3_cost_model.clone(),
+            constitution: (&src.constitution).try_into()?,
+            committee: (&src.committee).try_into()?,
+        })
+    }
+}
+
+impl TryFrom<&PoolVotingThresholds> for PoolVotingThresholdsRest {
+    type Error = anyhow::Error;
+
+    fn try_from(src: &PoolVotingThresholds) -> Result<Self, Self::Error> {
+        Ok(Self {
+            motion_no_confidence: src
+                .motion_no_confidence
+                .to_checked_f64("motion_no_confidence")?,
+            committee_normal: src.committee_normal.to_checked_f64("committee_normal")?,
+            committee_no_confidence: src
+                .committee_no_confidence
+                .to_checked_f64("committee_no_confidence")?,
+            hard_fork_initiation: src
+                .hard_fork_initiation
+                .to_checked_f64("hard_fork_initiation")?,
+            security_voting_threshold: src
+                .security_voting_threshold
+                .to_checked_f64("security_voting_threshold")?,
+        })
+    }
+}
+
+impl TryFrom<&DRepVotingThresholds> for DRepVotingThresholdsRest {
+    type Error = anyhow::Error;
+
+    fn try_from(src: &DRepVotingThresholds) -> Result<Self, Self::Error> {
+        Ok(Self {
+            motion_no_confidence: src
+                .motion_no_confidence
+                .to_checked_f64("motion_no_confidence")?,
+            committee_normal: src.committee_normal.to_checked_f64("committee_normal")?,
+            committee_no_confidence: src
+                .committee_no_confidence
+                .to_checked_f64("committee_no_confidence")?,
+            update_constitution: src.update_constitution.to_checked_f64("update_constitution")?,
+            hard_fork_initiation: src
+                .hard_fork_initiation
+                .to_checked_f64("hard_fork_initiation")?,
+            pp_network_group: src.pp_network_group.to_checked_f64("pp_network_group")?,
+            pp_economic_group: src.pp_economic_group.to_checked_f64("pp_economic_group")?,
+            pp_technical_group: src.pp_technical_group.to_checked_f64("pp_technical_group")?,
+            pp_governance_group: src.pp_governance_group.to_checked_f64("pp_governance_group")?,
+            treasury_withdrawal: src.treasury_withdrawal.to_checked_f64("treasury_withdrawal")?,
+        })
+    }
+}
+
+impl From<&Constitution> for ConstitutionRest {
+    fn from(src: &Constitution) -> Self {
+        Self {
+            anchor: src.anchor.clone(),
+            guardrail_script: src
+                .guardrail_script
+                .as_ref()
+                .map(|script_hash| hex::encode(script_hash)),
+        }
+    }
+}
+
+impl TryFrom<&Committee> for CommitteeRest {
+    type Error = anyhow::Error;
+
+    fn try_from(src: &Committee) -> Result<Self> {
+        Ok(Self {
+            members: src
+                .members
+                .iter()
+                .map(|(cred, amount)| (cred.to_json_string(), *amount))
+                .collect(),
+            threshold: src.threshold.to_checked_f64("threshold")?,
+        })
+    }
+}

--- a/modules/parameters_state/src/state.rs
+++ b/modules/parameters_state/src/state.rs
@@ -76,7 +76,6 @@ impl State {
             params: self.current_params.get_params(),
         };
 
-        self.active_epoch = block.epoch;
         if let Some(history) = self.parameter_history.as_mut() {
             let last = history.range(..block.epoch).next_back();
 
@@ -87,6 +86,7 @@ impl State {
 
             if should_store {
                 history.insert(block.epoch, params_message.clone());
+                self.active_epoch = block.epoch;
             }
         }
 

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -33,6 +33,7 @@ address-delta-topic = "cardano.address.delta"
 [module.governance-state]
 
 [module.parameters-state]
+store-history = true
 
 [module.stake-delta-filter]
 cache-mode = "predefined" # "predefined", "read", "write", "write-if-absent"

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -33,7 +33,7 @@ address-delta-topic = "cardano.address.delta"
 [module.governance-state]
 
 [module.parameters-state]
-store-history = true
+store-history = false
 
 [module.stake-delta-filter]
 cache-mode = "predefined" # "predefined", "read", "write", "write-if-absent"


### PR DESCRIPTION
Opening as a draft to get initial feedback. Updating OpenAPI specification and final testing will be done tomorrow.
This PR:
* Adds `active_epoch` and optional `parameter_history` fields to `parameters_state`.
* Introduces a `store-history` config option in `omnibus.toml` to enable historical protocol parameters storage.
* Implements `/epoch/parameters` and `/epochs/{epoch_number}/parameters` REST endpoints mentioned in #86 & #87. 