### PR TITLE
feat: REST Blockfrost module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "acropolis_module_rest_blockfrost"
+version = "0.1.0"
+dependencies = [
+ "acropolis_common",
+ "anyhow",
+ "async-trait",
+ "bech32 0.11.0",
+ "caryatid_module_rest_server",
+ "caryatid_sdk",
+ "config",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_with 3.14.0",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "acropolis_module_snapshot_bootstrapper"
 version = "0.1.0"
 dependencies = [
@@ -286,6 +305,7 @@ dependencies = [
  "acropolis_module_governance_state",
  "acropolis_module_mithril_snapshot_fetcher",
  "acropolis_module_parameters_state",
+ "acropolis_module_rest_blockfrost",
  "acropolis_module_spo_state",
  "acropolis_module_stake_delta_filter",
  "acropolis_module_tx_unpacker",

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -225,7 +225,8 @@ pub enum SnapshotStateMessage {
 // === Global message enum ===
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
 pub enum Message {
-    #[default] None, // Just so we have a simple default
+    #[default]
+    None, // Just so we have a simple default
 
     // Generic messages, get of jail free cards
     String(String),          // Simple string
@@ -241,6 +242,10 @@ pub enum Message {
 
     // Initialize state from a snapshot
     Snapshot(SnapshotMessage),
+
+    // State query messages
+    StateQuery(StateQuery),
+    StateQueryResponse(StateQueryResponse),
 }
 
 // Casts from specific Caryatid messages
@@ -271,4 +276,24 @@ impl GetRESTResponse for Message {
             None
         }
     }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum StateQuery {
+    GetAccountInfo { stake_key: Vec<u8> },
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub enum StateQueryResponse {
+    AccountInfo(AccountInfo),
+    NotFound,
+    Error(String),
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct AccountInfo {
+    pub utxo_value: u64,
+    pub rewards: u64,
+    pub delegated_spo: Option<KeyHash>,
+    pub delegated_drep: Option<DRepChoice>,
 }

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -34,8 +34,6 @@ const DEFAULT_DREP_DISTRIBUTION_TOPIC: &str = "cardano.drep.distribution";
 const DEFAULT_SPO_DISTRIBUTION_TOPIC: &str = "cardano.spo.distribution";
 const DEFAULT_PROTOCOL_PARAMETERS_TOPIC: &str = "cardano.protocol.parameters";
 
-const DEFAULT_HANDLE_SINGLE_ACCOUNT_TOPIC: (&str, &str) =
-    ("handle-topic-account-single", "rest.get.accounts.*");
 const DEFAULT_HANDLE_SPDD_TOPIC: (&str, &str) = ("handle-topic-spdd", "rest.get.spdd");
 const DEFAULT_HANDLE_POTS_TOPIC: (&str, &str) = ("handle-topic-pots", "rest.get.pots");
 const DEFAULT_HANDLE_DRDD_TOPIC: (&str, &str) = ("handle-topic-drdd", "rest.get.drdd");

--- a/modules/accounts_state/src/rest.rs
+++ b/modules/accounts_state/src/rest.rs
@@ -3,15 +3,12 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use acropolis_common::serialization::Bech32WithHrp;
-use acropolis_common::DRepChoice;
-use anyhow::{anyhow, Result};
+use anyhow::Result;
 use tokio::sync::Mutex;
 
 use crate::state::State;
 use acropolis_common::state_history::StateHistory;
-use acropolis_common::{
-    messages::RESTResponse, Address, Lovelace, StakeAddress, StakeAddressPayload,
-};
+use acropolis_common::{messages::RESTResponse, Lovelace};
 
 /// REST response structure for /accounts/{stake_address}
 #[derive(serde::Serialize)]
@@ -33,77 +30,6 @@ struct APIDRepDelegationDistribution {
     pub abstain: Lovelace,
     pub no_confidence: Lovelace,
     pub dreps: Vec<(String, u64)>,
-}
-
-/// Handles /accounts/info/{stake_address}
-pub async fn handle_single_account(
-    history: Arc<Mutex<StateHistory<State>>>,
-    param: String,
-) -> Result<RESTResponse> {
-    let stake_address = match Address::from_string(&param) {
-        Ok(Address::Stake(StakeAddress {
-            payload: StakeAddressPayload::StakeKeyHash(hash),
-            ..
-        })) => hash,
-        _ => {
-            return Ok(RESTResponse::with_text(
-                400,
-                &format!("Not a valid stake address: {param}"),
-            ));
-        }
-    };
-
-    let locked = history.lock().await;
-    let state = match locked.current() {
-        Some(state) => state,
-        None => return Ok(RESTResponse::with_text(500, "No current state available")),
-    };
-
-    let stake = match state.get_stake_state(&stake_address) {
-        Some(stake) => stake,
-        None => return Ok(RESTResponse::with_text(404, "Stake address not found")),
-    };
-
-    let delegated_spo = match &stake.delegated_spo {
-        Some(spo) => match spo.to_bech32_with_hrp("pool") {
-            Ok(val) => Some(val),
-            Err(e) => {
-                return Ok(RESTResponse::with_text(
-                    500,
-                    &format!("Internal server error while retrieving stake address: {e}"),
-                ));
-            }
-        },
-        None => None,
-    };
-
-    let delegated_drep = match &stake.delegated_drep {
-        Some(drep) => match map_drep_choice(drep) {
-            Ok(val) => Some(val),
-            Err(e) => {
-                return Ok(RESTResponse::with_text(
-                    500,
-                    &format!("Internal server error while retrieving stake address: {e}"),
-                ))
-            }
-        },
-        None => None,
-    };
-
-    let response = APIStakeAccount {
-        utxo_value: stake.utxo_value,
-        rewards: stake.rewards,
-        delegated_spo: delegated_spo,
-        delegated_drep: delegated_drep,
-    };
-
-    match serde_json::to_string(&response) {
-        Ok(json) => Ok(RESTResponse::with_json(200, &json)),
-        Err(e) => Ok(RESTResponse::with_text(
-            500,
-            &format!("Internal server error while retrieving stake address: {e}"),
-        )),
-    }
 }
 
 /// Handles /spdd
@@ -190,36 +116,5 @@ pub async fn handle_drdd(history: Arc<Mutex<StateHistory<State>>>) -> Result<RES
             500,
             &format!("Internal server error while retrieving DRep delegation distribution: {e}"),
         )),
-    }
-}
-
-fn map_drep_choice(drep: &DRepChoice) -> Result<APIDRepChoice> {
-    match drep {
-        DRepChoice::Key(hash) => {
-            let val = hash
-                .to_bech32_with_hrp("drep")
-                .map_err(|e| anyhow!("Bech32 encoding failed for DRep Key: {e}"))?;
-            Ok(APIDRepChoice {
-                drep_type: "Key".to_string(),
-                value: Some(val),
-            })
-        }
-        DRepChoice::Script(hash) => {
-            let val = hash
-                .to_bech32_with_hrp("drep_script")
-                .map_err(|e| anyhow!("Bech32 encoding failed for DRep Script: {e}"))?;
-            Ok(APIDRepChoice {
-                drep_type: "Script".to_string(),
-                value: Some(val),
-            })
-        }
-        DRepChoice::Abstain => Ok(APIDRepChoice {
-            drep_type: "Abstain".to_string(),
-            value: None,
-        }),
-        DRepChoice::NoConfidence => Ok(APIDRepChoice {
-            drep_type: "NoConfidence".to_string(),
-            value: None,
-        }),
     }
 }

--- a/modules/rest_blockfrost/Cargo.toml
+++ b/modules/rest_blockfrost/Cargo.toml
@@ -1,0 +1,27 @@
+# Acropolis Blockfrost-Compatible REST Module
+
+[package]
+name = "acropolis_module_rest_blockfrost"
+version = "0.1.0"
+edition = "2021"
+authors = ["William Hankins <william@sundae.fi>"]
+description = "Blockfrost-compatible REST API for Acropolis"
+license = "Apache-2.0"
+
+[dependencies]
+acropolis_common = { path = "../../common" }
+anyhow = "1.0"
+async-trait = "0.1"
+bech32 = "0.11"
+caryatid_sdk = "0.12"
+caryatid_module_rest_server = "0.13"
+config = "0.15.11"
+hex = "0.4.3"
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0"
+serde_with = { version = "3.12.0", features = ["hex"] }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1.40"
+
+[lib]
+path = "src/rest_blockfrost.rs"

--- a/modules/rest_blockfrost/src/handlers/accounts.rs
+++ b/modules/rest_blockfrost/src/handlers/accounts.rs
@@ -1,0 +1,139 @@
+//! REST handlers for Acropolis Blockfrost /accounts endpoints
+use std::sync::Arc;
+
+use acropolis_common::messages::{Message, RESTResponse, StateQuery, StateQueryResponse};
+use acropolis_common::serialization::Bech32WithHrp;
+use acropolis_common::{Address, DRepChoice, StakeAddress, StakeAddressPayload};
+use anyhow::{anyhow, Result};
+use caryatid_sdk::Context;
+
+#[derive(serde::Serialize)]
+pub struct StakeAccountRest {
+    pub utxo_value: u64,
+    pub rewards: u64,
+    pub delegated_spo: Option<String>,
+    pub delegated_drep: Option<DRepChoiceRest>,
+}
+
+#[derive(serde::Serialize)]
+pub struct DRepChoiceRest {
+    pub drep_type: String,
+    pub value: Option<String>,
+}
+
+/// Handle `/accounts/{stake_address}` Blockfrost-compatible endpoint
+pub async fn handle_single_account_blockfrost(
+    context: Arc<Context<Message>>,
+    param: String,
+) -> Result<RESTResponse> {
+    // Convert Bech32 stake address to StakeCredential
+    let stake_key = match Address::from_string(&param) {
+        Ok(Address::Stake(StakeAddress {
+            payload: StakeAddressPayload::StakeKeyHash(hash),
+            ..
+        })) => hash,
+        _ => {
+            return Ok(RESTResponse::with_text(
+                400,
+                &format!("Not a valid stake address: {param}"),
+            ));
+        }
+    };
+
+    // Prepare the message
+    let msg = Arc::new(Message::StateQuery(StateQuery::GetAccountInfo {
+        stake_key,
+    }));
+
+    // Send message via message bus
+    let raw = context.message_bus.request("accounts-state", msg).await?;
+
+    // Unwrap and match
+    let message = Arc::try_unwrap(raw).unwrap_or_else(|arc| (*arc).clone());
+
+    let account = match message {
+        Message::StateQueryResponse(StateQueryResponse::AccountInfo(account)) => account,
+        Message::StateQueryResponse(StateQueryResponse::NotFound) => {
+            return Ok(RESTResponse::with_text(404, "Stake address not found"));
+        }
+        Message::StateQueryResponse(StateQueryResponse::Error(e)) => {
+            return Ok(RESTResponse::with_text(
+                500,
+                &format!("Internal server error: {e}"),
+            ));
+        }
+        _ => return Ok(RESTResponse::with_text(500, "Unexpected message type")),
+    };
+
+    let delegated_spo = match &account.delegated_spo {
+        Some(spo) => match spo.to_bech32_with_hrp("pool") {
+            Ok(val) => Some(val),
+            Err(e) => {
+                return Ok(RESTResponse::with_text(
+                    500,
+                    &format!("Internal server error while retrieving stake address: {e}"),
+                ));
+            }
+        },
+        None => None,
+    };
+
+    let delegated_drep = match &account.delegated_drep {
+        Some(drep) => match map_drep_choice(drep) {
+            Ok(val) => Some(val),
+            Err(e) => {
+                return Ok(RESTResponse::with_text(
+                    500,
+                    &format!("Internal server error while retrieving stake address: {e}"),
+                ))
+            }
+        },
+        None => None,
+    };
+
+    let rest_response = StakeAccountRest {
+        utxo_value: account.utxo_value,
+        rewards: account.rewards,
+        delegated_spo: delegated_spo,
+        delegated_drep: delegated_drep,
+    };
+
+    match serde_json::to_string(&rest_response) {
+        Ok(json) => Ok(RESTResponse::with_json(200, &json)),
+        Err(e) => Ok(RESTResponse::with_text(
+            500,
+            &format!("Internal server error while retrieving DRep delegation distribution: {e}"),
+        )),
+    }
+}
+
+fn map_drep_choice(drep: &DRepChoice) -> Result<DRepChoiceRest> {
+    match drep {
+        DRepChoice::Key(hash) => {
+            let val = hash
+                .to_bech32_with_hrp("drep")
+                .map_err(|e| anyhow!("Bech32 encoding failed for DRep Key: {e}"))?;
+            Ok(DRepChoiceRest {
+                drep_type: "Key".to_string(),
+                value: Some(val),
+            })
+        }
+        DRepChoice::Script(hash) => {
+            let val = hash
+                .to_bech32_with_hrp("drep_script")
+                .map_err(|e| anyhow!("Bech32 encoding failed for DRep Script: {e}"))?;
+            Ok(DRepChoiceRest {
+                drep_type: "Script".to_string(),
+                value: Some(val),
+            })
+        }
+        DRepChoice::Abstain => Ok(DRepChoiceRest {
+            drep_type: "Abstain".to_string(),
+            value: None,
+        }),
+        DRepChoice::NoConfidence => Ok(DRepChoiceRest {
+            drep_type: "NoConfidence".to_string(),
+            value: None,
+        }),
+    }
+}

--- a/modules/rest_blockfrost/src/handlers/mod.rs
+++ b/modules/rest_blockfrost/src/handlers/mod.rs
@@ -1,0 +1,1 @@
+pub mod accounts;

--- a/modules/rest_blockfrost/src/rest_blockfrost.rs
+++ b/modules/rest_blockfrost/src/rest_blockfrost.rs
@@ -1,0 +1,48 @@
+//! Acropolis Blockfrost-Compatible REST Module
+
+use std::sync::Arc;
+
+use acropolis_common::{messages::Message, rest_helper::handle_rest_with_parameter};
+use anyhow::Result;
+use caryatid_sdk::{module, Context, Module};
+use config::Config;
+use tracing::info;
+mod handlers;
+use handlers::accounts::handle_single_account_blockfrost;
+
+const DEFAULT_HANDLE_SINGLE_ACCOUNT_TOPIC: (&str, &str) =
+    ("handle-topic-account-single", "rest.get.accounts.*");
+
+#[module(
+    message_type(Message),
+    name = "rest-blockfrost",
+    description = "Blockfrost-compatible REST API for Acropolis"
+)]
+
+pub struct BlockfrostREST;
+
+impl BlockfrostREST {
+    pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
+        info!("Blockfrost REST enabled");
+        // Register routes with the shared REST server
+        let handle_single_account_topic = config
+            .get_string(DEFAULT_HANDLE_SINGLE_ACCOUNT_TOPIC.0)
+            .unwrap_or(DEFAULT_HANDLE_SINGLE_ACCOUNT_TOPIC.1.to_string());
+
+        info!(
+            "Creating request handler on '{}'",
+            handle_single_account_topic
+        );
+
+        // Register individual endpoint handlers
+        handle_rest_with_parameter(
+            context.clone(),
+            &handle_single_account_topic,
+            move |param| handle_single_account_blockfrost(context.clone(), param[0].to_string()),
+        );
+
+        // Add more routes here as needed
+
+        Ok(())
+    }
+}

--- a/processes/omnibus/Cargo.toml
+++ b/processes/omnibus/Cargo.toml
@@ -31,6 +31,7 @@ acropolis_module_parameters_state = { path = "../../modules/parameters_state" }
 acropolis_module_stake_delta_filter = { path = "../../modules/stake_delta_filter" }
 acropolis_module_epoch_activity_counter = { path = "../../modules/epoch_activity_counter" }
 acropolis_module_accounts_state = { path = "../../modules/accounts_state" }
+acropolis_module_rest_blockfrost = { path = "../../modules/rest_blockfrost" }
 
 anyhow = "1.0"
 config = "0.15.11"

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -15,6 +15,8 @@ magic-number = 764824073
 
 [module.block-unpacker]
 
+[module.rest-blockfrost]
+
 [module.tx-unpacker]
 publish-utxo-deltas-topic = "cardano.utxo.deltas"
 publish-withdrawals-topic = "cardano.withdrawals"

--- a/processes/omnibus/src/main.rs
+++ b/processes/omnibus/src/main.rs
@@ -68,10 +68,10 @@ pub async fn main() -> Result<()> {
     StakeDeltaFilter::register(&mut process);
     EpochActivityCounter::register(&mut process);
     AccountsState::register(&mut process);
+    BlockfrostREST::register(&mut process);
 
     Clock::<Message>::register(&mut process);
     RESTServer::<Message>::register(&mut process);
-    BlockfrostREST::register(&mut process);
     Spy::<Message>::register(&mut process);
 
     // Run it

--- a/processes/omnibus/src/main.rs
+++ b/processes/omnibus/src/main.rs
@@ -17,6 +17,7 @@ use acropolis_module_genesis_bootstrapper::GenesisBootstrapper;
 use acropolis_module_governance_state::GovernanceState;
 use acropolis_module_mithril_snapshot_fetcher::MithrilSnapshotFetcher;
 use acropolis_module_parameters_state::ParametersState;
+use acropolis_module_rest_blockfrost::BlockfrostREST;
 use acropolis_module_spo_state::SPOState;
 use acropolis_module_stake_delta_filter::StakeDeltaFilter;
 use acropolis_module_tx_unpacker::TxUnpacker;
@@ -70,6 +71,7 @@ pub async fn main() -> Result<()> {
 
     Clock::<Message>::register(&mut process);
     RESTServer::<Message>::register(&mut process);
+    BlockfrostREST::register(&mut process);
     Spy::<Message>::register(&mut process);
 
     // Run it


### PR DESCRIPTION
This PR introduces cross-module state query capabilities and begins the migration to a centralized REST handler module:
* Adds 2 new message types: `StateQuery` and `StateQueryResponse`, enabling modules to request and respond with state data from other modules.
* Introduces a new `rest_blockfrost` module to handle all REST API requests. It delegates queries to the appropriate state modules using `StateQuery` messages and constructs responses from the resulting `StateQueryResponse`.
* Migrates the `/accounts/{stake_address}` endpoint from `accounts_state` to `rest_blockfrost` as a proof of concept. 