### PR TITLE
refactor: avoid overwriting blocks when clear-on-start is false

### DIFF
--- a/modules/chain_store/src/stores/fjall.rs
+++ b/modules/chain_store/src/stores/fjall.rs
@@ -11,6 +11,7 @@ pub struct FjallStore {
     keyspace: Keyspace,
     blocks: FjallBlockStore,
     txs: FjallTXStore,
+    last_persisted_block: Option<u64>,
 }
 
 const DEFAULT_DATABASE_PATH: &str = "fjall-blocks";
@@ -33,10 +34,20 @@ impl FjallStore {
         let keyspace = fjall_config.open()?;
         let blocks = FjallBlockStore::new(&keyspace)?;
         let txs = FjallTXStore::new(&keyspace)?;
+
+        let last_persisted_block = if !clear {
+            blocks.block_hashes_by_number.iter().next_back().and_then(|res| {
+                res.ok().and_then(|(key, _)| key.as_ref().try_into().ok().map(u64::from_be_bytes))
+            })
+        } else {
+            None
+        };
+
         Ok(Self {
             keyspace,
             blocks,
             txs,
+            last_persisted_block,
         })
     }
 }
@@ -67,6 +78,13 @@ impl super::Store for FjallStore {
         batch.commit()?;
 
         Ok(())
+    }
+
+    fn should_persist(&self, block_number: u64) -> bool {
+        match self.last_persisted_block {
+            Some(last) => block_number > last,
+            None => false,
+        }
     }
 
     fn get_block_by_hash(&self, hash: &[u8]) -> Result<Option<Block>> {
@@ -117,6 +135,7 @@ impl FjallBlockStore {
             BLOCK_HASHES_BY_EPOCH_SLOT_PARTITION,
             fjall::PartitionCreateOptions::default(),
         )?;
+
         Ok(Self {
             blocks,
             block_hashes_by_slot,

--- a/modules/chain_store/src/stores/mod.rs
+++ b/modules/chain_store/src/stores/mod.rs
@@ -5,6 +5,7 @@ pub mod fjall;
 
 pub trait Store: Send + Sync {
     fn insert_block(&self, info: &BlockInfo, block: &[u8]) -> Result<()>;
+    fn should_persist(&self, block_number: u64) -> bool;
 
     fn get_block_by_hash(&self, hash: &[u8]) -> Result<Option<Block>>;
     fn get_block_by_slot(&self, slot: u64) -> Result<Option<Block>>;


### PR DESCRIPTION
## Description
Refactors `chain_store` to stop overwriting blocks when `clear-on-start` is false. After the first full sync, subsequent syncs run 2-3x faster because persistence now resumes from `last_stored_block + 1`.

 To prevent corrupt state when switching networks, this adds `handle_first_block`, which compares the first block received from `cardano.block.available` with the stored block and returns an error if the block bodies differ. 

## Related Issue(s)
Speeds up development and testing for anything that depends on `chain_store`. Implemented primarily to accelerate testing of the `/addresses/{address}/utxos` endpoint in #335. 

## How was this tested?
* Verified persistence resumes at `last_stored_block + 1`
* Observed the 2-3x speedup on repeated runs. 

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
Major sync performance improvement (2-3x) after initial sync. Behavior unchanged when `clear-on-start = true`. 

## Reviewer notes / Areas to focus
All logic changes are fairly straight forward. 
