### PR TITLE
chore: make clippy fail tests on warnings

### DIFF
--- a/.github/workflows/run-tests-on-push-to-main.yml
+++ b/.github/workflows/run-tests-on-push-to-main.yml
@@ -24,7 +24,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Run Build
         run: cargo build --verbose

--- a/codec/src/map_parameters.rs
+++ b/codec/src/map_parameters.rs
@@ -198,7 +198,7 @@ pub fn map_nullable_gov_action_id(
 fn map_constitution(constitution: &conway::Constitution) -> Constitution {
     Constitution {
         anchor: map_anchor(&constitution.anchor),
-        guardrail_script: map_nullable(|x| to_hash(x), &constitution.guardrail_script),
+        guardrail_script: map_nullable(to_hash, &constitution.guardrail_script),
     }
 }
 

--- a/common/src/address.rs
+++ b/common/src/address.rs
@@ -398,8 +398,8 @@ impl StakeAddress {
 
     pub fn get_credential(&self) -> Credential {
         match &self.credential {
-            StakeCredential::AddrKeyHash(hash) => Credential::AddrKeyHash(hash.clone()),
-            StakeCredential::ScriptHash(hash) => Credential::ScriptHash(hash.clone()),
+            StakeCredential::AddrKeyHash(hash) => Credential::AddrKeyHash(*hash),
+            StakeCredential::ScriptHash(hash) => Credential::ScriptHash(*hash),
         }
     }
 
@@ -411,7 +411,7 @@ impl StakeAddress {
         };
 
         let data = self.to_binary();
-        Ok(bech32::encode::<bech32::Bech32>(hrp, &data.as_slice())?)
+        Ok(bech32::encode::<bech32::Bech32>(hrp, data.as_slice())?)
     }
 
     /// Read from a string format ("stake1xxx...")
@@ -520,7 +520,7 @@ impl<C> minicbor::Encode<C> for StakeAddress {
         _ctx: &mut C,
     ) -> Result<(), minicbor::encode::Error<W::Error>> {
         let data = self.to_binary();
-        e.bytes(&data.as_slice())?;
+        e.bytes(data.as_slice())?;
         Ok(())
     }
 }
@@ -902,7 +902,7 @@ mod tests {
         assert_eq!(sa.network, NetworkId::Mainnet);
         assert_eq!(
             match sa.credential {
-                StakeCredential::AddrKeyHash(key) => hex::encode(&key),
+                StakeCredential::AddrKeyHash(key) => hex::encode(key),
                 _ => "SCRIPT".to_string(),
             },
             "558f3ee09b26d88fac2eddc772a9eda94cce6dbadbe9fee439bd6001"
@@ -918,7 +918,7 @@ mod tests {
         assert_eq!(sa.network, NetworkId::Mainnet);
         assert_eq!(
             match sa.credential {
-                StakeCredential::ScriptHash(key) => hex::encode(&key),
+                StakeCredential::ScriptHash(key) => hex::encode(key),
                 _ => "STAKE".to_string(),
             },
             "558f3ee09b26d88fac2eddc772a9eda94cce6dbadbe9fee439bd6001"
@@ -934,7 +934,7 @@ mod tests {
         assert_eq!(sa.network, NetworkId::Testnet);
         assert_eq!(
             match sa.credential {
-                StakeCredential::AddrKeyHash(key) => hex::encode(&key),
+                StakeCredential::AddrKeyHash(key) => hex::encode(key),
                 _ => "SCRIPT".to_string(),
             },
             "558f3ee09b26d88fac2eddc772a9eda94cce6dbadbe9fee439bd6001"
@@ -963,7 +963,7 @@ mod tests {
         // - 0x1d: Length of 29 bytes (the stake address data)
         // - [29 bytes]: The actual stake address (network header + 28-byte hash)
         // Total: 31 bytes (2-byte CBOR framing + 29-byte payload)
-        let expected = [[0x58, 0x1d].as_slice(), &binary.as_slice()].concat();
+        let expected = [[0x58, 0x1d].as_slice(), binary.as_slice()].concat();
 
         let mut actual = Vec::new();
         let mut encoder = minicbor::Encoder::new(&mut actual);
@@ -977,7 +977,7 @@ mod tests {
     fn stake_addresses_decode_mainnet_stake() {
         let binary = {
             let mut v = vec![0x58, 0x1d];
-            v.extend_from_slice(&mainnet_stake_address().to_binary().as_slice());
+            v.extend_from_slice(mainnet_stake_address().to_binary().as_slice());
             v
         };
 
@@ -987,7 +987,7 @@ mod tests {
         assert_eq!(decoded.network, NetworkId::Mainnet);
         assert_eq!(
             match decoded.credential {
-                StakeCredential::AddrKeyHash(key) => hex::encode(&key),
+                StakeCredential::AddrKeyHash(key) => hex::encode(key),
                 _ => "STAKE".to_string(),
             },
             "558f3ee09b26d88fac2eddc772a9eda94cce6dbadbe9fee439bd6001"
@@ -1010,7 +1010,7 @@ mod tests {
         assert_eq!(decoded.network, NetworkId::Mainnet);
         assert_eq!(
             match decoded.credential {
-                StakeCredential::ScriptHash(key) => hex::encode(&key),
+                StakeCredential::ScriptHash(key) => hex::encode(key),
                 _ => "STAKE".to_string(),
             },
             "558f3ee09b26d88fac2eddc772a9eda94cce6dbadbe9fee439bd6001"
@@ -1031,7 +1031,7 @@ mod tests {
         assert_eq!(decoded.network, NetworkId::Testnet);
         assert_eq!(
             match decoded.credential {
-                StakeCredential::ScriptHash(key) => hex::encode(&key),
+                StakeCredential::ScriptHash(key) => hex::encode(key),
                 _ => "SCRIPT".to_string(),
             },
             "558f3ee09b26d88fac2eddc772a9eda94cce6dbadbe9fee439bd6001"

--- a/common/src/crypto.rs
+++ b/common/src/crypto.rs
@@ -9,7 +9,7 @@ use cryptoxide::hashing::blake2b::Blake2b;
 pub fn keyhash_256(key: &[u8]) -> Hash<32> {
     let mut context = Blake2b::<256>::new();
     context.update_mut(key);
-    Hash::new(context.finalize().into())
+    Hash::new(context.finalize())
 }
 
 /// Get a Blake2b-224 hash of a key
@@ -18,5 +18,5 @@ pub fn keyhash_256(key: &[u8]) -> Hash<32> {
 pub fn keyhash_224(key: &[u8]) -> Hash<28> {
     let mut context = Blake2b::<224>::new();
     context.update_mut(key);
-    Hash::new(context.finalize().into())
+    Hash::new(context.finalize())
 }

--- a/common/src/hash.rs
+++ b/common/src/hash.rs
@@ -312,10 +312,10 @@ macro_rules! declare_hash_type_with_bech32 {
             }
         }
 
-        impl crate::serialization::Bech32Conversion for $name {
+        impl $crate::serialization::Bech32Conversion for $name {
             fn to_bech32(&self) -> Result<String, anyhow::Error> {
-                use crate::serialization::Bech32WithHrp;
                 use anyhow::Context;
+                use $crate::serialization::Bech32WithHrp;
 
                 self.as_ref().to_bech32_with_hrp($hrp).with_context(|| {
                     format!(
@@ -327,8 +327,8 @@ macro_rules! declare_hash_type_with_bech32 {
             }
 
             fn from_bech32(s: &str) -> Result<Self, anyhow::Error> {
-                use crate::serialization::Bech32WithHrp;
                 use anyhow::Context;
+                use $crate::serialization::Bech32WithHrp;
 
                 let v = Vec::<u8>::from_bech32_with_hrp(s, $hrp).with_context(|| {
                     format!("Failed to decode {} from bech32", stringify!($name))

--- a/common/src/queries/blocks.rs
+++ b/common/src/queries/blocks.rs
@@ -157,7 +157,7 @@ impl Serialize for BlockInfo {
             "block_vrf",
             &self.block_vrf.and_then(|vkey| vkey.to_bech32().ok()),
         )?;
-        state.serialize_field("op_cert", &self.op_cert.clone().map(hex::encode))?;
+        state.serialize_field("op_cert", &self.op_cert.map(hex::encode))?;
         state.serialize_field("op_cert_counter", &self.op_cert_counter)?;
         state.serialize_field("previous_block", &self.previous_block)?;
         state.serialize_field("next_block", &self.next_block)?;

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -723,11 +723,10 @@ impl Credential {
     }
 
     pub fn get_hash(&self) -> KeyHash {
-        match self {
+        *match self {
             Self::AddrKeyHash(hash) => hash,
             Self::ScriptHash(hash) => hash,
         }
-        .clone()
     }
 
     pub fn from_drep_bech32(bech32_str: &str) -> Result<Self, Error> {

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -510,7 +510,7 @@ impl AccountsState {
                             AccountsStateQueryResponse::AccountInfo(AccountInfo {
                                 utxo_value: account.utxo_value,
                                 rewards: account.rewards,
-                                delegated_spo: account.delegated_spo.clone(),
+                                delegated_spo: account.delegated_spo,
                                 delegated_drep: account.delegated_drep.clone(),
                             })
                         } else {

--- a/modules/accounts_state/src/rewards.rs
+++ b/modules/accounts_state/src/rewards.rs
@@ -213,8 +213,8 @@ pub fn calculate_rewards(
                 result.total_paid += reward.amount;
             }
 
-            result.rewards.insert(operator_id.clone(), rewards);
-            result.spo_rewards.push((operator_id.clone(), spo_rewards));
+            result.rewards.insert(*operator_id, rewards);
+            result.spo_rewards.push((*operator_id, spo_rewards));
         }
     }
 

--- a/modules/accounts_state/src/snapshot.rs
+++ b/modules/accounts_state/src/snapshot.rs
@@ -105,7 +105,7 @@ impl Snapshot {
 
             // Add the new one
             snapshot.spos.insert(
-                spo_id.clone(),
+                *spo_id,
                 SnapshotSPO {
                     delegators: vec![],
                     total_stake: 0,
@@ -229,7 +229,7 @@ mod tests {
             StakeAddressState {
                 utxo_value: 42,
                 registered: true,
-                delegated_spo: Some(spo1.clone()),
+                delegated_spo: Some(spo1),
                 ..StakeAddressState::default()
             },
         );
@@ -238,7 +238,7 @@ mod tests {
             StakeAddressState {
                 utxo_value: 99,
                 registered: true,
-                delegated_spo: Some(spo2.clone()),
+                delegated_spo: Some(spo2),
                 ..StakeAddressState::default()
             },
         );
@@ -247,7 +247,7 @@ mod tests {
             StakeAddressState {
                 utxo_value: 0,
                 registered: true,
-                delegated_spo: Some(spo1.clone()),
+                delegated_spo: Some(spo1),
                 ..StakeAddressState::default()
             },
         );
@@ -271,8 +271,8 @@ mod tests {
         );
 
         let mut spos: OrdMap<PoolId, PoolRegistration> = OrdMap::new();
-        spos.insert(spo1.clone(), PoolRegistration::default());
-        spos.insert(spo2.clone(), PoolRegistration::default());
+        spos.insert(spo1, PoolRegistration::default());
+        spos.insert(spo2, PoolRegistration::default());
         let spo_block_counts: HashMap<PoolId, usize> = HashMap::new();
         let snapshot = Snapshot::new(
             42,
@@ -313,7 +313,7 @@ mod tests {
         let addr4 = create_test_stake_address(0x14);
 
         snapshot.spos.insert(
-            spo1.clone(),
+            spo1,
             SnapshotSPO {
                 delegators: vec![
                     (addr1.clone(), 100),
@@ -340,7 +340,7 @@ mod tests {
         let addr_x = create_test_stake_address(0x99);
 
         snapshot.spos.insert(
-            spo1.clone(),
+            spo1,
             SnapshotSPO {
                 delegators: vec![(addr1.clone(), 100)],
                 total_stake: 100,
@@ -369,7 +369,7 @@ mod tests {
         let addr1 = create_test_stake_address(0x11);
 
         snapshot.spos.insert(
-            spo1.clone(),
+            spo1,
             SnapshotSPO {
                 delegators: vec![(addr1.clone(), 100)],
                 total_stake: 100,

--- a/modules/accounts_state/src/spo_distribution_store.rs
+++ b/modules/accounts_state/src/spo_distribution_store.rs
@@ -230,11 +230,11 @@ mod tests {
     const DB_PATH: &str = "spdd_db";
 
     fn test_pool_hash(byte: u8) -> PoolId {
-        keyhash_224(&vec![byte]).into()
+        keyhash_224(&[byte]).into()
     }
 
     fn test_addr_hash(byte: u8) -> AddrKeyhash {
-        keyhash_224(&vec![byte])
+        keyhash_224(&[byte])
     }
 
     #[test]

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -626,7 +626,7 @@ impl State {
                                 stake_address: reward.account.clone(),
                                 delta: reward.amount,
                                 reward_type: reward.rtype.clone(),
-                                pool: reward.pool.clone(),
+                                pool: reward.pool,
                             });
                         } else {
                             warn!(
@@ -670,7 +670,7 @@ impl State {
             .spo_blocks
             .iter()
             .filter(|(hash, _)| self.spos.contains_key(hash))
-            .map(|(hash, count)| (hash.clone(), *count))
+            .map(|(hash, count)| (*hash, *count))
             .collect();
 
         // Enter epoch - note the message specifies the epoch that has just *ended*
@@ -689,7 +689,7 @@ impl State {
     pub fn handle_spo_state(&mut self, spo_msg: &SPOStateMessage) -> Result<()> {
         // Capture current SPOs, mapped by operator ID
         let new_spos: OrdMap<PoolId, PoolRegistration> =
-            spo_msg.spos.iter().cloned().map(|spo| (spo.operator.clone(), spo)).collect();
+            spo_msg.spos.iter().cloned().map(|spo| (spo.operator, spo)).collect();
 
         // Get pool deposit amount from parameters, or default
         let deposit = self
@@ -755,10 +755,7 @@ impl State {
                     hex::encode(id),
                     retired_spo.reward_account
                 );
-                self.pool_refunds.push((
-                    retired_spo.operator.clone(),
-                    retired_spo.reward_account.clone(),
-                ));
+                self.pool_refunds.push((retired_spo.operator, retired_spo.reward_account.clone()));
                 // Store full StakeAddress
             }
 
@@ -985,7 +982,7 @@ mod tests {
     }
 
     fn test_keyhash(byte: u8) -> KeyHash {
-        keyhash_224(&vec![byte])
+        keyhash_224(&[byte])
     }
 
     fn test_keyhash_from_bytes(bytes: &[u8]) -> KeyHash {
@@ -993,7 +990,7 @@ mod tests {
     }
 
     fn test_vrf_keyhash(byte: u8) -> VrfKeyHash {
-        keyhash_256(&vec![byte]).into()
+        keyhash_256(&[byte]).into()
     }
 
     const STAKE_KEY_HASH: [u8; 3] = [0x99, 0x0f, 0x00];

--- a/modules/accounts_state/src/verifier.rs
+++ b/modules/accounts_state/src/verifier.rs
@@ -195,7 +195,7 @@ impl Verifier {
                     Left(expected_spo) => {
                         error!(
                             "Missing rewards SPO: {} {} rewards",
-                            hex::encode(&expected_spo.0),
+                            hex::encode(expected_spo.0),
                             expected_spo.1.len()
                         );
                         errors += 1;
@@ -203,7 +203,7 @@ impl Verifier {
                     Right(actual_spo) => {
                         error!(
                             "Extra rewards SPO: {} {} rewards",
-                            hex::encode(&actual_spo.0),
+                            hex::encode(actual_spo.0),
                             actual_spo.1.len()
                         );
                         errors += 1;
@@ -222,7 +222,7 @@ impl Verifier {
                                 Left(expected) => {
                                     error!(
                                         "Missing reward: SPO {} account {} {:?} {}",
-                                        hex::encode(&expected_spo.0),
+                                        hex::encode(expected_spo.0),
                                         expected.account,
                                         expected.rtype,
                                         expected.amount
@@ -232,7 +232,7 @@ impl Verifier {
                                 Right(actual) => {
                                     error!(
                                         "Extra reward: SPO {} account {} {:?} {}",
-                                        hex::encode(&actual_spo.0),
+                                        hex::encode(actual_spo.0),
                                         actual.account,
                                         actual.rtype,
                                         actual.amount
@@ -242,7 +242,7 @@ impl Verifier {
                                 Both(expected, actual) => {
                                     if expected.amount != actual.amount {
                                         error!("Different reward: SPO {} account {} {:?} expected {}, actual {} ({})",
-                                               hex::encode(&expected_spo.0),
+                                               hex::encode(expected_spo.0),
                                                expected.account,
                                                expected.rtype,
                                                expected.amount,
@@ -252,7 +252,7 @@ impl Verifier {
                                     } else {
                                         debug!(
                                             "Reward match: SPO {} account {} {:?} {}",
-                                            hex::encode(&expected_spo.0),
+                                            hex::encode(expected_spo.0),
                                             expected.account,
                                             expected.rtype,
                                             expected.amount

--- a/modules/drep_state/src/state.rs
+++ b/modules/drep_state/src/state.rs
@@ -261,8 +261,8 @@ impl State {
         for (tx_hash, voting_procedures) in voting_procedures {
             for (voter, single_votes) in &voting_procedures.votes {
                 let drep_cred = match voter {
-                    Voter::DRepKey(k) => DRepCredential::AddrKeyHash(k.into_inner().into()),
-                    Voter::DRepScript(s) => DRepCredential::ScriptHash(s.into_inner().into()),
+                    Voter::DRepKey(k) => DRepCredential::AddrKeyHash(k.into_inner()),
+                    Voter::DRepScript(s) => DRepCredential::ScriptHash(s.into_inner()),
                     _ => continue,
                 };
 
@@ -559,8 +559,8 @@ impl State {
 
 fn drep_choice_to_credential(choice: &DRepChoice) -> Option<DRepCredential> {
     match choice {
-        DRepChoice::Key(k) => Some(DRepCredential::AddrKeyHash(k.clone())),
-        DRepChoice::Script(k) => Some(DRepCredential::ScriptHash(k.clone())),
+        DRepChoice::Key(k) => Some(DRepCredential::AddrKeyHash(*k)),
+        DRepChoice::Script(k) => Some(DRepCredential::ScriptHash(*k)),
         _ => None,
     }
 }

--- a/modules/epochs_state/src/state.rs
+++ b/modules/epochs_state/src/state.rs
@@ -191,7 +191,7 @@ impl State {
         let spo_id = PoolId::from(keyhash_224(issuer_vkey));
 
         // Count one on this hash
-        *(self.blocks_minted.entry(spo_id.clone()).or_insert(0)) += 1;
+        *(self.blocks_minted.entry(spo_id).or_insert(0)) += 1;
     }
 
     // Handle Block Txs
@@ -250,7 +250,7 @@ impl State {
             total_txs: self.epoch_txs,
             total_outputs: self.epoch_outputs,
             total_fees: self.epoch_fees,
-            spo_blocks: self.blocks_minted.iter().map(|(k, v)| (k.clone(), *v)).collect(),
+            spo_blocks: self.blocks_minted.iter().map(|(k, v)| (*k, *v)).collect(),
             nonce: self.nonces.as_ref().and_then(|n| n.active.hash),
         }
     }

--- a/modules/governance_state/src/alonzo_babbage_voting.rs
+++ b/modules/governance_state/src/alonzo_babbage_voting.rs
@@ -52,7 +52,7 @@ impl AlonzoBabbageVoting {
             let entry = self.proposals.entry(pp.enactment_epoch + 1).or_default();
             for (k, p) in &pp.proposals {
                 // A new proposal for key k always replaces the old one
-                entry.insert(k.clone(), (block_info.epoch, block_info.slot, p.clone()));
+                entry.insert(*k, (block_info.epoch, block_info.slot, p.clone()));
             }
         }
 
@@ -71,7 +71,7 @@ impl AlonzoBabbageVoting {
         let proposals = proposals_for_new_epoch
             .iter()
             .filter(|(_k, (_epoch, slot, _proposal))| self.is_timely_vote(*slot, new_blk))
-            .map(|(k, (_e, _s, proposal))| (k.clone(), proposal.clone()))
+            .map(|(k, (_e, _s, proposal))| (*k, proposal.clone()))
             .collect::<Vec<_>>();
 
         let mut cast_votes = HashSet::new();
@@ -85,12 +85,12 @@ impl AlonzoBabbageVoting {
                 let votes: Vec<_> = proposals
                     .iter()
                     .filter(|&(_, v)| v == parameter_update)
-                    .map(|(k, _)| k.clone())
+                    .map(|(k, _)| *k)
                     .collect();
 
                 for v in &votes {
                     // TODO Check keys (whether they are genesis keys)
-                    cast_votes.insert(v.clone());
+                    cast_votes.insert(*v);
                 }
 
                 let votes_len = votes.len() as u32;
@@ -168,8 +168,7 @@ mod tests {
             };
 
             for prop in proposals {
-                let decoded_updates =
-                    prop.1.iter().map(|(k, v)| (k.0.clone(), v.clone())).collect();
+                let decoded_updates = prop.1.iter().map(|(k, v)| (k.0, v.clone())).collect();
 
                 let update_prop = AlonzoBabbageUpdateProposal {
                     proposals: decoded_updates,

--- a/modules/governance_state/src/conway_voting_test.rs
+++ b/modules/governance_state/src/conway_voting_test.rs
@@ -99,7 +99,7 @@ mod tests {
                 *epoch,
                 HashMap::from_iter(distr.iter().map(|PoolRecord(id, active, live)| {
                     (
-                        id.clone(),
+                        *id,
                         DelegatedStake {
                             active: *active,
                             active_delegators_count: 0,

--- a/modules/historical_accounts_state/src/immutable_historical_account_store.rs
+++ b/modules/historical_accounts_state/src/immutable_historical_account_store.rs
@@ -326,7 +326,7 @@ impl ImmutableHistoricalAccountStore {
 
     fn make_epoch_key(account: &StakeAddress, epoch: u32) -> [u8; 32] {
         let mut key = [0u8; 32];
-        key[..28].copy_from_slice(&account.get_credential().get_hash().as_ref());
+        key[..28].copy_from_slice(account.get_credential().get_hash().as_ref());
         key[28..32].copy_from_slice(&epoch.to_be_bytes());
         key
     }

--- a/modules/historical_accounts_state/src/state.rs
+++ b/modules/historical_accounts_state/src/state.rs
@@ -117,7 +117,7 @@ impl State {
             let update = AccountReward {
                 epoch: reward_epoch,
                 amount: reward.delta,
-                pool: reward.pool.clone(),
+                pool: reward.pool,
                 reward_type: reward.reward_type.clone(),
             };
             entry.reward_history.get_or_insert_with(Vec::new).push(update);
@@ -376,7 +376,7 @@ impl State {
             active_epoch: epoch.saturating_add(2),
             tx_identifier: *tx_identifier,
             amount: 0, // Amount is set during persistence when active stake is known
-            pool: pool.clone(),
+            pool: *pool,
         };
         entry.delegation_history.get_or_insert_with(Vec::new).push(update);
     }

--- a/modules/rest_blockfrost/src/handlers/pools.rs
+++ b/modules/rest_blockfrost/src/handlers/pools.rs
@@ -201,10 +201,8 @@ async fn handle_pools_extended_blockfrost(
     };
 
     // Populate pools_operators
-    let pools_operators = pools_list_with_info
-        .iter()
-        .map(|(pool_operator, _)| pool_operator.clone())
-        .collect::<Vec<_>>();
+    let pools_operators =
+        pools_list_with_info.iter().map(|(pool_operator, _)| *pool_operator).collect::<Vec<_>>();
 
     // Get an active stake for each pool from spo-state
     let pools_active_stakes_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
@@ -423,7 +421,7 @@ async fn handle_pools_spo_blockfrost(
     // Get PoolRegistration from spo state
     let pool_info_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
         PoolsStateQuery::GetPoolInfo {
-            pool_id: pool_operator.clone(),
+            pool_id: pool_operator,
         },
     )));
 
@@ -472,9 +470,7 @@ async fn handle_pools_spo_blockfrost(
 
     // query live stakes from accounts_state
     let live_stakes_info_msg = Arc::new(Message::StateQuery(StateQuery::Accounts(
-        AccountsStateQuery::GetPoolLiveStake {
-            pool_operator: pool_operator.clone(),
-        },
+        AccountsStateQuery::GetPoolLiveStake { pool_operator },
     )));
     let live_stakes_info_f = query_state(
         &context,
@@ -507,7 +503,7 @@ async fn handle_pools_spo_blockfrost(
     // Query pool update events from spo_state
     let pool_updates_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
         PoolsStateQuery::GetPoolUpdates {
-            pool_id: pool_operator.clone(),
+            pool_id: pool_operator,
         },
     )));
     let pool_updates_f = query_state(
@@ -531,7 +527,7 @@ async fn handle_pools_spo_blockfrost(
     // Query total_blocks_minted from spo_state
     let total_blocks_minted_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
         PoolsStateQuery::GetPoolTotalBlocksMinted {
-            pool_id: pool_operator.clone(),
+            pool_id: pool_operator,
         },
     )));
     let total_blocks_minted_f = query_state(
@@ -600,7 +596,7 @@ async fn handle_pools_spo_blockfrost(
     // Query blocks_minted from epochs_state
     let epoch_blocks_minted_msg = Arc::new(Message::StateQuery(StateQuery::Epochs(
         EpochsStateQuery::GetLatestEpochBlocksMintedByPool {
-            spo_id: pool_info.operator.clone(),
+            spo_id: pool_info.operator,
         },
     )));
     let epoch_blocks_minted_f = query_state(
@@ -618,7 +614,7 @@ async fn handle_pools_spo_blockfrost(
     // query active stakes info from spo_state
     let active_stakes_info_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
         PoolsStateQuery::GetPoolActiveStakeInfo {
-            pool_operator: pool_operator.clone(),
+            pool_operator,
             epoch: latest_epoch,
         },
     )));
@@ -808,9 +804,7 @@ pub async fn handle_pool_metadata_blockfrost(
     };
 
     let pool_metadata_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
-        PoolsStateQuery::GetPoolMetadata {
-            pool_id: spo.clone(),
-        },
+        PoolsStateQuery::GetPoolMetadata { pool_id: spo },
     )));
     let pool_metadata = query_state(
         &context,
@@ -889,9 +883,7 @@ pub async fn handle_pool_relays_blockfrost(
     };
 
     let pool_relay_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
-        PoolsStateQuery::GetPoolRelays {
-            pool_id: spo.clone(),
-        },
+        PoolsStateQuery::GetPoolRelays { pool_id: spo },
     )));
 
     let pool_relays = query_state(
@@ -944,9 +936,7 @@ pub async fn handle_pool_delegators_blockfrost(
 
     // Get Pool delegators from spo-state
     let pool_delegators_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
-        PoolsStateQuery::GetPoolDelegators {
-            pool_id: spo.clone(),
-        },
+        PoolsStateQuery::GetPoolDelegators { pool_id: spo },
     )));
 
     let pool_delegators = query_state(
@@ -978,9 +968,7 @@ pub async fn handle_pool_delegators_blockfrost(
         None => {
             // Query from Accounts state
             let pool_delegators_msg = Arc::new(Message::StateQuery(StateQuery::Accounts(
-                AccountsStateQuery::GetPoolDelegators {
-                    pool_operator: spo.clone(),
-                },
+                AccountsStateQuery::GetPoolDelegators { pool_operator: spo },
             )));
             let pool_delegators = query_state(
                 &context,
@@ -1005,7 +993,7 @@ pub async fn handle_pool_delegators_blockfrost(
 
     let mut delegators_rest = Vec::<PoolDelegatorRest>::new();
     for (d, l) in pool_delegators {
-        let bech32 = StakeCredential::AddrKeyHash(d.clone())
+        let bech32 = StakeCredential::AddrKeyHash(d)
             .to_stake_bech32()
             .map_err(|e| anyhow::anyhow!("Invalid stake address in pool delegators: {e}"))?;
         delegators_rest.push(PoolDelegatorRest {
@@ -1041,9 +1029,7 @@ pub async fn handle_pool_blocks_blockfrost(
 
     // Get blocks by pool_id from spo_state
     let pool_blocks_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
-        PoolsStateQuery::GetBlocksByPool {
-            pool_id: spo.clone(),
-        },
+        PoolsStateQuery::GetBlocksByPool { pool_id: spo },
     )));
 
     let pool_blocks = query_state(
@@ -1093,9 +1079,7 @@ pub async fn handle_pool_updates_blockfrost(
 
     // query from spo_state
     let pool_updates_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
-        PoolsStateQuery::GetPoolUpdates {
-            pool_id: spo.clone(),
-        },
+        PoolsStateQuery::GetPoolUpdates { pool_id: spo },
     )));
     let pool_updates = query_state(
         &context,
@@ -1153,9 +1137,7 @@ pub async fn handle_pool_votes_blockfrost(
 
     // query from spo_state
     let pool_votes_msg = Arc::new(Message::StateQuery(StateQuery::Pools(
-        PoolsStateQuery::GetPoolVotes {
-            pool_id: spo.clone(),
-        },
+        PoolsStateQuery::GetPoolVotes { pool_id: spo },
     )));
     let pool_votes = query_state(
         &context,

--- a/modules/spdd_state/src/spdd_state.rs
+++ b/modules/spdd_state/src/spdd_state.rs
@@ -75,7 +75,7 @@ impl SPDDState {
 
                                 guard.apply_spdd_snapshot(
                                     msg.epoch,
-                                    msg.spos.iter().map(|(k, v)| (k.clone(), *v)),
+                                    msg.spos.iter().map(|(k, v)| (*k, *v)),
                                 );
                             }
                             .instrument(span)

--- a/modules/spdd_state/src/state.rs
+++ b/modules/spdd_state/src/state.rs
@@ -29,7 +29,7 @@ impl State {
                 None => true,
             };
             if changed {
-                next.insert(k.clone(), v_new);
+                next.insert(k, v_new);
             }
             present.insert(k);
         }

--- a/modules/spo_state/src/epochs_history.rs
+++ b/modules/spo_state/src/epochs_history.rs
@@ -187,7 +187,7 @@ impl EpochsHistoryState {
         epoch: u64,
         update_fn: impl FnOnce(&mut EpochState),
     ) {
-        let mut epochs = epochs_history.entry(spo.clone()).or_default();
+        let mut epochs = epochs_history.entry(*spo).or_default();
         let epoch_state = epochs.entry(epoch).or_insert_with(|| EpochState::new(epoch));
         update_fn(epoch_state);
     }
@@ -242,7 +242,7 @@ mod tests {
         epoch_activity_msg.spo_blocks = vec![(spo_block_key_hash, 1)];
         epoch_activity_msg.total_blocks = 1;
         epoch_activity_msg.total_fees = 10;
-        epochs_history.handle_epoch_activity(&block, &epoch_activity_msg, &vec![(pool_id, 1)]);
+        epochs_history.handle_epoch_activity(&block, &epoch_activity_msg, &[(pool_id, 1)]);
 
         let mut spo_rewards_msg = new_spo_rewards_message(1);
         spo_rewards_msg.spos = vec![(

--- a/modules/spo_state/src/retired_pools_history.rs
+++ b/modules/spo_state/src/retired_pools_history.rs
@@ -40,7 +40,7 @@ impl RetiredPoolsHistoryState {
                             .value()
                             .iter()
                             .map(move |pool| PoolRetirement {
-                                operator: pool.clone(),
+                                operator: *pool,
                                 epoch,
                             })
                             .collect::<Vec<PoolRetirement>>()

--- a/modules/spo_state/src/spo_state.rs
+++ b/modules/spo_state/src/spo_state.rs
@@ -287,7 +287,7 @@ impl SPOState {
                         let spos: Vec<(PoolId, usize)> = epoch_activity_message
                             .spo_blocks
                             .iter()
-                            .map(|(hash, count)| (hash.clone(), *count))
+                            .map(|(hash, count)| (*hash, *count))
                             .collect();
                         epochs_history.handle_epoch_activity(
                             block_info,

--- a/modules/stake_delta_filter/src/utils.rs
+++ b/modules/stake_delta_filter/src/utils.rs
@@ -345,12 +345,12 @@ pub fn process_message(
                     // Base addresses (stake delegated to itself)
                     ShelleyAddressDelegationPart::StakeKeyHash(keyhash) => StakeAddress {
                         network: shelley.network.clone(),
-                        credential: StakeCredential::AddrKeyHash(keyhash.clone()),
+                        credential: StakeCredential::AddrKeyHash(*keyhash),
                     },
 
                     ShelleyAddressDelegationPart::ScriptHash(scripthash) => StakeAddress {
                         network: shelley.network.clone(),
-                        credential: StakeCredential::ScriptHash(scripthash.clone()),
+                        credential: StakeCredential::ScriptHash(*scripthash),
                     },
 
                     // Shelley addresses (stake delegated to some different address)

--- a/processes/replayer/src/recorder_alonzo_governance.rs
+++ b/processes/replayer/src/recorder_alonzo_governance.rs
@@ -55,7 +55,7 @@ impl BlockRecorder {
         for vote in votes.iter() {
             let mut votes_indexed = Vec::new();
             for (h, u) in &vote.proposals {
-                votes_indexed.push(VoteRecord(ReplayerGenesisKeyhash(h.clone()), u.clone()));
+                votes_indexed.push(VoteRecord(ReplayerGenesisKeyhash(*h), u.clone()));
             }
             proposals.push((vote.enactment_epoch, votes_indexed));
         }


### PR DESCRIPTION
Partially addresses #260.

Now clippy will cause our PR checks to fail if it detects any warnings.