### PR TITLE
Undelegate stake from retiring pools

### DIFF
--- a/common/src/stake_addresses.rs
+++ b/common/src/stake_addresses.rs
@@ -448,6 +448,15 @@ impl StakeAddressMap {
         }
     }
 
+    /// Remove all delegations to a given SPO
+    pub fn remove_all_delegations_to(&mut self, spo: &PoolId) {
+        for sas in self.inner.values_mut() {
+            if sas.delegated_spo.as_ref() == Some(spo) {
+                sas.delegated_spo = None;
+            }
+        }
+    }
+
     /// Record a drep delegation
     pub fn record_drep_delegation(
         &mut self,
@@ -652,6 +661,26 @@ mod tests {
             assert_eq!(
                 stake_addresses.get(&stake_address).unwrap().delegated_spo,
                 Some(SPO_HASH)
+            );
+        }
+
+        #[test]
+        fn test_spo_delegation_and_retirement() {
+            let mut stake_addresses = StakeAddressMap::new();
+            let stake_address = create_stake_address(STAKE_KEY_HASH);
+
+            stake_addresses.register_stake_address(&stake_address);
+            assert!(stake_addresses.record_stake_delegation(&stake_address, &SPO_HASH));
+            assert_eq!(
+                stake_addresses.get(&stake_address).unwrap().delegated_spo,
+                Some(SPO_HASH)
+            );
+
+            // Retire the SPO
+            stake_addresses.remove_all_delegations_to(&SPO_HASH);
+            assert_eq!(
+                stake_addresses.get(&stake_address).unwrap().delegated_spo,
+                None
             );
         }
 

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -399,9 +399,12 @@ impl State {
         self.start_rewards_tx = Some(start_rewards_tx);
 
         // Now retire the SPOs fully
-        // TODO - wipe any delegations to retired pools
         for id in self.retiring_spos.drain(..) {
+            info!(epoch, "SPO {id} has retired");
             self.spos.remove(&id);
+
+            // Wipe any delegations to this pool
+            self.stake_addresses.lock().unwrap().remove_all_delegations_to(&id);
         }
 
         Ok(reward_deltas)

--- a/processes/omnibus/omnibus-rewards.toml
+++ b/processes/omnibus/omnibus-rewards.toml
@@ -1,0 +1,125 @@
+# Top-level configuration for Acropolis omnibus process
+# Cut down version for rewards testing only
+
+# ============================================================================
+# Startup Configuration
+# ============================================================================
+[global.startup]
+method = "mithril"  # Options: "mithril" | "snapshot"
+topic = "cardano.sequence.start"
+
+# ============================================================================
+# Bootstrap Module Configurations
+# ============================================================================
+[module.genesis-bootstrapper]
+
+[module.mithril-snapshot-fetcher]
+aggregator-url = "https://aggregator.release-mainnet.api.mithril.network/aggregator"
+genesis-key = "5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"
+# Download max age in hours. E.g. 8 means 8 hours (if there isn't any snapshot within this time range download from Mithril)
+download-max-age = "never"
+# Pause constraint E.g. "epoch:100", "block:1200"
+pause = "epoch:216"
+
+# ============================================================================
+# Core Module Configurations
+# ============================================================================
+
+[module.consensus]
+# List of validation result topics to listen on
+validators = [
+# Add these once they are actually being sent
+#           "cardano.validation.vrf",
+#           "cardano.validation.kes",
+#           "cardano.validation.utxo"
+]
+
+[module.block-unpacker]
+
+[module.tx-unpacker]
+publish-utxo-deltas-topic = "cardano.utxo.deltas"
+publish-asset-deltas-topic = "cardano.asset.deltas"
+publish-withdrawals-topic = "cardano.withdrawals"
+publish-certificates-topic = "cardano.certificates"
+publish-governance-topic = "cardano.governance"
+publish-block-txs-topic = "cardano.block.txs"
+network-name = "mainnet"
+
+[module.utxo-state]
+store = "memory" # "memory", "dashmap", "fjall", "fjall-async", "sled", "sled-async", "fake"
+address-delta-topic = "cardano.address.delta"
+
+[module.spo-state]
+# Enables /pools/{pool_id}/history endpoint, enables to query active_stakes
+store-epochs-history = false
+# Enable /pools/retired
+store-retired-pools = false
+# Enables /pools/{pool_id} endpoint
+store-registration = false
+# # Enables /pools/{pool_id}/updates endpoint
+store-updates = false
+# Enables /pools/{pool_id}/delegators endpoint (Requires store-stake-addresses to be enabled)
+store-delegators = false
+# Enables /pools/{pool_id}/votes endpoint
+store-votes = false
+# Store blocks, enables /pools/{pool_id}/blocks, /epochs/{number}/blocks/{pool_id}
+store-blocks = false
+# Store stake_addresses
+store-stake-addresses = false
+
+[module.spdd-state]
+# Enables active_stakes in /epochs/latest | {number} endpoints
+# Enables /epochs/{number}/{next | previous}
+store-spdd = false
+
+[module.drep-state]
+# Enables /governance/dreps/{drep_id} endpoint (Requires store-delegators to be enabled)
+store-info = false
+# Enables /governance/dreps/{drep_id}/delegators endpoint
+store-delegators = false
+# Enables /governance/dreps/{drep_id}/metadata endpoint
+store-metadata = false
+# Enables /governance/dreps/{drep_id}/updates endpoint
+store-updates = false
+# Enables /governance/dreps/{drep_id}/votes endpoint
+store-votes = false
+
+[module.drdd-state]
+store-drdd = false
+
+[module.governance-state]
+
+[module.parameters-state]
+store-history = false
+
+[module.stake-delta-filter]
+cache-mode = "predefined" # "predefined", "read", "write", "write-if-absent"
+write-full-cache = "false"
+
+[module.epochs-state]
+
+[module.accounts-state]
+# Enable /epochs/{number}/stakes & /epochs/{number}/stakes/{pool_id} endpoints
+spdd-retention-epochs = 0
+spdd-db-path = "./fjall-spdd"
+# Verify against captured CSV
+verify-pots-file = "../../modules/accounts_state/test-data/pots.mainnet.csv"
+verify-rewards-files = "../../modules/accounts_state/test-data/rewards.mainnet.{}.csv"
+
+[module.clock]
+
+# ============================================================================
+# Message Bus Configuration
+# ============================================================================
+[message-bus.internal]
+class = "in-memory"
+workers = 50
+dispatch-queue-size = 1000
+worker-queue-size = 100
+bulk-block-capacity = 50
+bulk-resume-capacity = 75
+
+# Message routing
+[[message-router.route]]  # Everything is internal only
+pattern = "#"
+bus = "internal"


### PR DESCRIPTION
Should fix divergence in active stake calculations

Also added special cut-down config to only run core functions, for reward and performance testing

$ cargo run --release -- --config omnibus-rewards.toml

## Description

Ensure that when a pool retires, all stake addresses that delegate to it are marked as undelegated.  This will affect
the 'active_stake' totals

## Related Issue(s)
Related to, but does not fix, #8 

## How was this tested?
Additional unit test, needs verification against active stake output from Haskell (@shd has the figures)

## Checklist

- [ X] My code builds and passes local tests
- [ X] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [ X] CI is green for this PR

## Impact / Side effects
-
## Reviewer notes / Areas to focus
-

Fixes #441 