### PR TITLE
Remove unused packages to free up disk space for running the tests

### DIFF
--- a/.github/workflows/run-tests-on-push-to-main.yml
+++ b/.github/workflows/run-tests-on-push-to-main.yml
@@ -1,4 +1,4 @@
-name: Run tests on push to main
+name: Run tests on push/PR to main
 
 on:
   push:
@@ -17,6 +17,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Remove packages to free up disk space
+        run:  |
+          sudo dpkg -P ant ant-optional azure-cli firefox google-chrome-stable \
+            google-cloud-cli google-cloud-cli-anthoscli kubectl \
+            microsoft-edge-stable mysql-server mysql-server-8.0 \
+            mysql-server-core-8.0 powershell temurin-11-jdk temurin-17-jdk \
+            temurin-21-jdk temurin-25-jdk temurin-8-jdk > /dev/null
+
       - name: Checkout code
         uses: actions/checkout@v4
 


### PR DESCRIPTION
## Description

Previous runs of this workflow have failed due to running out of disk space, so we are removing packages which are installed to the base runner image but are not currently required for this project.

The name of the workflow has been updated to indicate that it also runs on PR creation.

## How was this tested?

Tested extensively in fork of repo.
In all tests, github runners had a 72G filesystem, with 18G free following the checkout stage.  Removing these packages gave us 24G free, with 5.6G free after the tests had run, giving us plenty of headroom.

## Impact / Side effects

Some of these packages could potentially be required in the future.  In that case we can either look at different packages to remove, or there are several GB of other installed programs in `/opt` which we could potentially clear.
