### PR TITLE
feat: add pause at certain block number

### DIFF
--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -25,6 +25,9 @@ use std::time::Duration;
 use tokio::{join, sync::Mutex};
 use tracing::{debug, error, info};
 
+mod pause;
+use pause::PauseType;
+
 const DEFAULT_STARTUP_TOPIC: &str = "cardano.sequence.bootstrapped";
 const DEFAULT_HEADER_TOPIC: &str = "cardano.block.header";
 const DEFAULT_BODY_TOPIC: &str = "cardano.block.body";
@@ -36,7 +39,7 @@ const DEFAULT_GENESIS_KEY: &str = r#"
 5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32
 372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133
 382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"#;
-const DEFAULT_PAUSE_EPOCH: (&str, i64) = ("pause-epoch", -1);
+const DEFAULT_PAUSE: (&str, PauseType) = ("pause", PauseType::NoPause);
 const DEFAULT_DIRECTORY: &str = "downloads";
 
 /// Mithril feedback receiver
@@ -161,7 +164,8 @@ impl MithrilSnapshotFetcher {
         let completion_topic =
             config.get_string("completion-topic").unwrap_or(DEFAULT_COMPLETION_TOPIC.to_string());
         let directory = config.get_string("directory").unwrap_or(DEFAULT_DIRECTORY.to_string());
-        let mut pause_epoch = load_pause_epoch(&config);
+        let mut pause_constraint =
+            PauseType::from_config(&config, DEFAULT_PAUSE).unwrap_or(PauseType::NoPause);
 
         // Path to immutable DB
         let path = Path::new(&directory).join("immutable");
@@ -217,17 +221,6 @@ impl MithrilSnapshotFetcher {
 
                     if new_epoch {
                         info!(epoch, number, slot, "New epoch");
-
-                        if let Some(pe) = pause_epoch {
-                            if epoch == pe {
-                                if prompt_epoch_pause(epoch).await {
-                                    info!("Continuing without further pauses...");
-                                    pause_epoch = None;
-                                } else {
-                                    pause_epoch = Some(epoch + 1);
-                                }
-                            }
-                        }
                     }
 
                     let era = match block.era() {
@@ -249,6 +242,19 @@ impl MithrilSnapshotFetcher {
                         new_epoch,
                         era,
                     };
+
+                    // Check pause constraint
+                    if pause_constraint.should_pause(&block_info) {
+                        let description = pause_constraint.get_description();
+                        let next_pause_constraint = pause_constraint.get_next();
+                        let next_description = next_pause_constraint.get_description();
+                        if prompt_pause(description, next_description).await {
+                            info!("Continuing without further pauses...");
+                            pause_constraint = PauseType::NoPause;
+                        } else {
+                            pause_constraint = next_pause_constraint;
+                        }
+                    }
 
                     // Send the block header message
                     let header = block.header();
@@ -287,8 +293,10 @@ impl MithrilSnapshotFetcher {
 
         // Send completion message
         if let Some(last_block_info) = last_block_info {
-            info!("Finished shapshot at block {}, epoch {}",
-                  last_block_info.number, last_block_info.epoch);
+            info!(
+                "Finished shapshot at block {}, epoch {}",
+                last_block_info.number, last_block_info.epoch
+            );
             let message_enum =
                 Message::Cardano((last_block_info, CardanoMessage::SnapshotComplete));
             context
@@ -339,18 +347,11 @@ impl MithrilSnapshotFetcher {
     }
 }
 
-/// Helper to parse pause_epoch from config
-fn load_pause_epoch(config: &Config) -> Option<u64> {
-    let pause_epoch = config.get_int(DEFAULT_PAUSE_EPOCH.0).unwrap_or(DEFAULT_PAUSE_EPOCH.1);
-    (pause_epoch >= 0).then(|| {
-        info!("Pausing enabled at epoch {pause_epoch}");
-        pause_epoch as u64
-    })
-}
-
 /// Async helper to prompt user for pause behavior
-async fn prompt_epoch_pause(epoch: u64) -> bool {
-    info!("Paused at epoch {epoch}. Press [Enter] to step to next epoch, or [c + Enter] to continue without pauses.");
+async fn prompt_pause(description: String, next_description: String) -> bool {
+    info!(
+        "Paused at {description}. Press [Enter] to step to {next_description}, or [c + Enter] to continue without pauses."
+    );
     tokio::task::spawn_blocking(|| {
         use std::io::{self, BufRead};
         let stdin = io::stdin();

--- a/modules/mithril_snapshot_fetcher/src/pause.rs
+++ b/modules/mithril_snapshot_fetcher/src/pause.rs
@@ -1,0 +1,77 @@
+use acropolis_common::BlockInfo;
+use config::Config;
+use tracing::{error, info};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum PauseType {
+    NoPause,
+    Epoch(u64),
+    Block(u64),
+}
+
+impl PauseType {
+    pub fn from_config(config: &Config, default_pause: (&str, PauseType)) -> Option<Self> {
+        let pause_str = config.get_string(default_pause.0).ok()?;
+
+        if pause_str.eq_ignore_ascii_case("none") {
+            return Some(PauseType::NoPause);
+        }
+
+        let parts: Vec<&str> = pause_str.split(':').collect();
+
+        if parts.len() != 2 {
+            error!("Invalid pause format: {}. Expected format: 'type:value' (e.g., 'epoch:214', 'block:1200')", pause_str);
+            return None;
+        }
+
+        let pause_type = parts[0].trim();
+        let value = parts[1].trim().parse::<u64>().ok()?;
+
+        match pause_type {
+            "epoch" => {
+                info!("Pausing enabled at epoch {value}");
+                Some(PauseType::Epoch(value))
+            }
+            "block" => {
+                info!("Pausing enabled at block {value}");
+                Some(PauseType::Block(value))
+            }
+            _ => {
+                error!(
+                    "Unknown pause type: {}. Supported types: epoch, block",
+                    pause_type
+                );
+                None
+            }
+        }
+    }
+
+    pub fn should_pause(&self, block_info: &BlockInfo) -> bool {
+        match self {
+            PauseType::Epoch(target_epoch) => {
+                if block_info.new_epoch {
+                    return block_info.epoch == *target_epoch;
+                }
+                return false;
+            }
+            PauseType::Block(target_block) => block_info.number == *target_block,
+            PauseType::NoPause => false,
+        }
+    }
+
+    pub fn get_next(&self) -> Self {
+        match self {
+            PauseType::Epoch(target_epoch) => PauseType::Epoch(target_epoch + 1),
+            PauseType::Block(target_block) => PauseType::Block(target_block + 1),
+            PauseType::NoPause => PauseType::NoPause,
+        }
+    }
+
+    pub fn get_description(&self) -> String {
+        match self {
+            PauseType::Epoch(target_epoch) => format!("Epoch {target_epoch}"),
+            PauseType::Block(target_block) => format!("Block {target_block}"),
+            PauseType::NoPause => "No pause".to_string(),
+        }
+    }
+}

--- a/modules/mithril_snapshot_fetcher/src/pause.rs
+++ b/modules/mithril_snapshot_fetcher/src/pause.rs
@@ -75,3 +75,30 @@ impl PauseType {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    const DEFAULT_PAUSE: (&str, PauseType) = ("pause", PauseType::NoPause);
+
+    #[test]
+    fn test_pause_type_from_config_epoch() {
+        let config = Config::builder().set_override("pause", "epoch:100").unwrap().build().unwrap();
+        let pause_type = PauseType::from_config(&config, DEFAULT_PAUSE);
+        assert_eq!(pause_type, Some(PauseType::Epoch(100)));
+    }
+
+    #[test]
+    fn test_pause_type_from_config_block() {
+        let config = Config::builder().set_override("pause", "block:100").unwrap().build().unwrap();
+        let pause_type = PauseType::from_config(&config, DEFAULT_PAUSE);
+        assert_eq!(pause_type, Some(PauseType::Block(100)));
+    }
+
+    #[test]
+    fn test_pause_type_from_config_invalid() {
+        let config = Config::builder().set_override("pause", "invalid").unwrap().build().unwrap();
+        let pause_type = PauseType::from_config(&config, DEFAULT_PAUSE);
+        assert_eq!(pause_type, None);
+    }
+}

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -6,7 +6,8 @@
 aggregator-url = "https://aggregator.release-mainnet.api.mithril.network/aggregator"
 genesis-key = "5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"
 download = false
-pause-epoch = -1
+# Pause constraint E.g. "epoch:100", "block:1200"
+pause = "none"
 
 [module.upstream-chain-fetcher]
 sync-point = "snapshot"


### PR DESCRIPTION
## Summary

This PR enhances the Mithril snapshot processor with flexible pause functionality that allows pausing at specific block numbers or epoch numbers during the snapshot process.

### Changes Made

#### 🔧 **Core Implementation**
- **New module**: `modules/mithril_snapshot_fetcher/src/pause.rs`
  - Implements `PauseType` enum with support for `NoPause`, `Epoch(u64)`, and `Block(u64)`
  - Provides configuration parsing with format: `"type:value"` (e.g., `"epoch:214"`, `"block:1200"`)
  - Includes unit tests for configuration parsing

#### 🔄 **Main Fetcher Updates**
- **Modified**: `modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs`
  - Replaced epoch pause logic with flexible `PauseType` system
  - Updated pause checking logic to work with both block and epoch constraints
  - Improved user prompt messages to show current and next pause targets
  - Enhanced code formatting and structure

#### ⚙️ **Configuration Updates**
- **Modified**: `processes/omnibus/omnibus.toml`
  - Replaced `pause-epoch = -1` with `pause = "none"`
  - Added documentation comment explaining the new pause format

### Key Features

1. **Flexible Pause Types**:
   - **Epoch-based**: Pause at specific epoch numbers (e.g., `"epoch:214"`)
   - **Block-based**: Pause at specific block numbers (e.g., `"block:1200"`)
   - **No pause**: Continue without any pauses (`"none"`)

2. **User Interaction**:
   - Clear prompts showing current pause target and next target
   - Option to continue without further pauses or step to next target