### PR TITLE
feat: raw bytes transaction handler for indexes with Pallas version conflicts

### DIFF
--- a/modules/custom_indexer/src/custom_indexer.rs
+++ b/modules/custom_indexer/src/custom_indexer.rs
@@ -247,13 +247,6 @@ async fn process_tx_responses<F: futures::Future<Output = IndexResponse> + Send>
             Ok(IndexResult::Success { entry }) => {
                 new_tips.insert(name, entry);
             }
-            Ok(IndexResult::DecodeError { entry, reason }) => {
-                error!(
-                    "Failed to decode tx at slot {} for index '{}': {}",
-                    block_slot, name, reason
-                );
-                new_tips.insert(name, entry);
-            }
             Ok(IndexResult::HandleError { entry, reason }) => {
                 error!(
                     "Failed to handle tx at slot {} for index '{}': {}",

--- a/modules/custom_indexer/src/index_actor.rs
+++ b/modules/custom_indexer/src/index_actor.rs
@@ -3,8 +3,6 @@ use std::sync::Arc;
 use acropolis_common::{BlockInfo, Point};
 use tokio::sync::{mpsc, oneshot};
 
-use pallas::ledger::traverse::MultiEraTx;
-
 use crate::{cursor_store::CursorEntry, IndexWrapper};
 
 pub enum IndexCommand {
@@ -22,7 +20,6 @@ pub enum IndexCommand {
 #[derive(Debug)]
 pub enum IndexResult {
     Success { entry: CursorEntry },
-    DecodeError { entry: CursorEntry, reason: String },
     HandleError { entry: CursorEntry, reason: String },
     Reset { entry: CursorEntry },
     Halted,
@@ -70,43 +67,16 @@ async fn handle_apply_txs(
     }
 
     // Decode the transactions and call handle_onchain_tx for each, halting if decode or the handler return an error
-    let raw_mode = wrapper.index.wants_raw_bytes();
     for raw in txs {
-        if raw_mode {
-            if let Err(e) = wrapper.index.handle_onchain_tx_bytes(&block, &raw).await {
-                wrapper.halted = true;
-                return IndexResult::HandleError {
-                    entry: CursorEntry {
-                        tip: wrapper.tip.clone(),
-                        halted: true,
-                    },
-                    reason: e.to_string(),
-                };
-            }
-        } else {
-            let decoded = match MultiEraTx::decode(raw.as_ref()) {
-                Ok(tx) => tx,
-                Err(e) => {
-                    wrapper.halted = true;
-                    return IndexResult::DecodeError {
-                        entry: CursorEntry {
-                            tip: wrapper.tip.clone(),
-                            halted: true,
-                        },
-                        reason: e.to_string(),
-                    };
-                }
+        if let Err(e) = wrapper.index.handle_onchain_tx_bytes(&block, &raw).await {
+            wrapper.halted = true;
+            return IndexResult::HandleError {
+                entry: CursorEntry {
+                    tip: wrapper.tip.clone(),
+                    halted: true,
+                },
+                reason: e.to_string(),
             };
-            if let Err(e) = wrapper.index.handle_onchain_tx(&block, &decoded).await {
-                wrapper.halted = true;
-                return IndexResult::HandleError {
-                    entry: CursorEntry {
-                        tip: wrapper.tip.clone(),
-                        halted: true,
-                    },
-                    reason: e.to_string(),
-                };
-            }
         }
     }
 
@@ -316,24 +286,6 @@ mod tests {
                 assert!(reason.contains("handle error response"));
             }
             other => panic!("Expected HandleError, got {:?}", other),
-        }
-    }
-
-    #[tokio::test]
-    async fn apply_txs_decode_error_sets_halt() {
-        let mock = MockIndex {
-            on_tx: None,
-            ..Default::default()
-        };
-
-        let (_indexer, sender) = setup_indexer(mock).await;
-
-        match send_apply(&sender, test_block(1), vec![Arc::from([0u8; 1].as_slice())]).await {
-            IndexResult::DecodeError { entry, reason } => {
-                assert!(entry.halted);
-                assert!(!reason.is_empty());
-            }
-            other => panic!("Expected DecodeError, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
## Description
This PR introduces a new `handle_onchain_tx_raw` method on the `ChainIndex` trait.

This allows an index to override tx decoding to process raw bytes rather than a decoded `MultiEraTx`. This enables integrations (such as the Scooper) that depend on a different Pallas version than Acropolis. Indexes that do not override `handle_onchain_tx_raw` continue using the existing decoded path semantics with no behavior change. 

## Related Issue(s)
Relates to #462

## How was this tested?
* Verified that indexes relying on the default decoded mode behave exactly as before. 
* Verified that Scooper integration can decode transactions independently without Pallas dependency collisions. 

## Checklist
- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
Existing indexes require no changes. Index authors now have explicit control over how transaction decoding is performed, enabling compatibility with custom or conflicting Pallas versions. 

## Reviewer notes / Areas to focus
`handle_apply_txs` in `custom_indexer/src/index_actor.rs`. 
