### PR TITLE
feat: reference script persistence in utxo state

### DIFF
--- a/codec/src/map_parameters.rs
+++ b/codec/src/map_parameters.rs
@@ -18,6 +18,7 @@ use acropolis_common::{
     rational_number::RationalNumber,
     *,
 };
+use pallas_primitives::conway::PseudoScript;
 use std::collections::{HashMap, HashSet};
 
 /// Map Pallas Network to our NetworkId
@@ -1096,6 +1097,24 @@ pub fn map_datum(datum: &Option<conway::MintedDatumOption>) -> Option<Datum> {
         }
         Some(pallas::ledger::primitives::conway::MintedDatumOption::Data(d)) => {
             Some(Datum::Inline(d.raw_cbor().to_vec()))
+        }
+        None => None,
+    }
+}
+
+pub fn map_reference_script(script: &Option<conway::MintedScriptRef>) -> Option<ReferenceScript> {
+    match script {
+        Some(PseudoScript::NativeScript(script)) => {
+            Some(ReferenceScript::Native(script.raw_cbor().to_vec()))
+        }
+        Some(PseudoScript::PlutusV1Script(script)) => {
+            Some(ReferenceScript::PlutusV1(script.as_ref().to_vec()))
+        }
+        Some(PseudoScript::PlutusV2Script(script)) => {
+            Some(ReferenceScript::PlutusV2(script.as_ref().to_vec()))
+        }
+        Some(PseudoScript::PlutusV3Script(script)) => {
+            Some(ReferenceScript::PlutusV3(script.as_ref().to_vec()))
         }
         None => None,
     }

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -324,6 +324,15 @@ pub enum Datum {
     Inline(Vec<u8>),
 }
 
+// The full CBOR bytes of a reference script
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub enum ReferenceScript {
+    Native(Vec<u8>),
+    PlutusV1(Vec<u8>),
+    PlutusV2(Vec<u8>),
+    PlutusV3(Vec<u8>),
+}
+
 /// Value (lovelace + multiasset)
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Value {
@@ -448,6 +457,9 @@ pub struct TxOutput {
 
     /// Datum (Inline or Hash)
     pub datum: Option<Datum>,
+
+    /// Reference script
+    pub reference_script: Option<ReferenceScript>,
 }
 
 /// Transaction input (UTXO reference)

--- a/modules/assets_state/src/state.rs
+++ b/modules/assets_state/src/state.rs
@@ -769,6 +769,7 @@ mod tests {
                 )],
             },
             datum: datum.map(Datum::Inline),
+            reference_script: None,
         }
     }
 

--- a/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
+++ b/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
@@ -152,6 +152,7 @@ impl GenesisBootstrapper {
                         }),
                         value: Value::new(*amount, Vec::new()),
                         datum: None,
+                        reference_script: None,
                     };
 
                     utxo_deltas_message.deltas.push(UTXODelta::Output(tx_output));

--- a/modules/tx_unpacker/src/tx_unpacker.rs
+++ b/modules/tx_unpacker/src/tx_unpacker.rs
@@ -230,6 +230,7 @@ impl TxUnpacker {
                                                                         address,
                                                                         value: map_parameters::map_value(&output.value()),
                                                                         datum: map_parameters::map_datum(&output.datum()),
+                                                                        reference_script: map_parameters::map_reference_script(&output.script_ref())
                                                                     }));
 
                                                                     // catch all output lovelaces

--- a/modules/utxo_state/src/fake_immutable_utxo_store.rs
+++ b/modules/utxo_state/src/fake_immutable_utxo_store.rs
@@ -53,6 +53,7 @@ impl ImmutableUTXOStore for FakeImmutableUTXOStore {
             address: Address::None,
             value: Value::new(42, Vec::new()),
             datum: None,
+            reference_script: None,
         }))
     }
 


### PR DESCRIPTION
This PR expands `tx_unpacker` to map Pallas `MintedScriptRef` values into the new `ReferenceScript` type and include these scripts in `UTXODeltasMessage`, enabling them to be persisted within their corresponding `UTXOValue` entries. 

This work is part of #256 for the `/accounts/{stake_address}/utxos` endpoint, which requires reference script hashes in its response. 