### PR TITLE
Use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,7 +22,7 @@ dependencies = [
  "futures",
  "gcd",
  "hex",
- "imbl 5.0.0",
+ "imbl",
  "lf-queue",
  "minicbor 0.26.5",
  "num-rational",
@@ -46,7 +46,7 @@ dependencies = [
  "chrono",
  "config",
  "hex",
- "imbl 5.0.0",
+ "imbl",
  "serde",
  "serde_json",
  "serde_with 3.14.0",
@@ -62,7 +62,7 @@ dependencies = [
  "anyhow",
  "caryatid_sdk",
  "config",
- "imbl 5.0.0",
+ "imbl",
  "tokio",
  "tracing",
 ]
@@ -89,7 +89,7 @@ dependencies = [
  "caryatid_sdk",
  "config",
  "hex",
- "imbl 5.0.0",
+ "imbl",
  "serde",
  "serde_json",
  "tokio",
@@ -122,7 +122,7 @@ dependencies = [
  "config",
  "dashmap",
  "hex",
- "imbl 6.0.0",
+ "imbl",
  "pallas",
  "serde",
  "serde_json",
@@ -249,7 +249,7 @@ dependencies = [
  "caryatid_sdk",
  "config",
  "hex",
- "imbl 5.0.0",
+ "imbl",
  "serde_json",
  "tokio",
  "tracing",
@@ -265,7 +265,7 @@ dependencies = [
  "config",
  "dashmap",
  "hex",
- "imbl 5.0.0",
+ "imbl",
  "rayon",
  "serde",
  "serde_json",
@@ -285,8 +285,7 @@ dependencies = [
  "caryatid_sdk",
  "config",
  "hex",
- "pallas-addresses",
- "pallas-crypto",
+ "pallas",
  "serde",
  "serde_json",
  "serde_json_any_key",
@@ -385,7 +384,6 @@ dependencies = [
  "opentelemetry_sdk",
  "serde",
  "serde_json",
- "tikv-jemallocator",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -453,7 +451,6 @@ dependencies = [
  "chrono",
  "config",
  "hex",
- "minicbor 0.26.5",
  "serde",
  "serde_json",
  "tokio",
@@ -2812,20 +2809,6 @@ dependencies = [
  "rand_core 0.9.3",
  "rand_xoshiro",
  "serde",
- "version_check",
-]
-
-[[package]]
-name = "imbl"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33afdc5d333c1a43f1f640bfc6ad3788729e5b2f18472e5d33a9187315257f8e"
-dependencies = [
- "archery",
- "bitmaps",
- "imbl-sized-chunks",
- "rand_core 0.9.3",
- "rand_xoshiro",
  "version_check",
 ]
 
@@ -5625,26 +5608,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
-]
-
-[[package]]
-name = "tikv-jemalloc-sys"
-version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "tikv-jemallocator"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
-dependencies = [
- "libc",
- "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,4 +28,25 @@ members = [
     "processes/golden_tests", #All-inclusive golden tests process
 ]
 
+[workspace.dependencies]
+caryatid_sdk = "0.12"
+caryatid_process = "0.12"
+caryatid_module_rest_server = "0.14"
+caryatid_module_clock = "0.12"
+caryatid_module_spy = "0.12"
+anyhow = "1.0"
+chrono = "0.4"
+config = "0.15.11"
+dashmap = "6.1.0"
+hex = "0.4"
+imbl = { version = "5.0.0", features = ["serde"] }
+pallas = "0.32.1"
+pallas-addresses = "0.32.0"
+pallas-crypto = "0.32.0"
+serde = { version = "1.0.214", features = ["derive"] }
+serde_json = "1.0.132"
+serde_with = { version = "3.12.0", features = ["hex"] }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1.40"
+
 resolver = "2"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,32 +9,33 @@ description = "Common types, messages and helpers for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-anyhow = "1.0"
+caryatid_sdk = { workspace = true }
+caryatid_module_clock = { workspace = true }
+caryatid_module_rest_server = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1"
 bech32 = "0.11"
 bigdecimal = "0.4.8"
 bitmask-enum = "2.2"
 blake2 = "0.10"
 bs58 = "0.5"
-caryatid_sdk = "0.12"
-caryatid_module_clock = "0.12"
-caryatid_module_rest_server = "0.14"
-chrono = "0.4"
+chrono = { workspace = true }
 gcd = "2.3"
 fraction = "0.15"
-hex = "0.4"
+hex = { workspace = true }
 lf-queue = "0.1.0"
 num-rational = { version = "0.4.2", features = ["serde"] }
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0"
-serde_with = { version = "3.12.0", features = ["hex", "base64"] }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["base64"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
 futures = "0.3.31"
 minicbor = { version = "0.26.0", features = ["std", "half", "derive"] }
 num-traits = "0.2"
-imbl = { version = "5.0.0", features = ["serde"] }
-dashmap = "6.1.0"
+imbl = { workspace = true }
+dashmap = { workspace = true }
 rayon = "1.11.0"
 
 [lib]

--- a/ledger-state/cddl-codegen/rust/Cargo.toml
+++ b/ledger-state/cddl-codegen/rust/Cargo.toml
@@ -8,4 +8,4 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 cbor_event = "2.4.0"
-hex = "0.4.3"
+hex = { workspace = true }

--- a/modules/README.md
+++ b/modules/README.md
@@ -69,10 +69,10 @@ license = "Apache-2.0"
 [dependencies]
 caryatid_sdk = "0.4.0"
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
+anyhow = { workspace = true }
 async-trait = "0.1"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
+tokio = { workspace = true }
+config = { workspace = true }
 tracing = "0.1.40"
 
 [lib]

--- a/modules/accounts_state/Cargo.toml
+++ b/modules/accounts_state/Cargo.toml
@@ -9,19 +9,21 @@ description = "Stake and rewards accounts state Tracker"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-serde_with = { version = "3.12.0", features = ["hex"] }
-hex = "0.4.3"
-imbl = { version = "5.0.0", features = ["serde"] }
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
 bigdecimal = "0.4.8"
-chrono = "0.4.41"
+chrono = { workspace = true }
+config = { workspace = true }
+hex = { workspace = true }
+imbl = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/accounts_state.rs"

--- a/modules/assets_state/Cargo.toml
+++ b/modules/assets_state/Cargo.toml
@@ -9,13 +9,15 @@ description = "Native Asset State Tracker"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-config = "0.15.11"
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
-anyhow = "1.0"
-imbl = { version = "5.0.0", features = ["serde"] }
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+imbl = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/assets_state.rs"

--- a/modules/block_unpacker/Cargo.toml
+++ b/modules/block_unpacker/Cargo.toml
@@ -9,13 +9,15 @@ description = "Block unpacker Caryatid module for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.1"
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+pallas = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/block_unpacker.rs"

--- a/modules/drdd_state/Cargo.toml
+++ b/modules/drdd_state/Cargo.toml
@@ -9,16 +9,18 @@ description = "DRep Pool Delegation Distribution State Tracker"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
-config = "0.15.11"
-anyhow = "1.0"
 acropolis_common = { path = "../../common" }
-tracing = "0.1.40"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-hex = "0.4.3"
-imbl = { version = "5.0.0", features = ["serde"] }
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+hex = { workspace = true }
+imbl = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/drdd_state.rs"

--- a/modules/drep_state/Cargo.toml
+++ b/modules/drep_state/Cargo.toml
@@ -9,16 +9,18 @@ description = "DRep State Tracker"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-serde_with = { version = "3.12.0", features = ["hex"] }
-hex = "0.4.3"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/drep_state.rs"

--- a/modules/epochs_state/Cargo.toml
+++ b/modules/epochs_state/Cargo.toml
@@ -9,18 +9,20 @@ description = "Epochs state Caryatid module for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.1"
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-hex = "0.4.3"
-dashmap = "6.1.0"
-imbl = "6.0.0"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+dashmap = { workspace = true }
+hex = { workspace = true }
+imbl = { workspace = true }
+pallas = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/epochs_state.rs"

--- a/modules/genesis_bootstrapper/Cargo.toml
+++ b/modules/genesis_bootstrapper/Cargo.toml
@@ -11,19 +11,21 @@ build = "build.rs"
 
 [dependencies]
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
-caryatid_sdk = "0.12"
-config = "0.15.11"
-hex = "0.4"
-pallas = "0.32.1"
-serde_json = "1.0.138"
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+hex = { workspace = true }
+pallas = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
-anyhow = "1.0"
+anyhow = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 
 [lib]
 path = "src/genesis_bootstrapper.rs"

--- a/modules/governance_state/Cargo.toml
+++ b/modules/governance_state/Cargo.toml
@@ -9,17 +9,19 @@ description = "Governance State Tracker"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0"
-serde_with = { version = "3.12.0", features = ["hex","base64"] }
-hex = "0.4.3"
+config = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["base64"] }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/governance_state.rs"

--- a/modules/mithril_snapshot_fetcher/Cargo.toml
+++ b/modules/mithril_snapshot_fetcher/Cargo.toml
@@ -9,17 +9,19 @@ description = "Mithril snapshot fetcher Caryatid module for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = { version = "0.32.0", features = ["hardano"] }
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde_json = "1.0.138"
-mithril-client = { version = "0.12", features = ["fs"] }
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1.86"
-chrono = "0.4.41"
+chrono = { workspace = true }
+config = { workspace = true }
+mithril-client = { version = "0.12", features = ["fs"] }
+pallas = { version = "0.32.0", features = ["hardano"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/modules/parameters_state/Cargo.toml
+++ b/modules/parameters_state/Cargo.toml
@@ -11,18 +11,20 @@ build = "build.rs"
 
 [dependencies]
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1"
-caryatid_sdk = "0.12"
-config = "0.15.11"
-hex = "0.4.3"
+config = { workspace = true }
+hex = { workspace = true }
 num-rational = "0.4.2"
-pallas = "0.32.1"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0"
-serde_with = { version = "3.12.0", features = ["hex"] }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
+pallas = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [build-dependencies]
 reqwest = { version = "0.11", features = ["blocking"] }

--- a/modules/rest_blockfrost/Cargo.toml
+++ b/modules/rest_blockfrost/Cargo.toml
@@ -10,22 +10,24 @@ license = "Apache-2.0"
 
 [dependencies]
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
+
+caryatid_sdk = { workspace = true }
+caryatid_module_rest_server = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1"
 bech32 = "0.11"
 blake2 = "0.10.6"
-caryatid_sdk = "0.12"
-caryatid_module_rest_server = "0.14"
-config = "0.15.11"
-hex = "0.4.3"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0"
-serde_with = { version = "3.12.0", features = ["hex"] }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
-rust_decimal = "1.37.2"
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+config = { workspace = true }
+hex = { workspace = true }
 num-traits = "0.2"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+rust_decimal = "1.37.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/rest_blockfrost.rs"

--- a/modules/snapshot_bootstrapper/Cargo.toml
+++ b/modules/snapshot_bootstrapper/Cargo.toml
@@ -9,16 +9,18 @@ description = "Snapshot bootstrapper Caryatid module for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-hex = "0.4"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
 fraction = "0.15"
-pallas = "0.32.0"
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde_json = "1.0.138"
+hex = { workspace = true }
+pallas = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/snapshot_bootstrapper.rs"

--- a/modules/spdd_state/Cargo.toml
+++ b/modules/spdd_state/Cargo.toml
@@ -9,15 +9,17 @@ description = "Stake Pool Delegation Distribution State Tracker"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
-config = "0.15.11"
-anyhow = "1.0"
 acropolis_common = { path = "../../common" }
-tracing = "0.1.40"
-tokio = { version = "1", features = ["full"] }
-serde_json = "1.0.132"
-hex = "0.4.3"
-imbl = { version = "5.0.0", features = ["serde"] }
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+hex = { workspace = true }
+imbl = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+serde_json = { workspace = true }
 
 [lib]
 path = "src/spdd_state.rs"

--- a/modules/spo_state/Cargo.toml
+++ b/modules/spo_state/Cargo.toml
@@ -9,19 +9,21 @@ description = "SPO State Tracker"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-serde_with = { version = "3.12.0", features = ["hex"] }
-hex = "0.4.3"
-imbl = { version = "5.0.0", features = ["serde"] }
-dashmap = "6.1.0"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+dashmap = { workspace = true }
+hex = { workspace = true }
+imbl = { workspace = true }
 rayon = "1.11.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/spo_state.rs"

--- a/modules/stake_delta_filter/Cargo.toml
+++ b/modules/stake_delta_filter/Cargo.toml
@@ -10,20 +10,21 @@ license = "Apache-2.0"
 
 [dependencies]
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1"
 bech32 = "0.11"
-caryatid_sdk = "0.12"
-config = "0.15.11"
-hex = "0.4.3"
-pallas-addresses = "0.32.0"
-pallas-crypto = "0.32.0"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
+config = { workspace = true }
+hex = { workspace = true }
+pallas = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 serde_json_any_key = "2.0.0"
-serde_with = { version = "3.12.0", features = ["hex"] }
-tokio = { version = "1", features = ["full"] }
-tracing = "0.1.40"
+serde_with = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/stake_delta_filter.rs"

--- a/modules/stake_delta_filter/src/utils.rs
+++ b/modules/stake_delta_filter/src/utils.rs
@@ -407,7 +407,7 @@ mod test {
     use bech32::{Bech32, Hrp};
 
     fn parse_addr(s: &str) -> Result<AddressDelta> {
-        let a = pallas_addresses::Address::from_bech32(s)?;
+        let a = pallas::ledger::addresses::Address::from_bech32(s)?;
         Ok(AddressDelta {
             address: map_address(&a)?,
             delta: ValueDelta::new(1, Vec::new()),
@@ -415,10 +415,11 @@ mod test {
     }
 
     /// Map Pallas Network to our AddressNetwork
-    fn map_network(network: pallas_addresses::Network) -> Result<AddressNetwork> {
+    fn map_network(network: pallas::ledger::addresses::Network) -> Result<AddressNetwork> {
+        use pallas::ledger::addresses::Network;
         match network {
-            pallas_addresses::Network::Mainnet => Ok(AddressNetwork::Main),
-            pallas_addresses::Network::Testnet => Ok(AddressNetwork::Test),
+            Network::Mainnet => Ok(AddressNetwork::Main),
+            Network::Testnet => Ok(AddressNetwork::Test),
             _ => return Err(anyhow!("Unknown network in address")),
         }
     }
@@ -426,36 +427,37 @@ mod test {
     /// Derive our Address from a Pallas address
     // This is essentially a 1:1 mapping but makes the Message definitions independent
     // of Pallas
-    fn map_address(address: &pallas_addresses::Address) -> Result<Address> {
+    fn map_address(address: &pallas::ledger::addresses::Address) -> Result<Address> {
+        use pallas::ledger::addresses;
         match address {
-            pallas_addresses::Address::Byron(byron_address) => Ok(Address::Byron(ByronAddress {
+            addresses::Address::Byron(byron_address) => Ok(Address::Byron(ByronAddress {
                 payload: byron_address.payload.to_vec(),
             })),
 
-            pallas_addresses::Address::Shelley(shelley_address) => {
+            addresses::Address::Shelley(shelley_address) => {
                 Ok(Address::Shelley(ShelleyAddress {
                     network: map_network(shelley_address.network())?,
 
                     payment: match shelley_address.payment() {
-                        pallas_addresses::ShelleyPaymentPart::Key(hash) => {
+                        addresses::ShelleyPaymentPart::Key(hash) => {
                             ShelleyAddressPaymentPart::PaymentKeyHash(hash.to_vec())
                         }
-                        pallas_addresses::ShelleyPaymentPart::Script(hash) => {
+                        addresses::ShelleyPaymentPart::Script(hash) => {
                             ShelleyAddressPaymentPart::ScriptHash(hash.to_vec())
                         }
                     },
 
                     delegation: match shelley_address.delegation() {
-                        pallas_addresses::ShelleyDelegationPart::Null => {
+                        addresses::ShelleyDelegationPart::Null => {
                             ShelleyAddressDelegationPart::None
                         }
-                        pallas_addresses::ShelleyDelegationPart::Key(hash) => {
+                        addresses::ShelleyDelegationPart::Key(hash) => {
                             ShelleyAddressDelegationPart::StakeKeyHash(hash.to_vec())
                         }
-                        pallas_addresses::ShelleyDelegationPart::Script(hash) => {
+                        addresses::ShelleyDelegationPart::Script(hash) => {
                             ShelleyAddressDelegationPart::ScriptHash(hash.to_vec())
                         }
-                        pallas_addresses::ShelleyDelegationPart::Pointer(pointer) => {
+                        addresses::ShelleyDelegationPart::Pointer(pointer) => {
                             ShelleyAddressDelegationPart::Pointer(ShelleyAddressPointer {
                                 slot: pointer.slot(),
                                 tx_index: pointer.tx_idx(),
@@ -466,13 +468,13 @@ mod test {
                 }))
             }
 
-            pallas_addresses::Address::Stake(stake_address) => Ok(Address::Stake(StakeAddress {
+            addresses::Address::Stake(stake_address) => Ok(Address::Stake(StakeAddress {
                 network: map_network(stake_address.network())?,
                 payload: match stake_address.payload() {
-                    pallas_addresses::StakePayload::Stake(hash) => {
+                    addresses::StakePayload::Stake(hash) => {
                         StakeAddressPayload::StakeKeyHash(hash.to_vec())
                     }
-                    pallas_addresses::StakePayload::Script(hash) => {
+                    addresses::StakePayload::Script(hash) => {
                         StakeAddressPayload::ScriptHash(hash.to_vec())
                     }
                 },
@@ -482,7 +484,7 @@ mod test {
 
     fn key_to_keyhash(prefix: &str, key: &str) -> String {
         let (_hrp, key_vec) = bech32::decode(key).unwrap();
-        let hash_vec = pallas_crypto::hash::Hasher::<224>::hash(&key_vec);
+        let hash_vec = pallas::crypto::hash::Hasher::<224>::hash(&key_vec);
         let prefix_hrp: Hrp = Hrp::parse(prefix).unwrap();
         bech32::encode::<Bech32>(prefix_hrp, &hash_vec.to_vec()).unwrap()
     }

--- a/modules/tx_unpacker/Cargo.toml
+++ b/modules/tx_unpacker/Cargo.toml
@@ -9,18 +9,20 @@ description = "Transaction unpacker Caryatid module for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.1"
-anyhow = "1.0"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-serde = { version = "1.0.219", features = ["derive"] }
-serde_json = "1.0"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1"
+config = { workspace = true }
 futures = "0.3.31"
-hex = "0.4.3"
+hex = { workspace = true }
+pallas = { workspace = true }
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/tx_unpacker.rs"

--- a/modules/upstream_chain_fetcher/Cargo.toml
+++ b/modules/upstream_chain_fetcher/Cargo.toml
@@ -9,16 +9,18 @@ description = "Upstream chain fetcher Caryatid module for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
-crossbeam = "0.8.4"
 acropolis_common = { path = "../../common" }
-pallas = "0.32.1"
-anyhow = "1.0"
-serde = { version = "1.0.214", features = ["derive", "rc"] }
-serde_json = "1.0.132"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+crossbeam = "0.8.4"
+pallas = { workspace = true }
+serde = { workspace = true, features = ["rc"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/upstream_chain_fetcher.rs"

--- a/modules/utxo_state/Cargo.toml
+++ b/modules/utxo_state/Cargo.toml
@@ -9,20 +9,22 @@ description = "UTXO state Caryatid module for Acropolis"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_sdk = "0.12"
 acropolis_common = { path = "../../common" }
-anyhow = "1.0"
+
+caryatid_sdk = { workspace = true }
+
+anyhow = { workspace = true }
 async-trait = "0.1"
-tokio = { version = "1", features = ["full"] }
-config = "0.15.11"
-tracing = "0.1.40"
-hex = "0.4.3"
-dashmap = "6.1.0"
-sled = "0.34.7"
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-serde_cbor = "0.11.2"
+config = { workspace = true }
+dashmap = { workspace = true }
 fjall = "2.7.0"
+hex = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_cbor = "0.11.2"
+sled = "0.34.7"
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [lib]
 path = "src/utxo_state.rs"

--- a/processes/golden_tests/Cargo.toml
+++ b/processes/golden_tests/Cargo.toml
@@ -8,13 +8,6 @@ description = "Acropolis testing process to run end to end tests"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_process = "0.12"
-caryatid_sdk = "0.12"
-caryatid_module_clock = "0.12"
-caryatid_module_rest_server = "0.14"
-caryatid_module_spy = "0.12"
-
-
 acropolis_common = { path = "../../common" }
 acropolis_module_snapshot_bootstrapper = { path = "../../modules/snapshot_bootstrapper" }
 acropolis_module_mithril_snapshot_fetcher = { path = "../../modules/mithril_snapshot_fetcher" }
@@ -30,13 +23,18 @@ acropolis_module_stake_delta_filter = { path = "../../modules/stake_delta_filter
 acropolis_module_epochs_state = { path = "../../modules/epochs_state" }
 acropolis_module_accounts_state = { path = "../../modules/accounts_state" }
 
-anyhow = "1.0"
-config = "0.15.11"
-tracing = "0.1.40"
+caryatid_process = { workspace = true }
+caryatid_sdk = { workspace = true }
+caryatid_module_clock = { workspace = true }
+caryatid_module_rest_server = { workspace = true }
+caryatid_module_spy = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = "0.3.20"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-chrono = "0.4.38"
-minicbor = { version = "0.26.0", features = ["std", "half", "derive"] }
-hex = "0.4"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+hex = { workspace = true }

--- a/processes/omnibus/Cargo.toml
+++ b/processes/omnibus/Cargo.toml
@@ -8,16 +8,7 @@ description = "Acropolis omnibus process containing every module"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_process = "0.12"
-caryatid_sdk = "0.12"
-caryatid_module_clock = "0.12"
-caryatid_module_rest_server = "0.14"
-caryatid_module_spy = "0.12"
-
-# Core message definition
 acropolis_common = { path = "../../common" }
-
-# Modules we use
 acropolis_module_genesis_bootstrapper = { path = "../../modules/genesis_bootstrapper" }
 acropolis_module_mithril_snapshot_fetcher = { path = "../../modules/mithril_snapshot_fetcher" }
 acropolis_module_upstream_chain_fetcher = { path = "../../modules/upstream_chain_fetcher" }
@@ -36,14 +27,20 @@ acropolis_module_spdd_state = { path = "../../modules/spdd_state" }
 acropolis_module_drdd_state = { path = "../../modules/drdd_state" }
 acropolis_module_assets_state = { path = "../../modules/assets_state" }
 
-anyhow = "1.0"
-config = "0.15.11"
-tracing = "0.1.40"
+caryatid_process = { workspace = true }
+caryatid_sdk = { workspace = true }
+caryatid_module_clock = { workspace = true }
+caryatid_module_rest_server = { workspace = true }
+caryatid_module_spy = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.20", features = ["registry", "env-filter"] }
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-chrono = "0.4.38"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
 tracing-opentelemetry = "0.31.0"
 opentelemetry = { version = "0.30.0", features = ["trace"] }
 opentelemetry_sdk = { version = "0.30.0", features = ["rt-tokio"] }
@@ -51,5 +48,5 @@ opentelemetry-otlp = { version = "0.30.0", features = ["grpc-tonic", "trace", "t
 opentelemetry-stdout = "0.30.0"
 
 # Memory allocator
-[target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.6.0"
+# [target.'cfg(not(target_env = "msvc"))'.dependencies]
+# tikv-jemallocator = "0.6.0"

--- a/processes/omnibus/src/main.rs
+++ b/processes/omnibus/src/main.rs
@@ -38,11 +38,11 @@ use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{filter, fmt, EnvFilter, Registry};
 
-#[cfg(not(target_env = "msvc"))]
-use tikv_jemallocator::Jemalloc;
-#[cfg(not(target_env = "msvc"))]
-#[global_allocator]
-static GLOBAL: Jemalloc = Jemalloc;
+// #[cfg(not(target_env = "msvc"))]
+// use tikv_jemallocator::Jemalloc;
+// #[cfg(not(target_env = "msvc"))]
+// #[global_allocator]
+// static GLOBAL: Jemalloc = Jemalloc;
 
 /// Standard main
 #[tokio::main]

--- a/processes/replayer/Cargo.toml
+++ b/processes/replayer/Cargo.toml
@@ -8,16 +8,7 @@ description = "Acropolis replayer process, allowing to debug any module"
 license = "Apache-2.0"
 
 [dependencies]
-caryatid_process = "0.12"
-caryatid_sdk = "0.12"
-caryatid_module_clock = "0.12"
-caryatid_module_rest_server = "0.14"
-caryatid_module_spy = "0.12"
-
-# Core message definition
 acropolis_common = { path = "../../common" }
-
-# Modules we use
 acropolis_module_genesis_bootstrapper = { path = "../../modules/genesis_bootstrapper" }
 acropolis_module_mithril_snapshot_fetcher = { path = "../../modules/mithril_snapshot_fetcher" }
 acropolis_module_upstream_chain_fetcher = { path = "../../modules/upstream_chain_fetcher" }
@@ -32,12 +23,18 @@ acropolis_module_stake_delta_filter = { path = "../../modules/stake_delta_filter
 acropolis_module_epochs_state = { path = "../../modules/epochs_state" }
 acropolis_module_accounts_state = { path = "../../modules/accounts_state" }
 
-anyhow = "1.0"
-config = "0.15.11"
-tracing = "0.1.40"
+caryatid_process = { workspace = true }
+caryatid_sdk = { workspace = true }
+caryatid_module_clock = { workspace = true }
+caryatid_module_rest_server = { workspace = true }
+caryatid_module_spy = { workspace = true }
+
+anyhow = { workspace = true }
+config = { workspace = true }
+tracing = { workspace = true }
 tracing-subscriber = { version = "0.3.20", features = ["registry", "env-filter"] }
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1.0.214", features = ["derive"] }
-serde_json = "1.0.132"
-serde_with = { version = "3.12.0", features = ["hex", "base64"] }
-chrono = "0.4.38"
+tokio = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_with = { workspace = true, features = ["base64"] }
+chrono = { workspace = true }


### PR DESCRIPTION
Many crates across the project use the same or very similarly typed versions of external crates; this can be a pain to maintain and keep in sync, and can introduce subtle bugs.

So, instead, this PR updates most of these to use [workspace dependencies](https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#inheriting-a-dependency-from-a-workspace).

It also reorders dependencies to follow a consistent ordering of:
- Acropolis dependencies
- Caryatid dependencies
- External dependencies, in alphabetical order