### PR TITLE
Refactor: Remove redundant `hex::encode` calls for SPO/operator IDs across modules

### DIFF
--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -717,8 +717,8 @@ impl Credential {
 
     pub fn to_json_string(&self) -> String {
         match self {
-            Self::ScriptHash(hash) => format!("scriptHash-{}", hex::encode(hash)),
-            Self::AddrKeyHash(hash) => format!("keyHash-{}", hex::encode(hash)),
+            Self::ScriptHash(hash) => format!("scriptHash-{}", hash),
+            Self::AddrKeyHash(hash) => format!("keyHash-{}", hash),
         }
     }
 

--- a/modules/accounts_state/src/rewards.rs
+++ b/modules/accounts_state/src/rewards.rs
@@ -120,8 +120,7 @@ pub fn calculate_rewards(
 
         debug!(
             "SPO {} reward account registered two epochs ago: {}",
-            hex::encode(operator_id),
-            pay_to_pool_reward_account
+            operator_id, pay_to_pool_reward_account
         );
 
         // Also, to handle the early Shelley timing bug, we allow it if it was registered
@@ -138,8 +137,7 @@ pub fn calculate_rewards(
             if pay_to_pool_reward_account {
                 info!(
                     "SPO {}'s reward account {} was registered in this epoch",
-                    hex::encode(operator_id),
-                    staking_spo.reward_account
+                    operator_id, staking_spo.reward_account
                 );
             }
         }
@@ -160,18 +158,15 @@ pub fn calculate_rewards(
                     if performance.spos.get(other_id).map(|s| s.blocks_produced).unwrap_or(0) > 0 {
                         pay_to_pool_reward_account = false;
                         warn!("Shelley shared reward account bug: Dropping reward to {} in favour of {} on shared account {}",
-                              hex::encode(operator_id),
-                              hex::encode(other_id),
+                              operator_id,
+                              other_id,
                               staking_spo.reward_account);
                         break;
                     }
                 }
             }
         } else {
-            info!(
-                "Reward account for SPO {} isn't registered",
-                hex::encode(operator_id)
-            )
+            info!("Reward account for SPO {} isn't registered", operator_id)
         }
 
         // Calculate rewards for this SPO
@@ -250,7 +245,7 @@ fn calculate_spo_rewards(
     // Active stake (sigma)
     let pool_stake = BigDecimal::from(spo.total_stake);
     if pool_stake.is_zero() {
-        warn!("SPO {} has no stake - skipping", hex::encode(operator_id));
+        warn!("SPO {} has no stake - skipping", operator_id);
 
         // No stake, no rewards or earnings
         return vec![];
@@ -264,9 +259,7 @@ fn calculate_spo_rewards(
     if pool_owner_stake < spo.pledge {
         debug!(
             "SPO {} has owner stake {} less than pledge {} - skipping",
-            hex::encode(operator_id),
-            pool_owner_stake,
-            spo.pledge
+            operator_id, pool_owner_stake, spo.pledge
         );
         return vec![];
     }
@@ -313,7 +306,7 @@ fn calculate_spo_rewards(
 
     debug!(%pool_stake, %relative_pool_stake, %pool_performance,
            %optimum_rewards, %pool_rewards, pool_owner_stake, %pool_pledge,
-           "Pool {}", hex::encode(operator_id));
+           "Pool {}", operator_id);
 
     // Subtract fixed costs
     let fixed_cost = BigDecimal::from(spo.fixed_cost);
@@ -411,9 +404,7 @@ fn calculate_spo_rewards(
     } else {
         info!(
             "SPO {}'s reward account {} not paid {}",
-            hex::encode(operator_id),
-            spo.reward_account,
-            spo_benefit,
+            operator_id, spo.reward_account, spo_benefit,
         );
     }
 

--- a/modules/accounts_state/src/snapshot.rs
+++ b/modules/accounts_state/src/snapshot.rs
@@ -99,7 +99,7 @@ impl Snapshot {
                 epoch,
                 previous_epoch = two_previous_snapshot.epoch,
                 "Two previous reward account for SPO {} registered: {}",
-                hex::encode(spo_id),
+                spo_id,
                 two_previous_reward_account_is_registered
             );
 
@@ -135,9 +135,7 @@ impl Snapshot {
                         // SPO has retired - this stake is simply ignored
                         debug!(
                             epoch,
-                            "SPO {} for stake address {} retired?  Ignored",
-                            hex::encode(spo_id),
-                            stake_address
+                            "SPO {} for stake address {} retired?  Ignored", spo_id, stake_address
                         );
                         continue;
                     }

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -717,7 +717,7 @@ impl State {
                             margin = ?spo.margin,
                             reward = %spo.reward_account,
                             "Updated parameters for SPO {}",
-                            hex::encode(id)
+                            id
                         );
                     }
                 }
@@ -730,7 +730,7 @@ impl State {
                         margin = ?spo.margin,
                         reward = %spo.reward_account,
                         "Registered new SPO {}",
-                        hex::encode(id)
+                        id
                     );
                 }
             }
@@ -751,8 +751,7 @@ impl State {
             if let Some(retired_spo) = new_spos.get(id) {
                 debug!(
                     "SPO {} has retired - refunding their deposit to {}",
-                    hex::encode(id),
-                    retired_spo.reward_account
+                    id, retired_spo.reward_account
                 );
                 self.pool_refunds.push((retired_spo.operator, retired_spo.reward_account.clone()));
                 // Store full StakeAddress

--- a/modules/accounts_state/src/verifier.rs
+++ b/modules/accounts_state/src/verifier.rs
@@ -195,7 +195,7 @@ impl Verifier {
                     Left(expected_spo) => {
                         error!(
                             "Missing rewards SPO: {} {} rewards",
-                            hex::encode(expected_spo.0),
+                            expected_spo.0,
                             expected_spo.1.len()
                         );
                         errors += 1;
@@ -203,7 +203,7 @@ impl Verifier {
                     Right(actual_spo) => {
                         error!(
                             "Extra rewards SPO: {} {} rewards",
-                            hex::encode(actual_spo.0),
+                            actual_spo.0,
                             actual_spo.1.len()
                         );
                         errors += 1;
@@ -222,7 +222,7 @@ impl Verifier {
                                 Left(expected) => {
                                     error!(
                                         "Missing reward: SPO {} account {} {:?} {}",
-                                        hex::encode(expected_spo.0),
+                                        expected_spo.0,
                                         expected.account,
                                         expected.rtype,
                                         expected.amount
@@ -232,17 +232,14 @@ impl Verifier {
                                 Right(actual) => {
                                     error!(
                                         "Extra reward: SPO {} account {} {:?} {}",
-                                        hex::encode(actual_spo.0),
-                                        actual.account,
-                                        actual.rtype,
-                                        actual.amount
+                                        actual_spo.0, actual.account, actual.rtype, actual.amount
                                     );
                                     errors += 1;
                                 }
                                 Both(expected, actual) => {
                                     if expected.amount != actual.amount {
                                         error!("Different reward: SPO {} account {} {:?} expected {}, actual {} ({})",
-                                               hex::encode(expected_spo.0),
+                                               expected_spo.0,
                                                expected.account,
                                                expected.rtype,
                                                expected.amount,
@@ -252,7 +249,7 @@ impl Verifier {
                                     } else {
                                         debug!(
                                             "Reward match: SPO {} account {} {:?} {}",
-                                            hex::encode(expected_spo.0),
+                                            expected_spo.0,
                                             expected.account,
                                             expected.rtype,
                                             expected.amount

--- a/modules/spo_state/src/state.rs
+++ b/modules/spo_state/src/state.rs
@@ -283,12 +283,9 @@ impl State {
         let deregistrations = self.pending_deregistrations.remove(&self.epoch);
         if let Some(deregistrations) = deregistrations {
             for dr in deregistrations {
-                debug!("Retiring SPO {}", hex::encode(dr));
+                debug!("Retiring SPO {}", dr);
                 match self.spos.remove(&dr) {
-                    None => error!(
-                        "Retirement requested for unregistered SPO {}",
-                        hex::encode(dr),
-                    ),
+                    None => error!("Retirement requested for unregistered SPO {}", dr,),
                     Some(_de_reg) => {
                         retired_spos.push(dr);
                     }
@@ -318,7 +315,7 @@ impl State {
                 epoch = self.epoch,
                 block = block.number,
                 "New pending SPO update {} {:?}",
-                hex::encode(reg.operator),
+                reg.operator,
                 reg
             );
             self.pending_updates.insert(reg.operator, reg.clone());
@@ -327,7 +324,7 @@ impl State {
                 epoch = self.epoch,
                 block = block.number,
                 "Registering SPO {} {:?}",
-                hex::encode(reg.operator),
+                reg.operator,
                 reg
             );
             self.spos.insert(reg.operator, reg.clone());
@@ -340,8 +337,7 @@ impl State {
             if deregistrations.len() != old_len {
                 debug!(
                     "Removed pending deregistration of SPO {} from epoch {}",
-                    hex::encode(reg.operator),
-                    epoch
+                    reg.operator, epoch
                 );
             }
         }
@@ -368,21 +364,17 @@ impl State {
     ) {
         debug!(
             "SPO {} wants to retire at the end of epoch {} (cert in block number {})",
-            hex::encode(ret.operator),
-            ret.epoch,
-            block.number
+            ret.operator, ret.epoch, block.number
         );
         if ret.epoch <= self.epoch {
             error!(
                 "SPO retirement received for current or past epoch {} for SPO {}",
-                ret.epoch,
-                hex::encode(ret.operator)
+                ret.epoch, ret.operator
             );
         } else if ret.epoch > self.epoch + TECHNICAL_PARAMETER_POOL_RETIRE_MAX_EPOCH {
             error!(
                 "SPO retirement received for epoch {} that exceeds future limit for SPO {}",
-                ret.epoch,
-                hex::encode(ret.operator)
+                ret.epoch, ret.operator
             );
         } else {
             // Replace any existing queued deregistrations
@@ -392,8 +384,7 @@ impl State {
                 if deregistrations.len() != old_len {
                     debug!(
                         "Replaced pending deregistration of SPO {} from epoch {}",
-                        hex::encode(ret.operator),
-                        epoch
+                        ret.operator, epoch
                     );
                 }
             }
@@ -412,7 +403,7 @@ impl State {
             } else {
                 error!(
                     "Historical SPO for {} not registered when try to retire it",
-                    hex::encode(ret.operator)
+                    ret.operator
                 );
             }
         }
@@ -443,8 +434,7 @@ impl State {
                             if !removed {
                                 error!(
                                     "Historical SPO state for {} does not contain delegator {}",
-                                    hex::encode(old_spo),
-                                    stake_address
+                                    old_spo, stake_address
                                 );
                             }
                         }
@@ -474,14 +464,13 @@ impl State {
                                 if !removed {
                                     error!(
                                         "Historical SPO state for {} does not contain delegator {}",
-                                        hex::encode(old_spo),
-                                        stake_address
+                                        old_spo, stake_address
                                     );
                                 }
                             }
                         }
                         _ => {
-                            error!("Missing Historical SPO state for {}", hex::encode(old_spo));
+                            error!("Missing Historical SPO state for {}", old_spo);
                         }
                     }
                 }
@@ -494,8 +483,7 @@ impl State {
                     if !added {
                         error!(
                             "Historical SPO state for {} already contains delegator {}",
-                            hex::encode(spo),
-                            stake_address
+                            spo, stake_address
                         );
                     }
                 }

--- a/processes/tx_submitter_cli/src/main.rs
+++ b/processes/tx_submitter_cli/src/main.rs
@@ -114,7 +114,7 @@ impl CliDriver {
                 TransactionsCommandResponse::Submitted { id },
             )) = response.as_ref()
             {
-                info!("Submitted TX {}", hex::encode(id));
+                info!("Submitted TX {}", id);
             } else {
                 info!("{response:?}");
             }


### PR DESCRIPTION
### What this does:
- Cleans up places where we invoke `hex::encode(...)`, since the fixed sized byte array types (`Hash<N>`, `PoolId`, `KeyHash` etc) all have their format implementation that does just this.