### PR TITLE
feat: add multi-asset decoding to TxOutput

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -139,6 +139,35 @@ pub struct StakeAddressDelta {
     pub delta: i64,
 }
 
+/// Value (lovelace + multiasset)
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Value {
+    pub lovelace: u64,
+    pub assets: MultiAssets,
+}
+
+pub type MultiAssets = Vec<NativeAsset>;
+
+pub type PolicyId = [u8; 28];
+pub type AssetName = Vec<u8>;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct NativeAsset {
+    pub policy_id: PolicyId,
+    pub name: AssetName,
+    pub amount: u64,
+}
+
+impl Value {
+    pub fn new(lovelace: u64, assets: Vec<NativeAsset>) -> Self {
+        Self { lovelace, assets }
+    }
+
+    pub fn coin(&self) -> u64 {
+        self.lovelace
+    }
+}
+
 /// Transaction output (UTXO)
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct TxOutput {
@@ -152,7 +181,7 @@ pub struct TxOutput {
     pub address: Address,
 
     /// Output value (Lovelace)
-    pub value: u64,
+    pub value: Value,
     // todo: Implement datum    /// Datum (raw)
     // !!!    pub datum: Vec<u8>,
 }

--- a/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
+++ b/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
@@ -6,7 +6,7 @@ use acropolis_common::{
         CardanoMessage, GenesisCompleteMessage, Message, PotDeltasMessage, UTXODeltasMessage,
     },
     Address, BlockInfo, BlockStatus, ByronAddress, Era, Lovelace, LovelaceDelta, Pot, PotDelta,
-    TxOutput, UTXODelta,
+    TxOutput, UTXODelta, Value,
 };
 use anyhow::Result;
 use caryatid_sdk::{module, Context, Module};
@@ -107,7 +107,7 @@ impl GenesisBootstrapper {
                         address: Address::Byron(ByronAddress {
                             payload: address.payload.to_vec(),
                         }),
-                        value: *amount,
+                        value: Value::new(*amount, Vec::new()),
                     };
 
                     utxo_deltas_message.deltas.push(UTXODelta::Output(tx_output));

--- a/modules/tx_unpacker/src/map_parameters.rs
+++ b/modules/tx_unpacker/src/map_parameters.rs
@@ -890,28 +890,5 @@ pub fn map_value(pallas_value: &MultiEraValue) -> Value {
             _ => {}
         }
     }
-    canonicalize_assets(&mut assets);
     Value::new(lovelace, assets)
-}
-
-// Sorts by policy_id and name
-// merges duplicates and sums their amounts
-fn canonicalize_assets(assets: &mut Vec<NativeAsset>) {
-    if assets.len() <= 1 {
-        return;
-    }
-
-    assets.sort_unstable_by(|a, b| match a.policy_id.cmp(&b.policy_id) {
-        std::cmp::Ordering::Equal => a.name.cmp(&b.name),
-        ord => ord,
-    });
-
-    assets.dedup_by(|left, right| {
-        if left.policy_id == right.policy_id && left.name == right.name {
-            left.amount = left.amount.saturating_add(right.amount);
-            true
-        } else {
-            false
-        }
-    });
 }

--- a/modules/tx_unpacker/src/tx_unpacker.rs
+++ b/modules/tx_unpacker/src/tx_unpacker.rs
@@ -193,7 +193,7 @@ impl TxUnpacker {
                                                                     tx_hash: *tx.hash(),
                                                                     index: index as u64,
                                                                     address: address,
-                                                                    value: output.value().coin(),
+                                                                    value: map_parameters::map_value(&output.value())
                                                                     // !!! datum
                                                                 };
 

--- a/modules/utxo_state/src/state.rs
+++ b/modules/utxo_state/src/state.rs
@@ -254,7 +254,11 @@ impl State {
     pub async fn observe_output(&mut self, output: &TxOutput, block: &BlockInfo) -> Result<()> {
         if tracing::enabled!(tracing::Level::DEBUG) {
             debug!("UTXO >> {}:{}", encode(&output.tx_hash), output.index);
-            debug!("        - adding {} to {:?}", output.value, output.address);
+            debug!(
+                "        - adding {} to {:?}",
+                output.value.coin(),
+                output.address
+            );
         }
 
         // Insert the UTXO, checking if it already existed
@@ -262,7 +266,7 @@ impl State {
 
         let value = UTXOValue {
             address: output.address.clone(),
-            value: output.value,
+            value: output.value.coin(),
         };
 
         // Add to volatile or immutable maps
@@ -288,7 +292,7 @@ impl State {
 
         // Tell the observer
         if let Some(observer) = self.address_delta_observer.as_ref() {
-            observer.observe_delta(&output.address, output.value as i64).await;
+            observer.observe_delta(&output.address, output.value.coin() as i64).await;
         }
 
         Ok(())
@@ -396,7 +400,7 @@ impl State {
 mod tests {
     use super::*;
     use crate::InMemoryImmutableUTXOStore;
-    use acropolis_common::{ByronAddress, Era};
+    use acropolis_common::{ByronAddress, Era, Value};
     use config::Config;
     use tokio::sync::Mutex;
 
@@ -441,7 +445,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block = create_block(BlockStatus::Immutable, 1, 1);
@@ -470,7 +474,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block1 = create_block(BlockStatus::Immutable, 1, 1);
@@ -496,7 +500,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block10 = create_block(BlockStatus::Volatile, 10, 10);
@@ -521,7 +525,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block10 = create_block(BlockStatus::Volatile, 10, 10);
@@ -558,7 +562,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block1 = create_block(BlockStatus::Volatile, 1, 1);
@@ -590,7 +594,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block1 = create_block(BlockStatus::Volatile, 1, 1);
@@ -661,7 +665,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block1 = create_block(BlockStatus::Immutable, 1, 1);
@@ -692,7 +696,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block10 = create_block(BlockStatus::Volatile, 10, 10);
@@ -721,7 +725,7 @@ mod tests {
             tx_hash: TxHash::default(),
             index: 0,
             address: create_address(99),
-            value: 42,
+            value: Value::new(42, Vec::new()),
         };
 
         let block10 = create_block(BlockStatus::Volatile, 10, 10);


### PR DESCRIPTION
This PR introduces multi-asset decoding support in `tx_unpacker` for `TxOutput`. 

Main changes:
* Introduces `Value` struct:
  Holds a `lovelace` field alongside an `assets` vector of `NativeAsset`.
```
pub struct NativeAsset {
    pub policy_id: PolicyId,
    pub name: AssetName,  
    pub amount: u64,
}
```
* Adds `map_value()` in `tx_unpacker/src/map_parameters`:
  Decodes a Pallas `MultiEraValue`  into `Value`, supporting both lovelace and multi-asset balances. 
* Updates `TxOutput`:
  Changes the `value` field from `u64` (only lovelace) to `Value`.

`UTXODeltasMessage` now includes multi-asset outputs. A follow-up PR will extend  `utxo_state` to process and persist native asset balances. 