### PR TITLE
Don't debit deposits pot twice on stake refund (#299)

### DIFF
--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -837,7 +837,6 @@ impl State {
                         .unwrap_or(DEFAULT_KEY_DEPOSIT)
                 }
             };
-            self.pots.deposits -= deposit;
 
             // Schedule refund
             self.stake_refunds.push((stake_address.clone(), deposit));


### PR DESCRIPTION
One-line deletion!  Fixes #299 

This is an interesting one - it turns out although there was the mechanism to post stake refunds to the end of epoch, it was never actually actioned until @lowhung rightly added it in 497214ec7cb771:

```
             self.pots.deposits -= deposit;
 
+            // Schedule refund
+            self.stake_refunds.push((stake_address.clone(), deposit));
+

```
So we were previously only debiting the deposits pot, but not actually paying to the reward account - but adding this meant debiting the pot twice, but does pay the reward.  So we gained one, lost one.  Now we gain both :-)