### PR TITLE
feat:Add decoder and callbacks for Governance Protocol Parameters and Delegation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ run:
 fmt:
 	$(CARGO) fmt --all
 
+check:
+	$(CARGO) fmt --all -- --check
+
 clippy:
 	$(CARGO) clippy --workspace -- -D warnings
 

--- a/common/examples/test_streaming_parser.rs
+++ b/common/examples/test_streaming_parser.rs
@@ -2,6 +2,8 @@
 //
 // Usage: cargo run --example test_streaming_parser --release -- <snapshot_path>
 
+use acropolis_common::snapshot::protocol_parameters::ProtocolParameters;
+use acropolis_common::snapshot::streaming_snapshot::GovernanceProtocolParametersCallback;
 use acropolis_common::snapshot::EpochCallback;
 use acropolis_common::snapshot::{
     AccountState, DRepCallback, DRepInfo, GovernanceProposal, PoolCallback, PoolInfo,
@@ -30,6 +32,9 @@ struct CountingCallbacks {
     sample_accounts: Vec<AccountState>,
     sample_dreps: Vec<DRepInfo>,
     sample_proposals: Vec<GovernanceProposal>,
+    gs_previous_params: Option<ProtocolParameters>,
+    gs_current_params: Option<ProtocolParameters>,
+    gs_future_params: Option<ProtocolParameters>,
 }
 
 impl UtxoCallback for CountingCallbacks {
@@ -158,6 +163,115 @@ impl ProposalCallback for CountingCallbacks {
 
         // Keep first 10 for summary
         self.sample_proposals = proposals.into_iter().take(10).collect();
+        Ok(())
+    }
+}
+
+impl GovernanceProtocolParametersCallback for CountingCallbacks {
+    fn on_gs_protocol_parameters(
+        &mut self,
+        gs_previous_params: ProtocolParameters,
+        gs_current_params: ProtocolParameters,
+        gs_future_params: ProtocolParameters,
+    ) -> Result<()> {
+        eprintln!("\n=== Governance Protocol Parameters ===\n");
+
+        eprintln!("Previous Protocol Parameters:");
+        eprintln!(
+            "  Protocol Version: {}.{}",
+            gs_previous_params.protocol_version.major, gs_previous_params.protocol_version.minor
+        );
+        eprintln!("  Min Fee A: {}", gs_previous_params.min_fee_a);
+        eprintln!("  Min Fee B: {}", gs_previous_params.min_fee_b);
+        eprintln!(
+            "  Max Block Body Size: {}",
+            gs_previous_params.max_block_body_size
+        );
+        eprintln!(
+            "  Max Transaction Size: {}",
+            gs_previous_params.max_transaction_size
+        );
+        eprintln!(
+            "  Max Block Header Size: {}",
+            gs_previous_params.max_block_header_size
+        );
+        eprintln!(
+            "  Stake Pool Deposit: {}",
+            gs_previous_params.stake_pool_deposit
+        );
+        eprintln!(
+            "  Stake Credential Deposit: {}",
+            gs_previous_params.stake_credential_deposit
+        );
+        eprintln!("  Min Pool Cost: {}", gs_previous_params.min_pool_cost);
+        eprintln!(
+            "  Monetary Expansion: {}/{}",
+            gs_previous_params.monetary_expansion_rate.numerator,
+            gs_previous_params.monetary_expansion_rate.denominator
+        );
+        eprintln!(
+            "  Treasury Expansion: {}/{}",
+            gs_previous_params.treasury_expansion_rate.numerator,
+            gs_previous_params.treasury_expansion_rate.denominator
+        );
+
+        eprintln!("\nCurrent Protocol Parameters:");
+        eprintln!(
+            "  Protocol Version: {}.{}",
+            gs_current_params.protocol_version.major, gs_current_params.protocol_version.minor
+        );
+        eprintln!("  Min Fee A: {}", gs_current_params.min_fee_a);
+        eprintln!("  Min Fee B: {}", gs_current_params.min_fee_b);
+        eprintln!(
+            "  Max Block Body Size: {}",
+            gs_current_params.max_block_body_size
+        );
+        eprintln!(
+            "  Max Transaction Size: {}",
+            gs_current_params.max_transaction_size
+        );
+        eprintln!(
+            "  Max Block Header Size: {}",
+            gs_current_params.max_block_header_size
+        );
+        eprintln!(
+            "  Stake Pool Deposit: {}",
+            gs_current_params.stake_pool_deposit
+        );
+        eprintln!(
+            "  Stake Credential Deposit: {}",
+            gs_current_params.stake_credential_deposit
+        );
+        eprintln!("  Min Pool Cost: {}", gs_current_params.min_pool_cost);
+        eprintln!(
+            "  Monetary Expansion: {}/{}",
+            gs_current_params.monetary_expansion_rate.numerator,
+            gs_current_params.monetary_expansion_rate.denominator
+        );
+        eprintln!(
+            "  Treasury Expansion: {}/{}",
+            gs_current_params.treasury_expansion_rate.numerator,
+            gs_current_params.treasury_expansion_rate.denominator
+        );
+
+        eprintln!("\nFuture Protocol Parameters:");
+        eprintln!(
+            "  Protocol Version: {}.{}",
+            gs_future_params.protocol_version.major, gs_future_params.protocol_version.minor
+        );
+        eprintln!("  Min Fee A: {}", gs_future_params.min_fee_a);
+        eprintln!("  Min Fee B: {}", gs_future_params.min_fee_b);
+        eprintln!(
+            "  Max Block Body Size: {}",
+            gs_future_params.max_block_body_size
+        );
+
+        // Store for later display
+        self.gs_previous_params = Some(gs_previous_params);
+        self.gs_current_params = Some(gs_current_params);
+        self.gs_future_params = Some(gs_future_params);
+
+        eprintln!("\n=== End Protocol Parameters ===\n");
         Ok(())
     }
 }

--- a/common/src/protocol_params.rs
+++ b/common/src/protocol_params.rs
@@ -195,7 +195,7 @@ impl PraosParams {
 
 impl From<&ShelleyParams> for PraosParams {
     fn from(params: &ShelleyParams) -> Self {
-        let active_slots_coeff = params.active_slots_coeff;
+        let active_slots_coeff = &params.active_slots_coeff;
         let security_param = params.security_param;
         let stability_window =
             (security_param as u64) * active_slots_coeff.denom() / active_slots_coeff.numer() * 3;
@@ -204,7 +204,7 @@ impl From<&ShelleyParams> for PraosParams {
 
         Self {
             security_param,
-            active_slots_coeff,
+            active_slots_coeff: active_slots_coeff.clone(),
             epoch_length: params.epoch_length,
             max_kes_evolutions: params.max_kes_evolutions,
             max_lovelace_supply: params.max_lovelace_supply,

--- a/common/src/snapshot/decode.rs
+++ b/common/src/snapshot/decode.rs
@@ -1,0 +1,665 @@
+// Copyright 2025 PRAGMA
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+use minicbor as cbor;
+#[cfg(test)]
+use std::fmt::Display;
+
+// Misc
+// ----------------------------------------------------------------------------
+
+pub fn decode_break<'d>(
+    d: &mut cbor::Decoder<'d>,
+    len: Option<u64>,
+) -> Result<bool, cbor::decode::Error> {
+    if d.datatype()? == cbor::data::Type::Break {
+        // NOTE: If we encounter a rogue Break while decoding a definite map, that's an error.
+        if len.is_some() {
+            return Err(cbor::decode::Error::type_mismatch(cbor::data::Type::Break));
+        }
+
+        d.skip()?;
+
+        return Ok(true);
+    }
+
+    Ok(false)
+}
+
+// Array
+// ----------------------------------------------------------------------------
+
+/// Decode any heterogeneous CBOR array, irrespective of whether they're indefinite or definite.
+pub fn heterogeneous_array<'d, A>(
+    d: &mut cbor::Decoder<'d>,
+    elems: impl FnOnce(
+        &mut cbor::Decoder<'d>,
+        Box<dyn FnOnce(u64) -> Result<(), cbor::decode::Error>>,
+    ) -> Result<A, cbor::decode::Error>,
+) -> Result<A, cbor::decode::Error> {
+    let len = d.array()?;
+
+    match len {
+        None => {
+            let result = elems(d, Box::new(|_| Ok(())))?;
+            decode_break(d, len)?;
+            Ok(result)
+        }
+        Some(len) => elems(
+            d,
+            Box::new(move |expected_len| {
+                if len != expected_len {
+                    return Err(cbor::decode::Error::message(format!(
+                        "CBOR array length mismatch: expected {expected_len} got {len}"
+                    )));
+                }
+
+                Ok(())
+            }),
+        ),
+    }
+}
+
+// Map
+// ----------------------------------------------------------------------------
+
+/// Decode any heterogeneous CBOR map, irrespective of whether they're indefinite or definite.
+///
+/// A good choice for `S` is generally to pick a tuple of `PartialDecoder<_>` for each field item
+/// that needs decoding. For example:
+///
+/// ```rs
+/// let (address, value, datum, script) = decode_map(
+///     d,
+///     (
+///         missing_field::<Output, _>(0),
+///         missing_field::<Output, _>(1),
+///         with_default_value(MemoizedDatum::None),
+///         with_default_value(None),
+///     ),
+///     |d| d.u8(),
+///     |d, state, field| {
+///         match field {
+///             0 => state.0 = decode_chunk(d, |d| decode_address(d.bytes()?)),
+///             1 => state.1 = decode_chunk(d, |d| d.decode()),
+///             2 => state.2 = decode_chunk(d, decode_datum),
+///             3 => state.3 = decode_chunk(d, decode_reference_script),
+///             _ => return unexpected_field::<Output, _>(field),
+///         }
+///         Ok(())
+///     },
+/// )?;
+/// ```
+#[cfg(test)]
+pub fn heterogeneous_map<K, S>(
+    d: &mut cbor::Decoder<'_>,
+    mut state: S,
+    decode_key: impl Fn(&mut cbor::Decoder<'_>) -> Result<K, cbor::decode::Error>,
+    mut decode_value: impl FnMut(&mut cbor::Decoder<'_>, &mut S, K) -> Result<(), cbor::decode::Error>,
+) -> Result<S, cbor::decode::Error> {
+    let len = d.map()?;
+
+    let mut n = 0;
+    while len.is_none() || Some(n) < len {
+        if decode_break(d, len)? {
+            break;
+        }
+
+        let k = decode_key(d)?;
+        decode_value(d, &mut state, k)?;
+
+        n += 1;
+    }
+
+    Ok(state)
+}
+
+// PartialDecoder
+// ----------------------------------------------------------------------------
+
+/// A decoder that is part of another larger one. This is particularly useful to decode map
+/// key/value in an arbitrary order; while logically recomposing them in a readable order.
+#[cfg(test)]
+type PartialDecoder<A> = Box<dyn FnOnce() -> Result<A, cbor::decode::Error>>;
+
+/// Wrap a decoder as a `PartialDecoder`; this is mostly a convenient utility to avoid boilerplate.
+#[cfg(test)]
+pub fn decode_chunk<A: 'static>(
+    d: &mut cbor::Decoder<'_>,
+    decode: impl FnOnce(&mut cbor::Decoder<'_>) -> Result<A, cbor::decode::Error>,
+) -> PartialDecoder<A> {
+    // NOTE: It is crucial that this happens *outside* of the boxed closure, to ensure bytes are consumed
+    // when the closure is created; not when it is invoked!
+    let a = decode(d);
+    Box::new(|| a)
+}
+
+/// Yield a `PartialDecoder` that fails with a comprehensible error message when an expected field
+/// is missing from the map.
+#[cfg(test)]
+pub fn missing_field<C: ?Sized, A>(field_tag: impl Display) -> PartialDecoder<A> {
+    let msg = format!(
+        "missing <{}> at field .{field_tag} in <{}> CBOR map",
+        std::any::type_name::<A>(),
+        std::any::type_name::<C>(),
+    );
+    Box::new(move || Err(cbor::decode::Error::message(msg)))
+}
+
+/// Yield a `PartialDecoder` that always succeeds with the given default value.
+#[cfg(test)]
+pub fn with_default_value<A: 'static>(default: A) -> PartialDecoder<A> {
+    Box::new(move || Ok(default))
+}
+
+/// Yield a `Result<_, decode::Error>` that always fails with a comprehensible error message when a
+/// map key is unexpected.
+#[cfg(test)]
+pub fn unexpected_field<C: ?Sized, A>(field_tag: impl Display) -> Result<A, cbor::decode::Error> {
+    Err(cbor::decode::Error::message(format!(
+        "unexpected field .{field_tag} in <{}> CBOR map",
+        std::any::type_name::<C>(),
+    )))
+}
+
+// Tests
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Debug;
+
+    // Test fixtures
+    #[derive(Debug, PartialEq, Eq, Clone, Copy)]
+    struct Foo {
+        field0: u64,
+        field1: u64,
+    }
+
+    // Wrapper for encoding as definite-length array
+    struct AsDefinite<T>(T);
+
+    impl cbor::encode::Encode<()> for AsDefinite<&Foo> {
+        fn encode<W: cbor::encode::Write>(
+            &self,
+            e: &mut cbor::Encoder<W>,
+            _ctx: &mut (),
+        ) -> Result<(), cbor::encode::Error<W::Error>> {
+            e.array(2)?;
+            e.u64(self.0.field0)?;
+            e.u64(self.0.field1)?;
+            Ok(())
+        }
+    }
+
+    impl<'d, C> cbor::decode::Decode<'d, C> for AsDefinite<Foo> {
+        fn decode(d: &mut cbor::Decoder<'d>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
+            let len = d.array()?;
+            if len != Some(2) {
+                return Err(cbor::decode::Error::message(
+                    "expected definite array of length 2",
+                ));
+            }
+            Ok(AsDefinite(Foo {
+                field0: d.decode_with(ctx)?,
+                field1: d.decode_with(ctx)?,
+            }))
+        }
+    }
+
+    // Wrapper for encoding as indefinite-length array
+    struct AsIndefinite<T>(T);
+
+    impl cbor::encode::Encode<()> for AsIndefinite<&Foo> {
+        fn encode<W: cbor::encode::Write>(
+            &self,
+            e: &mut cbor::Encoder<W>,
+            _ctx: &mut (),
+        ) -> Result<(), cbor::encode::Error<W::Error>> {
+            e.begin_array()?;
+            e.u64(self.0.field0)?;
+            e.u64(self.0.field1)?;
+            e.end()?;
+            Ok(())
+        }
+    }
+
+    impl<'d, C> cbor::decode::Decode<'d, C> for AsIndefinite<Foo> {
+        fn decode(d: &mut cbor::Decoder<'d>, ctx: &mut C) -> Result<Self, cbor::decode::Error> {
+            let len = d.array()?;
+            if len.is_some() {
+                return Err(cbor::decode::Error::message("expected indefinite array"));
+            }
+            let field0 = d.decode_with(ctx)?;
+            let field1 = d.decode_with(ctx)?;
+            if d.datatype()? != cbor::data::Type::Break {
+                return Err(cbor::decode::Error::message("expected break"));
+            }
+            d.skip()?;
+            Ok(AsIndefinite(Foo { field0, field1 }))
+        }
+    }
+
+    // Wrapper for encoding as map
+    struct AsMap<T>(T);
+
+    impl cbor::encode::Encode<()> for AsMap<&Foo> {
+        fn encode<W: cbor::encode::Write>(
+            &self,
+            e: &mut cbor::Encoder<W>,
+            _ctx: &mut (),
+        ) -> Result<(), cbor::encode::Error<W::Error>> {
+            e.map(2)?;
+            e.u8(0)?;
+            e.u64(self.0.field0)?;
+            e.u8(1)?;
+            e.u64(self.0.field1)?;
+            Ok(())
+        }
+    }
+
+    // Composed encoders
+    impl cbor::encode::Encode<()> for AsIndefinite<AsMap<&Foo>> {
+        fn encode<W: cbor::encode::Write>(
+            &self,
+            e: &mut cbor::Encoder<W>,
+            _ctx: &mut (),
+        ) -> Result<(), cbor::encode::Error<W::Error>> {
+            e.begin_map()?;
+            e.u8(0)?;
+            e.u64(self.0 .0.field0)?;
+            e.u8(1)?;
+            e.u64(self.0 .0.field1)?;
+            e.end()?;
+            Ok(())
+        }
+    }
+
+    impl cbor::encode::Encode<()> for AsDefinite<AsMap<&Foo>> {
+        fn encode<W: cbor::encode::Write>(
+            &self,
+            e: &mut cbor::Encoder<W>,
+            _ctx: &mut (),
+        ) -> Result<(), cbor::encode::Error<W::Error>> {
+            e.map(2)?;
+            e.u8(0)?;
+            e.u64(self.0 .0.field0)?;
+            e.u8(1)?;
+            e.u64(self.0 .0.field1)?;
+            Ok(())
+        }
+    }
+
+    // Helper functions
+    fn to_cbor<T: for<'c> cbor::encode::Encode<()>>(value: &T) -> Vec<u8> {
+        let mut buf = Vec::new();
+        let mut encoder = cbor::Encoder::new(&mut buf);
+        encoder.encode(value).unwrap();
+        buf
+    }
+
+    fn from_cbor<'d, T: cbor::decode::Decode<'d, ()>>(bytes: &'d [u8]) -> Option<T> {
+        cbor::decode(bytes).ok()
+    }
+
+    fn from_cbor_no_leftovers<'d, T: cbor::decode::Decode<'d, ()>>(
+        bytes: &'d [u8],
+    ) -> Result<T, cbor::decode::Error> {
+        let mut decoder = cbor::Decoder::new(bytes);
+        let result = decoder.decode()?;
+        if decoder.position() != bytes.len() {
+            return Err(cbor::decode::Error::message("leftover bytes"));
+        }
+        Ok(result)
+    }
+
+    fn assert_ok<T: Eq + Debug + for<'d> cbor::decode::Decode<'d, ()>>(left: T, bytes: &[u8]) {
+        assert_eq!(
+            Ok(left),
+            from_cbor_no_leftovers::<T>(bytes).map_err(|e| e.to_string())
+        );
+    }
+
+    fn assert_err<T: Debug + for<'d> cbor::decode::Decode<'d, ()>>(msg: &str, bytes: &[u8]) {
+        match from_cbor_no_leftovers::<T>(bytes).map_err(|e| e.to_string()) {
+            Err(e) => assert!(e.contains(msg), "{e}"),
+            Ok(ok) => panic!("expected error but got {:#?}", ok),
+        }
+    }
+
+    const FIXTURE: Foo = Foo {
+        field0: 14,
+        field1: 42,
+    };
+
+    mod heterogeneous_array_tests {
+        use super::*;
+
+        #[test]
+        fn happy_case() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            // A flexible decoder that can ingest both definite and indefinite arrays.
+            impl<'d, C> cbor::decode::Decode<'d, C> for TestCase<Foo> {
+                fn decode(
+                    d: &mut cbor::Decoder<'d>,
+                    ctx: &mut C,
+                ) -> Result<Self, cbor::decode::Error> {
+                    heterogeneous_array(d, |d, assert_len| {
+                        assert_len(2)?;
+                        Ok(TestCase(Foo {
+                            field0: d.decode_with(ctx)?,
+                            field1: d.decode_with(ctx)?,
+                        }))
+                    })
+                }
+            }
+
+            assert_ok(TestCase(FIXTURE), &to_cbor(&AsDefinite(&FIXTURE)));
+            assert_ok(TestCase(FIXTURE), &to_cbor(&AsIndefinite(&FIXTURE)));
+        }
+
+        #[test]
+        fn smaller_definite_length() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            // A decoder which expects less elements than actually supplied.
+            impl<'d, C> cbor::decode::Decode<'d, C> for TestCase<Foo> {
+                fn decode(
+                    d: &mut cbor::Decoder<'d>,
+                    ctx: &mut C,
+                ) -> Result<Self, cbor::decode::Error> {
+                    heterogeneous_array(d, |d, assert_len| {
+                        assert_len(1)?;
+                        Ok(TestCase(Foo {
+                            field0: d.decode_with(ctx)?,
+                            field1: d.decode_with(ctx)?,
+                        }))
+                    })
+                }
+            }
+
+            assert_err::<TestCase<Foo>>("array length mismatch", &to_cbor(&AsDefinite(&FIXTURE)));
+        }
+
+        #[test]
+        fn larger_definite_length() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            // A decoder which expects more elements than actually supplied.
+            impl<'d, C> cbor::decode::Decode<'d, C> for TestCase<Foo> {
+                fn decode(
+                    d: &mut cbor::Decoder<'d>,
+                    ctx: &mut C,
+                ) -> Result<Self, cbor::decode::Error> {
+                    heterogeneous_array(d, |d, assert_len| {
+                        assert_len(3)?;
+                        Ok(TestCase(Foo {
+                            field0: d.decode_with(ctx)?,
+                            field1: d.decode_with(ctx)?,
+                        }))
+                    })
+                }
+            }
+
+            assert_err::<TestCase<Foo>>("array length mismatch", &to_cbor(&AsDefinite(&FIXTURE)))
+        }
+
+        #[test]
+        fn incomplete_indefinite() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            // An incomplete encoder, which skips the final break on indefinite arrays.
+            impl cbor::encode::Encode<()> for TestCase<&Foo> {
+                fn encode<W: cbor::encode::Write>(
+                    &self,
+                    e: &mut cbor::Encoder<W>,
+                    _ctx: &mut (),
+                ) -> Result<(), cbor::encode::Error<W::Error>> {
+                    e.begin_array()?;
+                    e.u64(self.0.field0)?;
+                    e.u64(self.0.field1)?;
+                    Ok(())
+                }
+            }
+
+            let bytes = to_cbor(&TestCase(&FIXTURE));
+
+            assert!(from_cbor::<AsDefinite<Foo>>(&bytes).is_none());
+            assert!(from_cbor::<AsIndefinite<Foo>>(&bytes).is_none());
+        }
+    }
+
+    mod heterogeneous_map_tests {
+        use super::*;
+
+        /// A decoder for `Foo` that interpret it as a map, and fails in case of a missing field.
+        #[derive(Debug, PartialEq, Eq)]
+        struct NoMissingFields<A>(A);
+        impl<'d, C> cbor::decode::Decode<'d, C> for NoMissingFields<Foo> {
+            fn decode(
+                d: &mut cbor::Decoder<'d>,
+                _ctx: &mut C,
+            ) -> Result<Self, cbor::decode::Error> {
+                let (field0, field1) = heterogeneous_map(
+                    d,
+                    (missing_field::<Foo, _>(0), missing_field::<Foo, _>(1)),
+                    |d| d.u8(),
+                    |d, state, field| {
+                        match field {
+                            0 => state.0 = decode_chunk(d, |d| d.u64()),
+                            1 => state.1 = decode_chunk(d, |d| d.u64()),
+                            _ => return unexpected_field::<Foo, _>(field),
+                        }
+                        Ok(())
+                    },
+                )?;
+
+                Ok(NoMissingFields(Foo {
+                    field0: field0()?,
+                    field1: field1()?,
+                }))
+            }
+        }
+
+        /// A decoder for `Foo` that interpret it as a map, but allows fields to be missing.
+        #[derive(Debug, PartialEq, Eq)]
+        struct WithDefaultValues<A>(A);
+        impl<'d, C> cbor::decode::Decode<'d, C> for WithDefaultValues<Foo> {
+            fn decode(
+                d: &mut cbor::Decoder<'d>,
+                _ctx: &mut C,
+            ) -> Result<Self, cbor::decode::Error> {
+                let (field0, field1) = heterogeneous_map(
+                    d,
+                    (with_default_value(14_u64), with_default_value(42_u64)),
+                    |d| d.u8(),
+                    |d, state, field| {
+                        match field {
+                            0 => state.0 = decode_chunk(d, |d| d.u64()),
+                            1 => state.1 = decode_chunk(d, |d| d.u64()),
+                            _ => return unexpected_field::<Foo, _>(field),
+                        }
+                        Ok(())
+                    },
+                )?;
+
+                Ok(WithDefaultValues(Foo {
+                    field0: field0()?,
+                    field1: field1()?,
+                }))
+            }
+        }
+
+        #[test]
+        fn no_optional_fields_no_missing_fields() {
+            assert_ok(
+                NoMissingFields(FIXTURE),
+                &to_cbor(&AsIndefinite(AsMap(&FIXTURE))),
+            );
+
+            assert_ok(
+                NoMissingFields(FIXTURE),
+                &to_cbor(&AsDefinite(AsMap(&FIXTURE))),
+            );
+        }
+
+        #[test]
+        fn out_of_order_fields() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            // An invalid encoder, which adds an extra break in an definite map.
+            impl cbor::encode::Encode<()> for TestCase<&Foo> {
+                fn encode<W: cbor::encode::Write>(
+                    &self,
+                    e: &mut cbor::Encoder<W>,
+                    _ctx: &mut (),
+                ) -> Result<(), cbor::encode::Error<W::Error>> {
+                    e.map(2)?;
+                    e.u8(1)?;
+                    e.u64(self.0.field1)?;
+                    e.u8(0)?;
+                    e.u64(self.0.field0)?;
+                    Ok(())
+                }
+            }
+
+            assert_ok(NoMissingFields(FIXTURE), &to_cbor(&TestCase(&FIXTURE)));
+        }
+
+        #[test]
+        fn optional_fields_no_missing_fields() {
+            assert_ok(
+                WithDefaultValues(FIXTURE),
+                &to_cbor(&AsIndefinite(AsMap(&FIXTURE))),
+            );
+
+            assert_ok(
+                WithDefaultValues(FIXTURE),
+                &to_cbor(&AsDefinite(AsMap(&FIXTURE))),
+            );
+        }
+
+        #[test]
+        fn one_field_missing() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            impl cbor::encode::Encode<()> for TestCase<AsIndefinite<&Foo>> {
+                fn encode<W: cbor::encode::Write>(
+                    &self,
+                    e: &mut cbor::Encoder<W>,
+                    _ctx: &mut (),
+                ) -> Result<(), cbor::encode::Error<W::Error>> {
+                    e.map(1)?;
+                    e.u8(0)?;
+                    e.u64(self.0 .0.field0)?;
+                    Ok(())
+                }
+            }
+
+            impl cbor::encode::Encode<()> for TestCase<AsDefinite<&Foo>> {
+                fn encode<W: cbor::encode::Write>(
+                    &self,
+                    e: &mut cbor::Encoder<W>,
+                    _ctx: &mut (),
+                ) -> Result<(), cbor::encode::Error<W::Error>> {
+                    e.begin_map()?;
+                    e.u8(1)?;
+                    e.u64(self.0 .0.field1)?;
+                    e.end()?;
+                    Ok(())
+                }
+            }
+
+            assert_err::<NoMissingFields<Foo>>(
+                "missing <u64> at field .1",
+                &to_cbor(&TestCase(AsIndefinite(&FIXTURE))),
+            );
+
+            assert_ok(
+                WithDefaultValues(FIXTURE),
+                &to_cbor(&TestCase(AsIndefinite(&FIXTURE))),
+            );
+
+            assert_err::<NoMissingFields<Foo>>(
+                "missing <u64> at field .0",
+                &to_cbor(&TestCase(AsDefinite(&FIXTURE))),
+            );
+
+            assert_ok(
+                WithDefaultValues(FIXTURE),
+                &to_cbor(&TestCase(AsDefinite(&FIXTURE))),
+            );
+        }
+
+        #[test]
+        fn rogue_break() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            // An invalid encoder, which adds an extra break in an definite map.
+            impl cbor::encode::Encode<()> for TestCase<&Foo> {
+                fn encode<W: cbor::encode::Write>(
+                    &self,
+                    e: &mut cbor::Encoder<W>,
+                    _ctx: &mut (),
+                ) -> Result<(), cbor::encode::Error<W::Error>> {
+                    e.map(2)?;
+                    e.u8(0)?;
+                    e.u64(self.0.field0)?;
+                    e.end()?;
+                    Ok(())
+                }
+            }
+
+            assert_err::<WithDefaultValues<Foo>>(
+                "unexpected type break",
+                &to_cbor(&TestCase(&FIXTURE)),
+            );
+        }
+
+        #[test]
+        fn unexpected_field_tag() {
+            #[derive(Debug, PartialEq, Eq)]
+            struct TestCase<A>(A);
+
+            // An invalid encoder, which adds an extra break in an definite map.
+            impl cbor::encode::Encode<()> for TestCase<&Foo> {
+                fn encode<W: cbor::encode::Write>(
+                    &self,
+                    e: &mut cbor::Encoder<W>,
+                    _ctx: &mut (),
+                ) -> Result<(), cbor::encode::Error<W::Error>> {
+                    e.map(2)?;
+                    e.u8(0)?;
+                    e.u64(self.0.field0)?;
+                    e.u8(14)?;
+                    e.u64(self.0.field0)?;
+                    Ok(())
+                }
+            }
+
+            assert_err::<WithDefaultValues<Foo>>(
+                "unexpected field .14",
+                &to_cbor(&TestCase(&FIXTURE)),
+            );
+        }
+    }
+}

--- a/common/src/snapshot/mod.rs
+++ b/common/src/snapshot/mod.rs
@@ -10,10 +10,12 @@
 //! - Error types (`error.rs`)
 
 // Submodules
+mod decode;
 mod error;
 pub mod mark_set_go;
 mod parser;
 pub mod pool_params;
+pub mod protocol_parameters;
 pub mod streaming_snapshot;
 
 // Re-export error types

--- a/common/src/snapshot/protocol_parameters.rs
+++ b/common/src/snapshot/protocol_parameters.rs
@@ -1,0 +1,420 @@
+use crate::rational_number::RationalNumber;
+use crate::{protocol_params::ProtocolVersion, snapshot::streaming_snapshot::Epoch};
+pub use crate::{
+    CostModel, CostModels, DRepVotingThresholds, ExUnitPrices, ExUnits, Lovelace,
+    PoolVotingThresholds, ProtocolParamUpdate, Ratio,
+};
+
+use crate::snapshot::decode::heterogeneous_array;
+use minicbor::{data::Tag, Decoder};
+
+/// Model from https://github.com/IntersectMBO/formal-ledger-specifications/blob/master/src/Ledger/PParams.lagda
+/// Some of the names have been adapted to improve readability.
+/// Also see https://github.com/IntersectMBO/cardano-ledger/blob/d90eb4df4651970972d860e95f1a3697a3de8977/eras/conway/impl/cddl-files/conway.cddl#L324
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtocolParameters {
+    // Outside of all groups.
+    pub protocol_version: ProtocolVersion,
+
+    // Network group
+    pub max_block_body_size: u64,
+    pub max_transaction_size: u64,
+    pub max_block_header_size: u16,
+    pub max_tx_ex_units: ExUnits,
+    pub max_block_ex_units: ExUnits,
+    pub max_value_size: u64,
+    pub max_collateral_inputs: u16,
+
+    // Economic group
+    pub min_fee_a: Lovelace,
+    pub min_fee_b: u64,
+    pub stake_credential_deposit: Lovelace,
+    pub stake_pool_deposit: Lovelace,
+    pub monetary_expansion_rate: Ratio,
+    pub treasury_expansion_rate: Ratio,
+    pub min_pool_cost: u64,
+    pub lovelace_per_utxo_byte: Lovelace,
+    pub prices: ExUnitPrices,
+    pub min_fee_ref_script_lovelace_per_byte: Ratio,
+    pub max_ref_script_size_per_tx: u32,
+    pub max_ref_script_size_per_block: u32,
+    pub ref_script_cost_stride: u32,
+    pub ref_script_cost_multiplier: Ratio,
+
+    // Technical group
+    pub stake_pool_max_retirement_epoch: Epoch,
+    pub optimal_stake_pools_count: u16,
+    pub pledge_influence: Ratio,
+    pub collateral_percentage: u16,
+    pub cost_models: CostModels,
+
+    // Governance group
+    pub pool_voting_thresholds: PoolVotingThresholds,
+    pub drep_voting_thresholds: DRepVotingThresholds,
+    pub min_committee_size: u16,
+    pub max_committee_term_length: Epoch,
+    pub gov_action_lifetime: Epoch,
+    pub gov_action_deposit: Lovelace,
+    pub drep_deposit: Lovelace,
+    pub drep_expiry: Epoch,
+}
+
+fn allow_tag(d: &mut Decoder<'_>, expected: Tag) -> Result<(), minicbor::decode::Error> {
+    if d.datatype()? == minicbor::data::Type::Tag {
+        let tag = d.tag()?;
+        if tag != expected {
+            return Err(minicbor::decode::Error::message(format!(
+                "invalid CBOR tag: expected {expected} got {tag}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn decode_rationale(d: &mut Decoder<'_>) -> Result<Ratio, minicbor::decode::Error> {
+    allow_tag(d, Tag::new(30))?;
+    heterogeneous_array(d, |d, assert_len| {
+        assert_len(2)?;
+        let numerator = d.u64()?;
+        let denominator = d.u64()?;
+        Ok(Ratio {
+            numerator,
+            denominator,
+        })
+    })
+}
+
+impl Default for ProtocolParameters {
+    fn default() -> Self {
+        ProtocolParameters {
+            protocol_version: ProtocolVersion { major: 0, minor: 0 },
+            min_fee_a: 0,
+            min_fee_b: 0,
+            max_block_body_size: 0,
+            max_transaction_size: 0,
+            max_block_header_size: 0,
+            stake_credential_deposit: 0,
+            stake_pool_deposit: 0,
+            stake_pool_max_retirement_epoch: 0,
+            optimal_stake_pools_count: 0,
+            pledge_influence: Ratio {
+                numerator: 0,
+                denominator: 1,
+            },
+            monetary_expansion_rate: Ratio {
+                numerator: 0,
+                denominator: 1,
+            },
+            treasury_expansion_rate: Ratio {
+                numerator: 0,
+                denominator: 1,
+            },
+            min_pool_cost: 0,
+            lovelace_per_utxo_byte: 0,
+            cost_models: CostModels {
+                plutus_v1: None,
+                plutus_v2: None,
+                plutus_v3: None,
+            },
+            prices: ExUnitPrices {
+                mem_price: RationalNumber::from(0, 1),
+                step_price: RationalNumber::from(0, 1),
+            },
+            max_tx_ex_units: ExUnits { mem: 0, steps: 0 },
+            max_block_ex_units: ExUnits { mem: 0, steps: 0 },
+            max_value_size: 0,
+            collateral_percentage: 0,
+            max_collateral_inputs: 0,
+            pool_voting_thresholds: PoolVotingThresholds {
+                motion_no_confidence: RationalNumber::from(0, 1),
+                committee_normal: RationalNumber::from(0, 1),
+                committee_no_confidence: RationalNumber::from(0, 1),
+                hard_fork_initiation: RationalNumber::from(0, 1),
+                security_voting_threshold: RationalNumber::from(0, 1),
+            },
+            drep_voting_thresholds: DRepVotingThresholds {
+                motion_no_confidence: RationalNumber::from(0, 1),
+                committee_normal: RationalNumber::from(0, 1),
+                committee_no_confidence: RationalNumber::from(0, 1),
+                update_constitution: RationalNumber::from(0, 1),
+                hard_fork_initiation: RationalNumber::from(0, 1),
+                pp_network_group: RationalNumber::from(0, 1),
+                pp_economic_group: RationalNumber::from(0, 1),
+                pp_technical_group: RationalNumber::from(0, 1),
+                pp_governance_group: RationalNumber::from(0, 1),
+                treasury_withdrawal: RationalNumber::from(0, 1),
+            },
+            min_committee_size: 0,
+            max_committee_term_length: 0,
+            gov_action_lifetime: 0,
+            gov_action_deposit: 0,
+            drep_deposit: 0,
+            drep_expiry: 0,
+            min_fee_ref_script_lovelace_per_byte: Ratio {
+                numerator: 0,
+                denominator: 1,
+            },
+            max_ref_script_size_per_tx: 0,
+            max_ref_script_size_per_block: 0,
+            ref_script_cost_stride: 0,
+            ref_script_cost_multiplier: Ratio {
+                numerator: 1,
+                denominator: 1,
+            },
+        }
+    }
+}
+
+fn decode_protocol_version(
+    d: &mut Decoder<'_>,
+) -> Result<ProtocolVersion, minicbor::decode::Error> {
+    heterogeneous_array(d, |d, assert_len| {
+        assert_len(2)?;
+        let major: u8 = d.u8()?;
+
+        // See: https://github.com/IntersectMBO/cardano-ledger/blob/693218df6cd90263da24e6c2118bac420ceea3a1/eras/conway/impl/cddl-files/conway.cddl#L126
+        if major > 12 {
+            return Err(minicbor::decode::Error::message(
+                "invalid protocol version's major: too high",
+            ));
+        }
+        Ok(ProtocolVersion {
+            major: major as u64,
+            minor: d.u64()?,
+        })
+    })
+}
+
+impl<'b, C> minicbor::decode::Decode<'b, C> for ProtocolParameters {
+    fn decode(d: &mut minicbor::Decoder<'b>, ctx: &mut C) -> Result<Self, minicbor::decode::Error> {
+        d.array()?;
+
+        // Check first field - for future params it might be a variant tag
+        let first_field_type = d.datatype()?;
+
+        // Peek at the value if it's U8
+        if first_field_type == minicbor::data::Type::U8 {
+            let tag_value = d.u8()?;
+
+            // future_pparams = [0] / [1, pparams_real] / [2, strict_maybe<pparams_real>]
+            if tag_value == 0 {
+                // Return default/empty protocol parameters
+                return Ok(ProtocolParameters::default());
+            } else if tag_value == 1 {
+                // Continue with normal parsing below (tag already consumed)
+            } else if tag_value == 2 {
+                // Next element might be Nothing or Just(params)
+                // For now, skip this case
+                return Err(minicbor::decode::Error::message(
+                    "Future params variant [2] not yet implemented",
+                ));
+            } else {
+                // Not a variant tag, this is the actual first field (max_block_header_size?)
+                let unknown_field = tag_value;
+                return Self::decode_real_params(d, ctx, unknown_field);
+            }
+        }
+
+        // If we get here, we have variant [1] or [2] and need to parse the real params
+        // For variant [1], the next field should be the start of pparams_real
+        // which starts with the first real field (not a tag)
+        let first_field_type = d.datatype()?;
+        if first_field_type == minicbor::data::Type::U8 {
+            let first_field = d.u8()?;
+            Self::decode_real_params(d, ctx, first_field)
+        } else {
+            Err(minicbor::decode::Error::message(
+                "Expected U8 for first field of pparams_real",
+            ))
+        }
+    }
+}
+
+impl ProtocolParameters {
+    fn decode_real_params<'b, C>(
+        d: &mut minicbor::Decoder<'b>,
+        ctx: &mut C,
+        first_field: u8,
+    ) -> Result<Self, minicbor::decode::Error> {
+        // first_field is field 0 which we already consumed (U8=44 or similar, unknown purpose)
+
+        // Read what appears to be the fee parameters
+        let min_fee_a = d.u32()? as u64;
+        let min_fee_b = d.u32()? as u64;
+
+        // Read what appears to be size limits (but check types - they might be u16 not u64)
+        let max_block_body_size = d.u16()? as u64;
+        let max_transaction_size = d.u16()? as u64;
+
+        // Deposits
+        let stake_credential_deposit = d.u32()? as u64;
+        let stake_pool_deposit = d.u32()? as u64;
+
+        // Retirement epoch
+        let stake_pool_max_retirement_epoch = d.u8()? as u64;
+
+        // Pool count
+        let optimal_stake_pools_count = d.u16()?;
+
+        // Fields 9-11 should be ratios (Tag 30)
+        let pledge_influence = decode_rationale(d)?;
+        let monetary_expansion_rate = decode_rationale(d)?;
+        let treasury_expansion_rate = decode_rationale(d)?;
+
+        // Field 12 should be protocol version array
+        let protocol_version = decode_protocol_version(d)?;
+
+        // Field 13
+        let min_pool_cost = d.u32()? as u64;
+
+        // Field 14
+        let lovelace_per_utxo_byte = d.u16()? as u64;
+
+        // Field 15: cost_models map - manually decode since CostModel format might be different
+        let mut plutus_v1 = None;
+        let mut plutus_v2 = None;
+        let mut plutus_v3 = None;
+
+        let map_len = d.map()?;
+
+        if let Some(len) = map_len {
+            for _ in 0..len {
+                let lang_id: u8 = d.decode()?;
+
+                // Try decoding as array of i64 (could be indefinite)
+                let array_len = d.array()?;
+
+                let mut costs = Vec::new();
+                if array_len.is_none() {
+                    // Indefinite array - read until break
+                    loop {
+                        match d.datatype()? {
+                            minicbor::data::Type::Break => {
+                                d.skip()?; // consume the break
+                                break;
+                            }
+                            _ => {
+                                // Decode as i64, handling different integer sizes
+                                let cost: i64 = d.decode()?;
+                                costs.push(cost);
+                            }
+                        }
+                    }
+                } else if let Some(alen) = array_len {
+                    for _ in 0..alen {
+                        let cost: i64 = d.decode()?;
+                        costs.push(cost);
+                    }
+                }
+
+                let cost_model = CostModel::new(costs);
+                match lang_id {
+                    0 => plutus_v1 = Some(cost_model),
+                    1 => plutus_v2 = Some(cost_model),
+                    2 => plutus_v3 = Some(cost_model),
+                    _ => unreachable!("unexpected language version: {}", lang_id),
+                }
+            }
+        }
+
+        // Field 16: prices - encoded as array containing two tag-30 ratios
+        d.array()?; // Outer array
+        let mem_price = decode_rationale(d)?; // First ratio (tag 30)
+        let step_price = decode_rationale(d)?; // Second ratio (tag 30)
+        let prices = ExUnitPrices {
+            mem_price: RationalNumber::from(mem_price.numerator, mem_price.denominator),
+            step_price: RationalNumber::from(step_price.numerator, step_price.denominator),
+        };
+
+        // Field 17: max_tx_ex_units
+        let max_tx_ex_units = d.decode_with(ctx)?;
+
+        // Field 18: max_block_ex_units
+        let max_block_ex_units = d.decode_with(ctx)?;
+
+        // Field 19: max_value_size
+        let max_value_size = d.u16()? as u64;
+
+        // Field 20: collateral_percentage
+        let collateral_percentage = d.u16()?;
+
+        // Field 21: max_collateral_inputs
+        let max_collateral_inputs = d.u16()?;
+
+        // Field 22: pool_voting_thresholds
+        let pool_voting_thresholds = d.decode_with(ctx)?;
+
+        // Field 23: drep_voting_thresholds
+        let drep_voting_thresholds = d.decode_with(ctx)?;
+
+        // Field 24: min_committee_size
+        let min_committee_size = d.u16()?;
+
+        // Field 25: max_committee_term_length
+        let max_committee_term_length = d.u64()?;
+
+        // Field 26: gov_action_lifetime
+        let gov_action_lifetime = d.u64()?;
+
+        // Field 27: gov_action_deposit
+        let gov_action_deposit = d.u64()?;
+
+        // Field 28: drep_deposit
+        let drep_deposit = d.u64()?;
+
+        // Field 29: drep_expiry
+        let drep_expiry = d.decode_with(ctx)?;
+
+        // Field 30: min_fee_ref_script_lovelace_per_byte
+        let min_fee_ref_script_lovelace_per_byte = decode_rationale(d)?;
+
+        // Field 0 (U8=44) - still unknown, need to determine max_block_header_size
+        let max_block_header_size = first_field as u16;
+
+        Ok(ProtocolParameters {
+            protocol_version,
+            min_fee_a,
+            min_fee_b,
+            max_block_body_size,
+            max_transaction_size,
+            max_block_header_size,
+            stake_credential_deposit,
+            stake_pool_deposit,
+            stake_pool_max_retirement_epoch,
+            optimal_stake_pools_count,
+            pledge_influence,
+            monetary_expansion_rate,
+            treasury_expansion_rate,
+            min_pool_cost,
+            lovelace_per_utxo_byte,
+            cost_models: CostModels {
+                plutus_v1,
+                plutus_v2,
+                plutus_v3,
+            },
+            prices,
+            max_tx_ex_units,
+            max_block_ex_units,
+            max_value_size,
+            collateral_percentage,
+            max_collateral_inputs,
+            pool_voting_thresholds,
+            drep_voting_thresholds,
+            min_committee_size,
+            max_committee_term_length,
+            gov_action_lifetime,
+            gov_action_deposit,
+            drep_deposit,
+            drep_expiry,
+            min_fee_ref_script_lovelace_per_byte,
+            max_ref_script_size_per_tx: 200 * 1024,
+            max_ref_script_size_per_block: 1024 * 1024,
+            ref_script_cost_stride: 25600,
+            ref_script_cost_multiplier: Ratio {
+                numerator: 12,
+                denominator: 10,
+            },
+        })
+    }
+}

--- a/modules/accounts_state/src/monetary.rs
+++ b/modules/accounts_state/src/monetary.rs
@@ -92,7 +92,7 @@ fn calculate_monetary_expansion(
     reserves: Lovelace,
     eta: &BigDecimal,
 ) -> BigDecimal {
-    let monetary_expansion_factor = params.protocol_params.monetary_expansion;
+    let monetary_expansion_factor = params.protocol_params.monetary_expansion.clone();
     let monetary_expansion =
         (BigDecimal::from(reserves) * eta * BigDecimal::from(monetary_expansion_factor.numer())
             / BigDecimal::from(monetary_expansion_factor.denom()))

--- a/modules/block_vrf_validator/src/ouroboros/overlay_schedule.rs
+++ b/modules/block_vrf_validator/src/ouroboros/overlay_schedule.rs
@@ -135,7 +135,7 @@ mod tests {
     fn test_lookup_in_overlay_schedule_1() {
         let genesis_values = GenesisValues::mainnet();
         let genesis_delegs = genesis_values.genesis_delegs;
-        let decentralisation_param = RationalNumber::from(1);
+        let decentralisation_param = RationalNumber::ONE;
         let active_slots_coeff = RationalNumber::new(1, 20);
         let epoch_slot = 0;
         let obft_slot = lookup_in_overlay_schedule(

--- a/modules/block_vrf_validator/src/ouroboros/tpraos.rs
+++ b/modules/block_vrf_validator/src/ouroboros/tpraos.rs
@@ -201,7 +201,7 @@ mod tests {
             .unwrap(),
         );
         let active_slots_coeff = RationalNumber::new(1, 20);
-        let decentralisation_param = RationalNumber::from(1);
+        let decentralisation_param = RationalNumber::ONE;
 
         let block_header_4490511: Vec<u8> =
             hex::decode(include_str!("./data/4490511.cbor")).unwrap();

--- a/modules/block_vrf_validator/src/ouroboros/vrf_validation.rs
+++ b/modules/block_vrf_validator/src/ouroboros/vrf_validation.rs
@@ -183,7 +183,7 @@ pub fn validate_vrf_leader_value(
             Err(VrfLeaderValueTooBigError::VrfLeaderValueTooBig {
                 pool_id: *pool_id,
                 active_stake: *leader_relative_stake.numer(),
-                relative_stake: *leader_relative_stake,
+                relative_stake: leader_relative_stake.clone(),
             })
         }
     }

--- a/modules/block_vrf_validator/src/state.rs
+++ b/modules/block_vrf_validator/src/state.rs
@@ -55,8 +55,8 @@ impl State {
     pub fn handle_protocol_parameters(&mut self, msg: &ProtocolParamsMessage) {
         if let Some(shelley_params) = msg.params.shelley.as_ref() {
             self.decentralisation_param =
-                Some(shelley_params.protocol_params.decentralisation_param);
-            self.active_slots_coeff = Some(shelley_params.active_slots_coeff);
+                Some(shelley_params.protocol_params.decentralisation_param.clone());
+            self.active_slots_coeff = Some(shelley_params.active_slots_coeff.clone());
         }
     }
 
@@ -95,12 +95,12 @@ impl State {
             }
         };
 
-        let Some(decentralisation_param) = self.decentralisation_param else {
+        let Some(decentralisation_param) = self.decentralisation_param.clone() else {
             return Err(Box::new(VrfValidationError::Other(
                 "Decentralisation Param is not set".to_string(),
             )));
         };
-        let Some(active_slots_coeff) = self.active_slots_coeff else {
+        let Some(active_slots_coeff) = self.active_slots_coeff.clone() else {
             return Err(Box::new(VrfValidationError::Other(
                 "Active Slots Coeff is not set".to_string(),
             )));

--- a/modules/governance_state/src/alonzo_babbage_voting.rs
+++ b/modules/governance_state/src/alonzo_babbage_voting.rs
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn test_decentralisation_updates() -> Result<()> {
-        let dcu = extract_mainnet_parameter(|p| p.decentralisation_constant)?;
+        let dcu = extract_mainnet_parameter(|p| p.decentralisation_constant.clone())?;
 
         assert_eq!(DECENTRALISATION.len(), dcu.len());
         for (decent, param) in DECENTRALISATION.iter().zip(dcu) {

--- a/modules/governance_state/src/voting_state.rs
+++ b/modules/governance_state/src/voting_state.rs
@@ -163,28 +163,46 @@ impl VotingRegistrationState {
                     d_th = max(d_th, &d.pp_governance_group);
                 }
 
-                VoteResult::new(c.threshold, *d_th, *p_th)
+                VoteResult::new(c.threshold.clone(), d_th.clone(), p_th.clone())
             }
-            GovernanceAction::HardForkInitiation(_) => {
-                VoteResult::new(c.threshold, d.hard_fork_initiation, p.hard_fork_initiation)
-            }
-            GovernanceAction::TreasuryWithdrawals(_) => {
-                VoteResult::new(c.threshold, d.treasury_withdrawal, *zero)
-            }
-            GovernanceAction::NoConfidence(_) => {
-                VoteResult::new(*zero, d.motion_no_confidence, p.motion_no_confidence)
-            }
+            GovernanceAction::HardForkInitiation(_) => VoteResult::new(
+                c.threshold.clone(),
+                d.hard_fork_initiation.clone(),
+                p.hard_fork_initiation.clone(),
+            ),
+            GovernanceAction::TreasuryWithdrawals(_) => VoteResult::new(
+                c.threshold.clone(),
+                d.treasury_withdrawal.clone(),
+                zero.clone(),
+            ),
+            GovernanceAction::NoConfidence(_) => VoteResult::new(
+                zero.clone(),
+                d.motion_no_confidence.clone(),
+                p.motion_no_confidence.clone(),
+            ),
             GovernanceAction::UpdateCommittee(_) => {
                 if thresholds.committee.is_empty() {
-                    VoteResult::new(*zero, d.committee_no_confidence, p.committee_no_confidence)
+                    VoteResult::new(
+                        zero.clone(),
+                        d.committee_no_confidence.clone(),
+                        p.committee_no_confidence.clone(),
+                    )
                 } else {
-                    VoteResult::new(*zero, d.committee_normal, p.committee_normal)
+                    VoteResult::new(
+                        zero.clone(),
+                        d.committee_normal.clone(),
+                        p.committee_normal.clone(),
+                    )
                 }
             }
-            GovernanceAction::NewConstitution(_) => {
-                VoteResult::new(c.threshold, d.update_constitution, *zero)
+            GovernanceAction::NewConstitution(_) => VoteResult::new(
+                c.threshold.clone(),
+                d.update_constitution.clone(),
+                zero.clone(),
+            ),
+            GovernanceAction::Information => {
+                VoteResult::new(zero.clone(), one.clone(), one.clone())
             }
-            GovernanceAction::Information => VoteResult::new(*zero, *one, *one),
         }
     }
 

--- a/modules/parameters_state/src/genesis_params.rs
+++ b/modules/parameters_state/src/genesis_params.rs
@@ -156,6 +156,7 @@ fn map_conway(genesis: &conway::GenesisFile) -> Result<ConwayParams> {
         d_rep_activity: genesis.d_rep_activity,
         min_fee_ref_script_cost_per_byte: RationalNumber::from(
             genesis.min_fee_ref_script_cost_per_byte,
+            1,
         ),
         plutus_v3_cost_model: CostModel::new(genesis.plutus_v3_cost_model.clone()),
         constitution: map_constitution(&genesis.constitution)?,

--- a/modules/parameters_state/src/parameters_updater.rs
+++ b/modules/parameters_state/src/parameters_updater.rs
@@ -231,7 +231,7 @@ impl ParametersUpdater {
                 );
             }
         }
-        c.threshold = cu.terms;
+        c.threshold = cu.terms.clone();
     }
 
     fn apply_alonzo_babbage_outcome_elem(&mut self, u: &AlonzoBabbageVotingOutcome) -> Result<()> {

--- a/modules/snapshot_bootstrapper/src/publisher.rs
+++ b/modules/snapshot_bootstrapper/src/publisher.rs
@@ -1,4 +1,5 @@
 use acropolis_common::protocol_params::{Nonces, PraosParams};
+use acropolis_common::snapshot::protocol_parameters::ProtocolParameters;
 use acropolis_common::snapshot::{RawSnapshotsContainer, SnapshotsCallback};
 use acropolis_common::{
     genesis_values::GenesisValues,
@@ -7,9 +8,9 @@ use acropolis_common::{
     },
     params::EPOCH_LENGTH,
     snapshot::streaming_snapshot::{
-        DRepCallback, DRepInfo, EpochCallback, GovernanceProposal, PoolCallback, PoolInfo,
-        ProposalCallback, SnapshotCallbacks, SnapshotMetadata, StakeCallback, UtxoCallback,
-        UtxoEntry,
+        DRepCallback, DRepInfo, EpochCallback, GovernanceProposal,
+        GovernanceProtocolParametersCallback, PoolCallback, PoolInfo, ProposalCallback,
+        SnapshotCallbacks, SnapshotMetadata, StakeCallback, UtxoCallback, UtxoEntry,
     },
     stake_addresses::AccountState,
     BlockInfo, EpochBootstrapData,
@@ -192,6 +193,23 @@ impl ProposalCallback for SnapshotPublisher {
     fn on_proposals(&mut self, proposals: Vec<GovernanceProposal>) -> Result<()> {
         info!("Received {} proposals", proposals.len());
         self.proposals.extend(proposals);
+        Ok(())
+    }
+}
+
+impl GovernanceProtocolParametersCallback for SnapshotPublisher {
+    fn on_gs_protocol_parameters(
+        &mut self,
+        _gs_previous_params: ProtocolParameters,
+        _gs_current_params: ProtocolParameters,
+        _gs_future_params: ProtocolParameters,
+    ) -> Result<()> {
+        info!("Received governance protocol parameters (current, previous, future)");
+        // TODO: Publish protocol parameters to appropriate message bus topics
+        // This could involve publishing messages for:
+        // - CurrentProtocolParameters → ParametersState processor
+        // - PreviousProtocolParameters → ParametersState processor
+        // - FutureProtocolParameters → ParametersState processor
         Ok(())
     }
 }

--- a/modules/spo_state/src/epochs_history.rs
+++ b/modules/spo_state/src/epochs_history.rs
@@ -52,7 +52,7 @@ impl EpochState {
             epoch: self.epoch,
             blocks_minted: self.blocks_minted.unwrap_or(0),
             active_stake: self.active_stake.unwrap_or(0),
-            active_size: self.active_size.unwrap_or(RationalNumber::from(0)),
+            active_size: self.active_size.clone().unwrap_or(RationalNumber::ZERO),
             delegators_count: self.delegators_count.unwrap_or(0),
             pool_reward: self.pool_reward.unwrap_or(0),
             spo_reward: self.spo_reward.unwrap_or(0),

--- a/modules/spo_state/src/spo_state.rs
+++ b/modules/spo_state/src/spo_state.rs
@@ -552,8 +552,8 @@ impl SPOState {
                                     .unwrap_or(0),
                                 active_size: epoch_state
                                     .as_ref()
-                                    .and_then(|state| state.active_size)
-                                    .unwrap_or(RationalNumber::from(0)),
+                                    .and_then(|state| state.active_size.clone())
+                                    .unwrap_or(RationalNumber::ZERO),
                             })
                         } else {
                             PoolsStateQueryResponse::Error(QueryError::storage_disabled(


### PR DESCRIPTION



## Description

This PR adds mini-cbor decoder and callbacks for Governance Protocol Parameters and Delegation into the Snapshot parser.

* added ProtocolParameters type
* converted the RationalNumber type to use decoder and other depedent types of the protocol parameters
* add constitution parsing as a correctness checkpoint (not needed yet for bootstrapping) just before protocol params
* add stub callbacks for the boostrapper
* fixed the Anchor decoder so that reads various formatted structures (bytes and strings)

## Related Issue(s)
Resolves issue #445 

## How was this tested?
It was tested manually by running `make snap-test-streaming` to demonstrate proper parsing and logging of the previous, current, and future (empty) protocol parameters as well as the delegation. You can run that command and look for the output in the logs more directly with `make snap-test-streaming 2>&1 | grep -A8 "Protocol Parameters"`

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [x] I updated documentation (if applicable)
- [ ] CI is green for this PR

## Impact / Side effects
I've added an empty stub callback in the boostrapper as a TODO item, which can be filled as needed.

## Reviewer notes / Areas to focus
Nothing specific. I've tried to build a type called ProtocolParameters that uses the existing types and fixed up their decoders, so there is no "adapter" layer required.
