### PR TITLE
Add `timestamp` and `epoch_slot` to `BlockInfo`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,7 +124,7 @@ dependencies = [
  "config",
  "hex",
  "pallas",
- "reqwest 0.11.27",
+ "reqwest 0.12.23",
  "serde_json",
  "tokio",
  "tracing",

--- a/common/src/calculations.rs
+++ b/common/src/calculations.rs
@@ -6,7 +6,7 @@ const SHELLEY_START_EPOCH: u64 = 208;
 const BYRON_START_TIMESTAMP: u64 = 1506203091;
 
 /// Derive an epoch number from a slot, handling Byron/Shelley era changes
-pub fn slot_to_epoch(slot: u64) -> u64 {
+pub fn slot_to_epoch(slot: u64) -> (u64, u64) {
     slot_to_epoch_with_shelley_params(slot, SHELLEY_START_EPOCH, SHELLEY_SLOTS_PER_EPOCH)
 }
 
@@ -14,12 +14,16 @@ pub fn slot_to_epoch_with_shelley_params(
     slot: u64,
     shelley_epoch: u64,
     shelley_epoch_len: u64,
-) -> u64 {
+) -> (u64, u64) {
     let shelley_start_slot = shelley_epoch * BYRON_SLOTS_PER_EPOCH;
     if slot < shelley_start_slot {
-        slot / BYRON_SLOTS_PER_EPOCH
+        (slot / BYRON_SLOTS_PER_EPOCH, slot % BYRON_SLOTS_PER_EPOCH)
     } else {
-        shelley_epoch + (slot - shelley_start_slot) / shelley_epoch_len
+        let slots_since_shelley_start = slot - shelley_start_slot;
+        (
+            shelley_epoch + slots_since_shelley_start / shelley_epoch_len,
+            slots_since_shelley_start % shelley_epoch_len,
+        )
     }
 }
 
@@ -27,11 +31,7 @@ pub fn slot_to_timestamp(slot: u64) -> u64 {
     slot_to_timestamp_with_params(slot, BYRON_START_TIMESTAMP, SHELLEY_START_EPOCH)
 }
 
-pub fn slot_to_timestamp_with_params(
-    slot: u64,
-    byron_timestamp: u64,
-    shelley_epoch: u64,
-) -> u64 {
+pub fn slot_to_timestamp_with_params(slot: u64, byron_timestamp: u64, shelley_epoch: u64) -> u64 {
     let shelley_start_slot = shelley_epoch * BYRON_SLOTS_PER_EPOCH;
     if slot < shelley_start_slot {
         byron_timestamp + slot * 20
@@ -48,39 +48,39 @@ mod tests {
 
     #[test]
     fn byron_epoch_0() {
-        assert_eq!(slot_to_epoch(0), 0);
+        assert_eq!(slot_to_epoch(0), (0, 0));
         assert_eq!(slot_to_timestamp(0), 1506203091);
     }
 
     #[test]
     fn byron_epoch_1() {
-        assert_eq!(slot_to_epoch(21_600), 1);
+        assert_eq!(slot_to_epoch(21_600), (1, 0));
         assert_eq!(slot_to_timestamp(21_600), 1506635091);
     }
 
     #[test]
     fn byron_last_slot() {
-        assert_eq!(slot_to_epoch(4_492_799), 207);
+        assert_eq!(slot_to_epoch(4_492_799), (207, 21_599));
         assert_eq!(slot_to_timestamp(4_492_799), 1596059071);
     }
 
     #[test]
     fn shelley_first_slot() {
-        assert_eq!(slot_to_epoch(4_492_800), 208);
+        assert_eq!(slot_to_epoch(4_492_800), (208, 0));
         assert_eq!(slot_to_timestamp(4_492_800), 1596059091);
     }
 
     #[test]
     fn shelley_epoch_209_start() {
         // 432_000 slots later
-        assert_eq!(slot_to_epoch(4_492_800 + 432_000), 209);
+        assert_eq!(slot_to_epoch(4_492_800 + 432_000), (209, 0));
         assert_eq!(slot_to_timestamp(4_492_800 + 432_000), 1596491091);
     }
 
     #[test]
     fn mainnet_example_from_cexplorer() {
         // Slot 98_272_003 maps to epoch 425
-        assert_eq!(slot_to_epoch(98_272_003), 425);
+        assert_eq!(slot_to_epoch(98_272_003), (425, 35_203));
         assert_eq!(slot_to_timestamp(98_272_003), 1689838294);
     }
 }

--- a/common/src/calculations.rs
+++ b/common/src/calculations.rs
@@ -2,8 +2,8 @@
 
 const BYRON_SLOTS_PER_EPOCH: u64 = 21_600;
 pub const SHELLEY_SLOTS_PER_EPOCH: u64 = 432_000;
-const SHELLEY_START_SLOT: u64 = 4_492_800;
 const SHELLEY_START_EPOCH: u64 = 208;
+const BYRON_START_TIMESTAMP: u64 = 1506203091;
 
 /// Derive an epoch number from a slot, handling Byron/Shelley era changes
 pub fn slot_to_epoch(slot: u64) -> u64 {
@@ -23,6 +23,24 @@ pub fn slot_to_epoch_with_shelley_params(
     }
 }
 
+pub fn slot_to_timestamp(slot: u64) -> u64 {
+    slot_to_timestamp_with_params(slot, BYRON_START_TIMESTAMP, SHELLEY_START_EPOCH)
+}
+
+pub fn slot_to_timestamp_with_params(
+    slot: u64,
+    byron_timestamp: u64,
+    shelley_epoch: u64,
+) -> u64 {
+    let shelley_start_slot = shelley_epoch * BYRON_SLOTS_PER_EPOCH;
+    if slot < shelley_start_slot {
+        byron_timestamp + slot * 20
+    } else {
+        let shelley_timestamp = byron_timestamp + shelley_start_slot * 20;
+        shelley_timestamp + (slot - shelley_start_slot)
+    }
+}
+
 // -- Tests --
 #[cfg(test)]
 mod tests {
@@ -30,45 +48,39 @@ mod tests {
 
     #[test]
     fn byron_epoch_0() {
-        assert_eq!(0, slot_to_epoch(0));
+        assert_eq!(slot_to_epoch(0), 0);
+        assert_eq!(slot_to_timestamp(0), 1506203091);
     }
 
     #[test]
     fn byron_epoch_1() {
-        assert_eq!(1, slot_to_epoch(21_600));
+        assert_eq!(slot_to_epoch(21_600), 1);
+        assert_eq!(slot_to_timestamp(21_600), 1506635091);
     }
 
     #[test]
     fn byron_last_slot() {
         assert_eq!(slot_to_epoch(4_492_799), 207);
+        assert_eq!(slot_to_timestamp(4_492_799), 1596059071);
     }
 
     #[test]
     fn shelley_first_slot() {
         assert_eq!(slot_to_epoch(4_492_800), 208);
+        assert_eq!(slot_to_timestamp(4_492_800), 1596059091);
     }
 
     #[test]
     fn shelley_epoch_209_start() {
         // 432_000 slots later
         assert_eq!(slot_to_epoch(4_492_800 + 432_000), 209);
-    }
-
-    #[test]
-    fn before_transition_boundary() {
-        // One slot before Shelley starts
-        assert_eq!(slot_to_epoch(4_492_799), 207);
-    }
-
-    #[test]
-    fn after_transition_boundary() {
-        // First Shelley slot
-        assert_eq!(slot_to_epoch(4_492_800), 208);
+        assert_eq!(slot_to_timestamp(4_492_800 + 432_000), 1596491091);
     }
 
     #[test]
     fn mainnet_example_from_cexplorer() {
         // Slot 98_272_003 maps to epoch 425
         assert_eq!(slot_to_epoch(98_272_003), 425);
+        assert_eq!(slot_to_timestamp(98_272_003), 1689838294);
     }
 }

--- a/common/src/calculations.rs
+++ b/common/src/calculations.rs
@@ -1,15 +1,8 @@
 //! Common calculations for Cardano
 
 const BYRON_SLOTS_PER_EPOCH: u64 = 21_600;
-pub const SHELLEY_SLOTS_PER_EPOCH: u64 = 432_000;
-const SHELLEY_START_EPOCH: u64 = 208;
-const BYRON_START_TIMESTAMP: u64 = 1506203091;
 
 /// Derive an epoch number from a slot, handling Byron/Shelley era changes
-pub fn slot_to_epoch(slot: u64) -> (u64, u64) {
-    slot_to_epoch_with_shelley_params(slot, SHELLEY_START_EPOCH, SHELLEY_SLOTS_PER_EPOCH)
-}
-
 pub fn slot_to_epoch_with_shelley_params(
     slot: u64,
     shelley_epoch: u64,
@@ -27,10 +20,6 @@ pub fn slot_to_epoch_with_shelley_params(
     }
 }
 
-pub fn slot_to_timestamp(slot: u64) -> u64 {
-    slot_to_timestamp_with_params(slot, BYRON_START_TIMESTAMP, SHELLEY_START_EPOCH)
-}
-
 pub fn slot_to_timestamp_with_params(slot: u64, byron_timestamp: u64, shelley_epoch: u64) -> u64 {
     let shelley_start_slot = shelley_epoch * BYRON_SLOTS_PER_EPOCH;
     if slot < shelley_start_slot {
@@ -45,6 +34,17 @@ pub fn slot_to_timestamp_with_params(slot: u64, byron_timestamp: u64, shelley_ep
 #[cfg(test)]
 mod tests {
     use super::*;
+    const SHELLEY_START_EPOCH: u64 = 208;
+    const SHELLEY_SLOTS_PER_EPOCH: u64 = 432_000;
+    const BYRON_START_TIMESTAMP: u64 = 1506203091;
+
+    fn slot_to_epoch(slot: u64) -> (u64, u64) {
+        slot_to_epoch_with_shelley_params(slot, SHELLEY_START_EPOCH, SHELLEY_SLOTS_PER_EPOCH)
+    }
+
+    fn slot_to_timestamp(slot: u64) -> u64 {
+        slot_to_timestamp_with_params(slot, BYRON_START_TIMESTAMP, SHELLEY_START_EPOCH)
+    }
 
     #[test]
     fn byron_epoch_0() {

--- a/common/src/genesis_values.rs
+++ b/common/src/genesis_values.rs
@@ -1,0 +1,25 @@
+use crate::calculations::{slot_to_epoch_with_shelley_params, slot_to_timestamp_with_params};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct GenesisValues {
+    pub byron_timestamp: u64,
+    pub shelley_epoch: u64,
+    pub shelley_epoch_len: u64,
+}
+
+impl GenesisValues {
+    pub fn mainnet() -> Self {
+        Self {
+            byron_timestamp: 1506203091,
+            shelley_epoch: 208,
+            shelley_epoch_len: 432000,
+        }
+    }
+
+    pub fn slot_to_epoch(&self, slot: u64) -> (u64, u64) {
+        slot_to_epoch_with_shelley_params(slot, self.shelley_epoch, self.shelley_epoch_len)
+    }
+    pub fn slot_to_timestamp(&self, slot: u64) -> u64 {
+        slot_to_timestamp_with_params(slot, self.byron_timestamp, self.shelley_epoch)
+    }
+}

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -4,6 +4,7 @@ pub mod address;
 pub mod calculations;
 pub mod cip19;
 pub mod crypto;
+pub mod genesis_values;
 pub mod ledger_state;
 pub mod messages;
 pub mod params;

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -3,6 +3,7 @@
 // We don't use these messages in the acropolis_common crate itself
 #![allow(dead_code)]
 
+use crate::genesis_values::GenesisValues;
 use crate::ledger_state::SPOState;
 use crate::protocol_params::ProtocolParams;
 use crate::queries::parameters::{ParametersStateQuery, ParametersStateQueryResponse};
@@ -58,7 +59,9 @@ pub struct RawTxsMessage {
 
 /// Genesis completion message
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct GenesisCompleteMessage {}
+pub struct GenesisCompleteMessage {
+    pub values: GenesisValues,
+}
 
 /// Message encapsulating multiple UTXO deltas, in order
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -100,8 +100,14 @@ pub struct BlockInfo {
     /// Epoch number
     pub epoch: u64,
 
+    /// Epoch slot number
+    pub epoch_slot: u64,
+
     /// Does this block start a new epoch?
     pub new_epoch: bool,
+
+    /// UNIX timestamp
+    pub timestamp: u64,
 
     /// Protocol era
     pub era: Era,

--- a/modules/epoch_activity_counter/src/state.rs
+++ b/modules/epoch_activity_counter/src/state.rs
@@ -133,7 +133,9 @@ mod tests {
             number: 42,
             hash: Vec::new(),
             epoch,
+            epoch_slot: 99,
             new_epoch: false,
+            timestamp: 99999,
             era: Era::Conway,
         }
     }

--- a/modules/genesis_bootstrapper/Cargo.toml
+++ b/modules/genesis_bootstrapper/Cargo.toml
@@ -21,7 +21,9 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1.40"
 
 [build-dependencies]
-reqwest = { version = "0.11", features = ["blocking"] }
+anyhow = "1.0"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+tokio = { version = "1", features = ["full"] }
 
 [lib]
 path = "src/genesis_bootstrapper.rs"

--- a/modules/genesis_bootstrapper/build.rs
+++ b/modules/genesis_bootstrapper/build.rs
@@ -1,36 +1,60 @@
 // Build-time script to download generics
-use reqwest::blocking::get;
 use std::fs;
 use std::io::Write;
 use std::path::Path;
 
+use anyhow::{Context, Result};
+
 const OUTPUT_DIR: &str = "downloads";
 
 /// Download a URL to a file in OUTPUT_DIR
-fn download(url: &str, filename: &str) {
-    let response = get(url).expect("Failed to fetch {url}");
-    let data = response.text().expect("Failed to read response");
+async fn download(client: &reqwest::Client, url: &str, filename: &str) -> Result<()> {
+    let request = client.get(url).build().with_context(|| format!("Failed to request {url}"))?;
+    let response =
+        client.execute(request).await.with_context(|| format!("Failed to fetch {url}"))?;
+    let data = response.text().await.context("Failed to read response")?;
 
     let output_path = Path::new(OUTPUT_DIR);
     if !output_path.exists() {
-        fs::create_dir_all(output_path).expect("Failed to create {OUTPUT_DIR} directory");
+        fs::create_dir_all(output_path)
+            .with_context(|| format!("Failed to create {OUTPUT_DIR} directory"))?;
     }
 
     let file_path = output_path.join(filename);
-    let mut file = fs::File::create(&file_path).expect("Failed to create file {file_path}");
-    file.write_all(data.as_bytes()).expect("Failed to write file {file_path}");
+    let mut file = fs::File::create(&file_path)
+        .with_context(|| format!("Failed to create file {}", file_path.display()))?;
+    file.write_all(data.as_bytes())
+        .with_context(|| format!("Failed to write file {}", file_path.display()))?;
+    Ok(())
 }
 
-fn main() {
+#[tokio::main]
+async fn main() -> Result<()> {
     println!("cargo:rerun-if-changed=build.rs"); // Ensure the script runs if modified
+    let client = reqwest::Client::new();
 
-    download(
-        "https://book.world.dev.cardano.org/environments/mainnet/byron-genesis.json",
-        "mainnet-byron-genesis.json",
-    );
+    tokio::try_join!(
+        download(
+            &client,
+            "https://book.world.dev.cardano.org/environments/mainnet/byron-genesis.json",
+            "mainnet-byron-genesis.json",
+        ),
+        download(
+            &client,
+            "https://book.world.dev.cardano.org/environments/mainnet/shelley-genesis.json",
+            "mainnet-shelley-genesis.json",
+        ),
+        download(
+            &client,
+            "https://raw.githubusercontent.com/Hornan7/SanchoNet-Tutorials/refs/heads/main/genesis/byron-genesis.json",
+            "sanchonet-byron-genesis.json",
+        ),
+        download(
+            &client,
+            "https://raw.githubusercontent.com/Hornan7/SanchoNet-Tutorials/refs/heads/main/genesis/shelley-genesis.json",
+            "sanchonet-shelley-genesis.json",
+        )
+    )?;
 
-    download(
-        "https://raw.githubusercontent.com/Hornan7/SanchoNet-Tutorials/refs/heads/main/genesis/byron-genesis.json",
-        "sanchonet-byron-genesis.json",
-    );
+    Ok(())
 }

--- a/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
+++ b/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
@@ -91,7 +91,9 @@ impl GenesisBootstrapper {
                     number: 0,
                     hash: Vec::new(),
                     epoch: 0,
+                    epoch_slot: 0,
                     new_epoch: false,
+                    timestamp: genesis.start_time,
                     era: Era::Byron,
                 };
 

--- a/modules/governance_state/src/alonzo_babbage_voting.rs
+++ b/modules/governance_state/src/alonzo_babbage_voting.rs
@@ -138,8 +138,10 @@ mod tests {
                 slot,
                 number: slot,
                 epoch,
+                epoch_slot: epoch % 432_000,
                 era: era.try_into()?,
                 new_epoch: new_epoch != 0,
+                timestamp: 0,
                 hash: Vec::new(),
             };
 

--- a/modules/governance_state/src/state.rs
+++ b/modules/governance_state/src/state.rs
@@ -77,6 +77,9 @@ impl State {
         &mut self,
         message: &ProtocolParamsMessage,
     ) -> Result<()> {
+        if let Some(shelley) = &message.params.shelley {
+            self.alonzo_babbage_voting.update_shelley_slots_per_epoch(shelley.epoch_length as u64);
+        }
         if message.params.conway.is_some() {
             self.conway = message.params.conway.clone();
         }

--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -2,7 +2,7 @@
 //! Fetches a snapshot from Mithril and replays all the blocks in it
 
 use acropolis_common::{
-    calculations::slot_to_epoch,
+    calculations::{slot_to_epoch, slot_to_timestamp},
     messages::{BlockBodyMessage, BlockHeaderMessage, CardanoMessage, Message},
     BlockInfo, BlockStatus, Era,
 };
@@ -290,7 +290,7 @@ impl MithrilSnapshotFetcher {
                         }
                         last_block_number = number;
 
-                        let (epoch, _epoch_slot) = slot_to_epoch(slot);
+                        let (epoch, epoch_slot) = slot_to_epoch(slot);
                         let new_epoch = match last_epoch {
                             Some(last_epoch) => epoch != last_epoch,
                             None => true,
@@ -300,6 +300,8 @@ impl MithrilSnapshotFetcher {
                         if new_epoch {
                             info!(epoch, number, slot, "New epoch");
                         }
+
+                        let timestamp = slot_to_timestamp(slot);
 
                         let era = match block.era() {
                             PallasEra::Byron => Era::Byron,
@@ -317,7 +319,9 @@ impl MithrilSnapshotFetcher {
                             number,
                             hash: block.hash().to_vec(),
                             epoch,
+                            epoch_slot,
                             new_epoch,
+                            timestamp,
                             era,
                         };
 

--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -290,7 +290,7 @@ impl MithrilSnapshotFetcher {
                         }
                         last_block_number = number;
 
-                        let epoch = slot_to_epoch(slot);
+                        let (epoch, _epoch_slot) = slot_to_epoch(slot);
                         let new_epoch = match last_epoch {
                             Some(last_epoch) => epoch != last_epoch,
                             None => true,

--- a/modules/spo_state/src/test_utils.rs
+++ b/modules/spo_state/src/test_utils.rs
@@ -50,7 +50,9 @@ pub fn new_block(epoch: u64) -> BlockInfo {
         number: 10 * epoch,
         hash: Vec::<u8>::new(),
         epoch,
+        epoch_slot: 0,
         new_epoch: true,
+        timestamp: epoch,
         era: Era::Byron,
     }
 }

--- a/modules/stake_delta_filter/src/utils.rs
+++ b/modules/stake_delta_filter/src/utils.rs
@@ -541,7 +541,9 @@ mod test {
             number: 1,
             hash: vec![],
             epoch: 1,
+            epoch_slot: 14243,
             new_epoch: true,
+            timestamp: 2498243,
             era: Era::Conway,
         };
 

--- a/modules/upstream_chain_fetcher/src/body_fetcher.rs
+++ b/modules/upstream_chain_fetcher/src/body_fetcher.rs
@@ -83,7 +83,7 @@ impl BodyFetcher {
         let number = header.number();
         let hash = header.hash().to_vec();
 
-        let epoch = self.cfg.slot_to_epoch(slot);
+        let (epoch, _epoch_slot) = self.cfg.slot_to_epoch(slot);
         let new_epoch = match self.last_epoch {
             Some(last_epoch) => epoch != last_epoch,
             None => true,

--- a/modules/upstream_chain_fetcher/src/body_fetcher.rs
+++ b/modules/upstream_chain_fetcher/src/body_fetcher.rs
@@ -83,12 +83,13 @@ impl BodyFetcher {
         let number = header.number();
         let hash = header.hash().to_vec();
 
-        let (epoch, _epoch_slot) = self.cfg.slot_to_epoch(slot);
+        let (epoch, epoch_slot) = self.cfg.slot_to_epoch(slot);
         let new_epoch = match self.last_epoch {
             Some(last_epoch) => epoch != last_epoch,
             None => true,
         };
         self.last_epoch = Some(epoch);
+        let timestamp = self.cfg.slot_to_timestamp(slot);
 
         if new_epoch {
             info!(epoch, number, slot, "New epoch");
@@ -116,7 +117,9 @@ impl BodyFetcher {
             number,
             hash: hash.clone(),
             epoch,
+            epoch_slot,
             new_epoch,
+            timestamp,
             era,
         };
 

--- a/modules/upstream_chain_fetcher/src/upstream_cache.rs
+++ b/modules/upstream_chain_fetcher/src/upstream_cache.rs
@@ -184,7 +184,9 @@ mod test {
             number: n,
             hash: vec![],
             epoch: 0,
+            epoch_slot: n,
             new_epoch: false,
+            timestamp: n,
             era: Era::default(),
         }
     }

--- a/modules/upstream_chain_fetcher/src/upstream_chain_fetcher.rs
+++ b/modules/upstream_chain_fetcher/src/upstream_chain_fetcher.rs
@@ -2,6 +2,7 @@
 //! Multi-connection, multi-protocol client interface to the Cardano node
 
 use acropolis_common::{
+    genesis_values::GenesisValues,
     messages::{CardanoMessage, Message},
     BlockInfo,
 };
@@ -141,6 +142,18 @@ impl UpstreamChainFetcher {
         Ok(last_block)
     }
 
+    async fn wait_genesis_completion(
+        subscription: &mut Box<dyn Subscription<Message>>,
+    ) -> Result<GenesisValues> {
+        let (_, message) = subscription.read().await?;
+        match message.as_ref() {
+            Message::Cardano((_, CardanoMessage::GenesisComplete(complete))) => {
+                Ok(complete.values.clone())
+            }
+            msg => bail!("Unexpected message in genesis completion topic: {msg:?}"),
+        }
+    }
+
     async fn wait_snapshot_completion(
         subscription: &mut Box<dyn Subscription<Message>>,
     ) -> Result<Option<BlockInfo>> {
@@ -209,8 +222,13 @@ impl UpstreamChainFetcher {
 
     /// Main init function
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        let cfg = FetcherConfig::new(context.clone(), config)?;
-        let mut subscription = match cfg.sync_point {
+        let mut cfg = FetcherConfig::new(context.clone(), config)?;
+        let genesis_complete = if cfg.genesis_values.is_none() {
+            Some(cfg.context.subscribe(&cfg.genesis_completion_topic).await?)
+        } else {
+            None
+        };
+        let mut snapshot_complete = match cfg.sync_point {
             SyncPoint::Snapshot => {
                 Some(cfg.context.subscribe(&cfg.snapshot_completion_topic).await?)
             }
@@ -218,7 +236,14 @@ impl UpstreamChainFetcher {
         };
 
         context.clone().run(async move {
-            Self::run_chain_sync(cfg, &mut subscription)
+            if let Some(mut genesis_complete) = genesis_complete {
+                let genesis = Self::wait_genesis_completion(&mut genesis_complete)
+                    .await
+                    .unwrap_or_else(|err| panic!("could not fetch genesis: {err}"));
+                cfg.genesis_values = Some(genesis);
+            }
+            let cfg = Arc::new(cfg);
+            Self::run_chain_sync(cfg, &mut snapshot_complete)
                 .await
                 .unwrap_or_else(|e| error!("Chain sync failed: {e}"));
         });

--- a/modules/upstream_chain_fetcher/src/upstream_chain_fetcher.rs
+++ b/modules/upstream_chain_fetcher/src/upstream_chain_fetcher.rs
@@ -62,8 +62,8 @@ impl UpstreamChainFetcher {
         let mut response_count = 0;
 
         let last_epoch: Option<u64> = match slot {
-            0 => None,                          // If we're starting from origin
-            _ => Some(cfg.slot_to_epoch(slot)), // From slot of last block
+            0 => None,                            // If we're starting from origin
+            _ => Some(cfg.slot_to_epoch(slot).0), // From slot of last block
         };
 
         let (sender, receiver) = bounded(MAX_BODY_FETCHER_CHANNEL_LENGTH);

--- a/modules/upstream_chain_fetcher/src/utils.rs
+++ b/modules/upstream_chain_fetcher/src/utils.rs
@@ -92,7 +92,7 @@ impl FetcherConfig {
         }))
     }
 
-    pub fn slot_to_epoch(&self, slot: u64) -> u64 {
+    pub fn slot_to_epoch(&self, slot: u64) -> (u64, u64) {
         slot_to_epoch_with_shelley_params(slot, self.shelley_epoch, self.shelley_epoch_len)
     }
 }

--- a/modules/upstream_chain_fetcher/src/utils.rs
+++ b/modules/upstream_chain_fetcher/src/utils.rs
@@ -1,5 +1,7 @@
 use crate::UpstreamCacheRecord;
-use acropolis_common::calculations::slot_to_epoch_with_shelley_params;
+use acropolis_common::calculations::{
+    slot_to_epoch_with_shelley_params, slot_to_timestamp_with_params,
+};
 use acropolis_common::messages::{CardanoMessage, Message};
 use anyhow::{anyhow, bail, Result};
 use caryatid_sdk::Context;
@@ -20,6 +22,7 @@ const DEFAULT_MAGIC_NUMBER: (&str, u64) = ("magic-number", 764824073);
 const DEFAULT_SYNC_POINT: (&str, SyncPoint) = ("sync-point", SyncPoint::Snapshot);
 const DEFAULT_CACHE_DIR: (&str, &str) = ("cache-dir", "upstream-cache");
 
+const DEFAULT_BYRON_TIMESTAMP: (&str, u64) = ("byron-timestamp", 1506203091);
 const DEFAULT_SHELLEY_EPOCH: (&str, u64) = ("shelley-epoch", 208);
 const DEFAULT_SHELLEY_EPOCH_LEN: (&str, u64) = ("shelley-epoch-len", 432000);
 
@@ -45,6 +48,7 @@ pub struct FetcherConfig {
     pub magic_number: u64,
     pub cache_dir: String,
 
+    pub byron_timestamp: u64,
     pub shelley_epoch: u64,
     pub shelley_epoch_len: u64,
 }
@@ -83,6 +87,9 @@ impl FetcherConfig {
                 .unwrap_or(DEFAULT_MAGIC_NUMBER.1),
             node_address: Self::conf(&config, DEFAULT_NODE_ADDRESS),
             cache_dir: Self::conf(&config, DEFAULT_CACHE_DIR),
+            byron_timestamp: config
+                .get::<u64>(DEFAULT_BYRON_TIMESTAMP.0)
+                .unwrap_or(DEFAULT_BYRON_TIMESTAMP.1),
             shelley_epoch: config
                 .get::<u64>(DEFAULT_SHELLEY_EPOCH.0)
                 .unwrap_or(DEFAULT_SHELLEY_EPOCH.1),
@@ -94,6 +101,10 @@ impl FetcherConfig {
 
     pub fn slot_to_epoch(&self, slot: u64) -> (u64, u64) {
         slot_to_epoch_with_shelley_params(slot, self.shelley_epoch, self.shelley_epoch_len)
+    }
+
+    pub fn slot_to_timestamp(&self, slot: u64) -> u64 {
+        slot_to_timestamp_with_params(slot, self.byron_timestamp, self.shelley_epoch)
     }
 }
 

--- a/modules/utxo_state/src/state.rs
+++ b/modules/utxo_state/src/state.rs
@@ -414,7 +414,9 @@ mod tests {
             number,
             hash: vec![],
             epoch: 99,
+            epoch_slot: slot,
             new_epoch: false,
+            timestamp: slot,
             era: Era::Byron,
         }
     }

--- a/processes/golden_tests/src/test_module.rs
+++ b/processes/golden_tests/src/test_module.rs
@@ -48,7 +48,9 @@ impl TestModule {
                 number: 1,
                 hash: vec![],
                 epoch: 1,
+                epoch_slot: 1,
                 new_epoch: false,
+                timestamp: 1,
                 era: Era::Conway,
             },
             CardanoMessage::ReceivedTxs(RawTxsMessage {

--- a/processes/omnibus/omnibus-sancho.toml
+++ b/processes/omnibus/omnibus-sancho.toml
@@ -15,8 +15,6 @@ network-name = "sanchonet" # "sanchonet", "mainnet"
 sync-point = "cache" #"cache" # "origin", "tip", "snapshot"
 node-address = "sancho-testnet.able-pool.io:6002"
 magic-number = 4
-shelley-epoch = 0
-shelley-epoch-len = 86400
 
 [module.block-unpacker]
 


### PR DESCRIPTION
Add two useful fields to the common `BlockInfo` struct attached to all Cardano messages: `epoch_slot` and `timestamp`. These fields can both be computed from the `slot`, but only with access to some values populated at genesis. (This is also true for the existing `epoch` field).

This PR also ensures that we compute these values correctly: we create a `GenesisValues` struct in `genesis-bootstrapper`, and read it in modules which need it (`mithril-snapshot-fetcher` and `upstream-chain-fetcher`). This'll make it easier to run in other environments down the road.

@shd if you want to keep running `upstream-chain-fetcher` independently, you need to set `"byron-timestamp"` in your local config. The fetcher still reads genesis values from local config, but it'll wait for `genesis-bootstrapper` to run to use values from there if any of those values are missing from local config.

Fixes #147 