### PR TITLE
chore: use clippy on all modules

### DIFF
--- a/.github/workflows/run-tests-on-push-to-main.yml
+++ b/.github/workflows/run-tests-on-push-to-main.yml
@@ -24,34 +24,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        run: |
-          cargo clippy --all-targets --all-features \
-            --package acropolis_common \
-            --package acropolis_codec \
-            --package acropolis_module_accounts_state \
-            --package acropolis_module_address_state \
-            --package acropolis_module_assets_state \
-            --package acropolis_module_block_unpacker \
-            --package acropolis_module_chain_store \
-            --package acropolis_module_consensus \
-            --package acropolis_module_drdd_state \
-            --package acropolis_module_drep_state \
-            --package acropolis_module_epochs_state \
-            --package acropolis_module_genesis_bootstrapper \
-            --package acropolis_module_governance_state \
-            --package acropolis_module_historical_accounts_state \
-            --package acropolis_module_mithril_snapshot_fetcher \
-            --package acropolis_module_parameters_state \
-            --package acropolis_module_rest_blockfrost \
-            --package acropolis_module_snapshot_bootstrapper \
-            --package acropolis_module_spdd_state \
-            --package acropolis_module_spo_state \
-            --package acropolis_module_stake_delta_filter \
-            --package acropolis_module_tx_submitter \
-            --package acropolis_module_tx_unpacker \
-            --package acropolis_module_upstream_chain_fetcher \
-            --package acropolis_module_utxo_state \
-            --package acropolis_process_tx_submitter_cli
+        run: cargo clippy --all-targets --all-features
 
       - name: Run Build
         run: cargo build --verbose

--- a/processes/golden_tests/src/lib.rs
+++ b/processes/golden_tests/src/lib.rs
@@ -28,8 +28,8 @@ pub fn signal_test_completion() {
     }
 }
 
-// Disabled test pending fix
-// #[tokio::test]
+#[tokio::test]
+#[ignore = "Disabled test pending fix"]
 async fn golden_test() -> Result<()> {
     let config = Arc::new(
         Config::builder()

--- a/processes/golden_tests/src/test_module.rs
+++ b/processes/golden_tests/src/test_module.rs
@@ -23,10 +23,6 @@ pub struct TestModule;
 
 impl TestModule {
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        // temporarily forcing test to pass so CI looks happy :)
-        super::signal_test_completion();
-        return Ok(());
-
         // TODO: we need to somehow get test data into the context so this module can unpack it all
         // Currently just *assuming* it exists in the context as a string
         let transactions_topic = config
@@ -87,14 +83,12 @@ impl TestModule {
                     return;
                 };
 
-                match message.as_ref() {
-                    Message::Snapshot(SnapshotMessage::Dump(SnapshotStateMessage::SPOState(
-                        spo_state,
-                    ))) => {
-                        assert_eq!(&expected_final_state.spo_state, spo_state);
-                        super::signal_test_completion();
-                    }
-                    _ => {}
+                if let Message::Snapshot(SnapshotMessage::Dump(SnapshotStateMessage::SPOState(
+                    spo_state,
+                ))) = message.as_ref()
+                {
+                    assert_eq!(&expected_final_state.spo_state, spo_state);
+                    super::signal_test_completion();
                 }
             }
         });

--- a/processes/omnibus/src/main.rs
+++ b/processes/omnibus/src/main.rs
@@ -6,7 +6,6 @@ use caryatid_process::Process;
 use config::{Config, Environment, File};
 use std::sync::Arc;
 use tracing::info;
-use tracing_subscriber;
 
 // External modules
 use acropolis_module_accounts_state::AccountsState;

--- a/processes/replayer/src/recorder.rs
+++ b/processes/replayer/src/recorder.rs
@@ -110,25 +110,23 @@ impl Recorder {
                 gov_recorder.write(&blk_g, CardanoMessage::GovernanceProcedures(gov_procs));
             }
 
-            if blk_g.new_epoch {
-                if blk_g.epoch > 0 {
-                    info!("Waiting drep...");
-                    let (blk_drep, d_drep) = Self::read_drep(&mut drep_s).await?;
-                    if blk_g != blk_drep {
-                        error!("Governance {blk_g:?} and DRep distribution {blk_drep:?} are out of sync");
-                    }
-
-                    info!("Waiting spo...");
-                    let (blk_spo, d_spo) = Self::read_spo(&mut spo_s).await?;
-                    if blk_g != blk_spo {
-                        error!(
-                            "Governance {blk_g:?} and SPO distribution {blk_spo:?} are out of sync"
-                        );
-                    }
-
-                    drep_recorder.write(&blk_g, CardanoMessage::DRepStakeDistribution(d_drep));
-                    spo_recorder.write(&blk_g, CardanoMessage::SPOStakeDistribution(d_spo));
+            if blk_g.new_epoch && blk_g.epoch > 0 {
+                info!("Waiting drep...");
+                let (blk_drep, d_drep) = Self::read_drep(&mut drep_s).await?;
+                if blk_g != blk_drep {
+                    error!(
+                        "Governance {blk_g:?} and DRep distribution {blk_drep:?} are out of sync"
+                    );
                 }
+
+                info!("Waiting spo...");
+                let (blk_spo, d_spo) = Self::read_spo(&mut spo_s).await?;
+                if blk_g != blk_spo {
+                    error!("Governance {blk_g:?} and SPO distribution {blk_spo:?} are out of sync");
+                }
+
+                drep_recorder.write(&blk_g, CardanoMessage::DRepStakeDistribution(d_drep));
+                spo_recorder.write(&blk_g, CardanoMessage::SPOStakeDistribution(d_spo));
             }
         }
     }


### PR DESCRIPTION
Partially addresses #260

Every module has been clippy-cleaned, so we don't need to maintain a list to check. Will start failing checks on warnings :soon: 