### PR TITLE
fix: genesis_to_hash return type

### DIFF
--- a/codec/src/map_parameters.rs
+++ b/codec/src/map_parameters.rs
@@ -37,7 +37,7 @@ pub fn to_hash<const N: usize>(pallas_hash: &pallas_primitives::Hash<N>) -> Hash
 
 /// Convert a Pallas Hash reference to an Acropolis Hash (owned)
 /// Works for any hash size N
-pub fn genesis_to_hash(pallas_hash: &pallas_primitives::Genesishash) -> Hash<32> {
+pub fn genesis_to_hash(pallas_hash: &pallas_primitives::Genesishash) -> Hash<28> {
     Hash::try_from(pallas_hash.as_ref()).unwrap()
 }
 

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1012,7 +1012,7 @@ pub struct SPORewards {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct GenesisKeyDelegation {
     /// Genesis hash
-    pub genesis_hash: Hash<32>,
+    pub genesis_hash: Hash<28>,
 
     /// Genesis delegate hash
     pub genesis_delegate_hash: PoolId,


### PR DESCRIPTION
This PR fixes a bug in `genesis_to_hash` which caused a panic at epoch 350, preventing further sync. Merging as its only a 2 line change. 