### PR TITLE
Add checking of pool metadata hash

### DIFF
--- a/modules/rest_blockfrost/Cargo.toml
+++ b/modules/rest_blockfrost/Cargo.toml
@@ -13,6 +13,7 @@ acropolis_common = { path = "../../common" }
 anyhow = "1.0"
 async-trait = "0.1"
 bech32 = "0.11"
+blake2 = "0.10.6"
 caryatid_sdk = "0.12"
 caryatid_module_rest_server = "0.14"
 config = "0.15.11"
@@ -21,7 +22,6 @@ serde = { version = "1.0.214", features = ["derive"] }
 serde_cbor = "0.11.2"
 serde_json = "1.0"
 serde_with = { version = "3.12.0", features = ["hex"] }
-sha2 = "0.10.9" 
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
 rust_decimal = "1.37.2"

--- a/modules/rest_blockfrost/Cargo.toml
+++ b/modules/rest_blockfrost/Cargo.toml
@@ -18,8 +18,10 @@ caryatid_module_rest_server = "0.14"
 config = "0.15.11"
 hex = "0.4.3"
 serde = { version = "1.0.214", features = ["derive"] }
+serde_cbor = "0.11.2"
 serde_json = "1.0"
 serde_with = { version = "3.12.0", features = ["hex"] }
+sha2 = "0.10.9" 
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
 rust_decimal = "1.37.2"

--- a/modules/rest_blockfrost/Cargo.toml
+++ b/modules/rest_blockfrost/Cargo.toml
@@ -19,7 +19,6 @@ caryatid_module_rest_server = "0.14"
 config = "0.15.11"
 hex = "0.4.3"
 serde = { version = "1.0.214", features = ["derive"] }
-serde_cbor = "0.11.2"
 serde_json = "1.0"
 serde_with = { version = "3.12.0", features = ["hex"] }
 tokio = { version = "1", features = ["full"] }

--- a/modules/rest_blockfrost/src/handlers/pools.rs
+++ b/modules/rest_blockfrost/src/handlers/pools.rs
@@ -587,6 +587,12 @@ pub async fn handle_pool_metadata_blockfrost(
         Duration::from_secs(handlers_config.external_api_timeout),
     )
     .await?;
+
+    // Verify hash of the fetched pool metadata, matches with the metadata hash provided by PoolRegistration
+    if let Err(e) = pool_metadata_json.verify(&pool_metadata.hash) {
+        return Ok(RESTResponse::with_text(400, &e));
+    }
+
     let pool_metadata_rest = PoolMetadataRest {
         pool_id: pool_id.to_string(),
         hex: hex::encode(spo),

--- a/modules/rest_blockfrost/src/handlers/pools.rs
+++ b/modules/rest_blockfrost/src/handlers/pools.rs
@@ -592,7 +592,7 @@ pub async fn handle_pool_metadata_blockfrost(
 
     // Verify hash of the fetched pool metadata, matches with the metadata hash provided by PoolRegistration
     if let Err(e) = verify_pool_metadata_hash(&pool_metadata_bytes, &pool_metadata.hash) {
-        return Ok(RESTResponse::with_text(400, &e));
+        return Ok(RESTResponse::with_text(404, &e));
     }
 
     // Convert bytes into an understandable PoolMetadata structure

--- a/modules/rest_blockfrost/src/handlers/pools.rs
+++ b/modules/rest_blockfrost/src/handlers/pools.rs
@@ -16,9 +16,11 @@ use caryatid_sdk::Context;
 use rust_decimal::Decimal;
 use std::{sync::Arc, time::Duration};
 
-use crate::types::{PoolEpochStateRest, PoolExtendedRest, PoolMetadataRest, PoolRetirementRest};
-use crate::utils::fetch_pool_metadata;
 use crate::{handlers_config::HandlersConfig, types::PoolRelayRest};
+use crate::{
+    types::{PoolEpochStateRest, PoolExtendedRest, PoolMetadataRest, PoolRetirementRest},
+    utils::{fetch_pool_metadata_as_bytes, verify_pool_metadata_hash, PoolMetadataJson},
+};
 
 /// Handle `/pools` Blockfrost-compatible endpoint
 pub async fn handle_pools_list_blockfrost(
@@ -582,16 +584,24 @@ pub async fn handle_pool_metadata_blockfrost(
     )
     .await?;
 
-    let pool_metadata_json = fetch_pool_metadata(
+    let pool_metadata_bytes = fetch_pool_metadata_as_bytes(
         pool_metadata.url.clone(),
         Duration::from_secs(handlers_config.external_api_timeout),
     )
     .await?;
 
     // Verify hash of the fetched pool metadata, matches with the metadata hash provided by PoolRegistration
-    if let Err(e) = pool_metadata_json.verify(&pool_metadata.hash) {
+    if let Err(e) = verify_pool_metadata_hash(&pool_metadata_bytes, &pool_metadata.hash) {
         return Ok(RESTResponse::with_text(400, &e));
     }
+
+    // Convert bytes into an understandable PoolMetadata structure
+    let Ok(pool_metadata_json) = PoolMetadataJson::try_from(pool_metadata_bytes) else {
+        return Ok(RESTResponse::with_text(
+            400,
+            &format!("Failed PoolMetadata Json conversion"),
+        ));
+    };
 
     let pool_metadata_rest = PoolMetadataRest {
         pool_id: pool_id.to_string(),

--- a/modules/rest_blockfrost/src/utils.rs
+++ b/modules/rest_blockfrost/src/utils.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use anyhow::Result;
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use sha2::Digest;
 
 #[derive(Serialize, Deserialize)]
 pub struct PoolMetadataJson {
@@ -10,6 +11,25 @@ pub struct PoolMetadataJson {
     pub name: String,
     pub description: String,
     pub homepage: String,
+}
+
+impl PoolMetadataJson {
+    /// verifies the calculated pool metadata hash, is similar to the expected hash
+    pub fn verify(&self, expected_hash: &acropolis_common::types::DataHash) -> Result<(), String> {
+        // convert to serialized cbor
+        let serialized_metadata = serde_cbor::to_vec(&self)
+            .map_err(|e| format!("Cannot serialize pool metadata json: {e:?}"))?;
+
+        // hash the serialized metadata
+        let hasher = sha2::Sha256::digest(serialized_metadata);
+        let actual_hash = hasher.as_slice();
+
+        if actual_hash == expected_hash {
+            return Ok(());
+        }
+
+        Err("pool metadata hash does not match to expected".into())
+    }
 }
 
 pub async fn fetch_pool_metadata(url: String, timeout: Duration) -> Result<PoolMetadataJson> {

--- a/modules/rest_blockfrost/src/utils.rs
+++ b/modules/rest_blockfrost/src/utils.rs
@@ -1,44 +1,91 @@
 use std::time::Duration;
 
 use anyhow::Result;
+use blake2::{
+    digest::{Update, VariableOutput},
+    Digest,
+};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
-use sha2::Digest;
 
 #[derive(Serialize, Deserialize)]
 pub struct PoolMetadataJson {
-    pub ticker: String,
     pub name: String,
     pub description: String,
+    pub ticker: String,
     pub homepage: String,
 }
 
-impl PoolMetadataJson {
-    /// verifies the calculated pool metadata hash, is similar to the expected hash
-    pub fn verify(&self, expected_hash: &acropolis_common::types::DataHash) -> Result<(), String> {
-        // convert to serialized cbor
-        let serialized_metadata = serde_cbor::to_vec(&self)
-            .map_err(|e| format!("Cannot serialize pool metadata json: {e:?}"))?;
+impl TryFrom<&[u8]> for PoolMetadataJson {
+    type Error = serde_json::Error;
 
-        // hash the serialized metadata
-        let hasher = sha2::Sha256::digest(serialized_metadata);
-        let actual_hash = hasher.as_slice();
-
-        if actual_hash == expected_hash {
-            return Ok(());
-        }
-
-        Err("pool metadata hash does not match to expected".into())
+    /// Returns `PoolMetadataJson`
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - Pool metadata (in json) as slice
+    fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
+        serde_json::from_slice::<Self>(value)
     }
 }
 
-pub async fn fetch_pool_metadata(url: String, timeout: Duration) -> Result<PoolMetadataJson> {
-    let client = Client::new();
-    let response = client.get(url).timeout(timeout).send().await?;
-    let body = response.json::<PoolMetadataJson>().await?;
-    Ok(body)
+impl TryFrom<Vec<u8>> for PoolMetadataJson {
+    type Error = serde_json::Error;
+
+    /// Returns `PoolMetadataJson`
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - Pool metadata (in json) as bytes
+    fn try_from(value: Vec<u8>) -> std::result::Result<Self, Self::Error> {
+        PoolMetadataJson::try_from(value.as_ref())
+    }
 }
 
+/// Fetches pool metadata
+///
+/// # Returns
+///
+/// * `Ok<Vec<u8>>` - pool metadata in bytes format
+pub async fn fetch_pool_metadata_as_bytes(url: String, timeout: Duration) -> Result<Vec<u8>> {
+    let client = Client::new();
+    let response = client.get(url).timeout(timeout).send().await?;
+    let body = response.bytes().await?;
+    Ok(body.to_vec())
+}
+
+/// Verifies the calculated pool metadata hash, is similar to the expected hash
+///
+/// # Arguments
+///
+/// * `pool_metadata` - The pool metadata as bytes
+/// * `expected_hash` - The expected hash of the `pool_metadata`
+///
+/// # Returns
+///
+/// * `Ok(())` - for successful verification
+/// * `Err(<error description>)` - for failed verifaction
+pub fn verify_pool_metadata_hash(
+    pool_metadata: &[u8],
+    expected_hash: &acropolis_common::types::DataHash,
+) -> Result<(), String> {
+    // hash the serialized metadata
+    let mut hasher = blake2::Blake2bVar::new(32).map_err(invalid_size_desc)?;
+    hasher.update(pool_metadata);
+
+    let mut hash = vec![0; 32];
+    hasher.finalize_variable(&mut hash).map_err(invalid_size_desc)?;
+
+    if &hash == expected_hash {
+        return Ok(());
+    }
+
+    Err("pool metadata hash does not match to expected".into())
+}
+
+fn invalid_size_desc<T: std::fmt::Display>(e: T) -> String {
+    format!("Invalid size for hashing pool metadata json {e}")
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,10 +94,29 @@ mod tests {
     async fn test_fetch_pool_metadata() {
         let url = "https://raw.githubusercontent.com/Octalus/cardano/master/p.json";
         let pool_metadata =
-            fetch_pool_metadata(url.to_string(), Duration::from_secs(3)).await.unwrap();
+            fetch_pool_metadata_as_bytes(url.to_string(), Duration::from_secs(3)).await.unwrap();
+
+        let pool_metadata = PoolMetadataJson::try_from(pool_metadata).expect("failed to convert");
+
         assert_eq!(pool_metadata.ticker, "OCTAS");
         assert_eq!(pool_metadata.name, "OctasPool");
         assert_eq!(pool_metadata.description, "Octa's Performance Pool");
         assert_eq!(pool_metadata.homepage, "https://octaluso.dyndns.org");
+    }
+
+    #[tokio::test]
+    async fn test_pool_metadata_hash_verify() {
+        let url = " https://880w.short.gy/clrsp.json ";
+
+        let expected_hash = "3c914463aa1cddb425fba48b21c4db31958ea7a30e077f756a82903f30e04905";
+        let expected_hash_as_arr = hex::decode(expected_hash).expect("should be able to decode {}");
+
+        let pool_metadata =
+            fetch_pool_metadata_as_bytes(url.to_string(), Duration::from_secs(3)).await.unwrap();
+
+        assert_eq!(
+            verify_pool_metadata_hash(&pool_metadata, &expected_hash_as_arr),
+            Ok(())
+        );
     }
 }


### PR DESCRIPTION
### 📋 Summary
This PR adds a checking to verify the hash of the pool metadata json fetch from the url, against the metadata hash in the `PoolRegistration`

### ✨ Features Changed
#### 1. `fn fetch_pool_metadata` to `fetch_pool_metadata_as_bytes`
- Getting the hash of the metadata, must come from the file (in bytes) itself. The hash changes if directly from `PoolMetadataJson`


### ✨ Features Added
#### 1.  `fn verify_pool_metadata_hash` 
- hashes (blake2b 256) the pool metadata bytes
- compare this actual hash, to the expected hash

#### 2. `TryFrom` implementation of`PoolMetadataJson`
- to be able to convert bytes to `PoolMetadataJson`

### 🔧 Technical Details
#### Dependencies
- added `blake2` to create a hash from the serialized `PoolMetadataJson`


### 🧪 Testing
add unit test case: `fn test_pool_metadata_hash_verify`

### 🔒 Error Handling
- **404 **: Hashes did not match

### 🚦 Backward Compatibility
- [ ]  No breaking changes to existing endpoints
- [ ]  Maintains existing API response structures
- [ ]  Preserves all current functionality

### 📝 Notes
