### PR TITLE
fix: use correct blocks subscription in chain store module

### DIFF
--- a/modules/chain_store/src/chain_store.rs
+++ b/modules/chain_store/src/chain_store.rs
@@ -24,7 +24,7 @@ use tracing::error;
 
 use crate::stores::{fjall::FjallStore, Block, Store};
 
-const DEFAULT_BLOCKS_TOPIC: &str = "cardano.block.body";
+const DEFAULT_BLOCKS_TOPIC: &str = "cardano.block.available";
 const DEFAULT_PROTOCOL_PARAMETERS_TOPIC: &str = "cardano.protocol.parameters";
 const DEFAULT_STORE: &str = "fjall";
 


### PR DESCRIPTION
This PR fixes a bug in the chain store module which was subscribing to a nonexistent block topic. This lead to the parameters subscription queue filling as the chainstore module never read its subscription and ultimately caused a deadlock as all modules dependent on the parameters subscription could not advance past the queue length. 