### PR TITLE
refactor: Mithril fetcher to download intelligently

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "caryatid_sdk",
+ "chrono",
  "config",
  "mithril-client",
  "pallas",

--- a/modules/mithril_snapshot_fetcher/Cargo.toml
+++ b/modules/mithril_snapshot_fetcher/Cargo.toml
@@ -19,6 +19,7 @@ tracing = "0.1.40"
 serde_json = "1.0.138"
 mithril-client = { version = "0.12", features = ["fs"] }
 async-trait = "0.1.86"
+chrono = "0.4.41"
 
 [build-dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -164,7 +164,7 @@ impl MithrilSnapshotFetcher {
                 }
             }
             Err(error) => {
-                info!("SKIP DOWNLOAD: Download max age is not set: {error:?}");
+                info!("SKIP DOWNLOAD: Download max age is not set or invalid: {error:?}");
                 true
             }
         }

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -5,7 +5,8 @@
 [module.mithril-snapshot-fetcher]
 aggregator-url = "https://aggregator.release-mainnet.api.mithril.network/aggregator"
 genesis-key = "5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"
-download = false
+# Download max age in hours. E.g. 8 means 8 hours (if there isn't any snapshot within this time range download from Mithril)
+download-max-age = "never"
 # Pause constraint E.g. "epoch:100", "block:1200"
 pause = "none"
 


### PR DESCRIPTION
## 🚀 Intelligent Snapshot Download Management

### Overview
This PR introduces an intelligent snapshot download system that manages Mithril snapshot downloads more efficiently based on age constraints, replacing the simple boolean `download` flag with a more granular `download-max-age` configuration.

### ✨ Key Features

#### **Age-Based Download Logic**
- **unset or invalid `u64`**: Never download.
- **`0`**: Always download (equivalent to old `download = true`)
- **`8`**: Download only if there is no snapshot within 8 hours

#### **Metadata Persistence**
- Saves snapshot metadata as JSON for reliable age tracking
- Uses snapshot creation time from metadata (not file timestamp)
- Enables intelligent age comparison between snapshots

#### **Smart Download Decisions**
- Compares existing snapshot age against `download-max-age` configuration
- Only downloads if current snapshot is expired AND newer snapshot is available
- Prevents unnecessary downloads when valid snapshots exist

### 🔧 Technical Changes

#### **Dependencies**
- Added `chrono = "0.4.41"` for time handling
- Added `Snapshot` import from `mithril_client`

#### **New Functions**
```rust
fn load_snapshot_metadata(path: &Path) -> Result<Snapshot>
fn save_snapshot_metadata(snapshot: &Snapshot, path: &Path) -> Result<()>
fn should_skip_download(old_snapshot: &Snapshot, latest_snapshot: &Snapshot, config: &Config) -> bool
```

#### **Configuration Migration**
```toml
# Before
download = false

# After
download-max-age = "never"  # Never download or
download-max-age = 0      # Always download  or
download-max-age = 8      # Download if older than 8 hours
```

### 🧪 Testing
- Added comprehensive unit tests for metadata persistence
- Added tests for age-based download logic

## Related Issue
#2 