### PR TITLE
chore: update caryatid_process to 0.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1566,9 +1566,9 @@ dependencies = [
 
 [[package]]
 name = "caryatid_process"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5964024f9c302253bdf84b3f35dc068853ed0c643961072b59f6e69b8f83552"
+checksum = "2297ab4f0eb5ccd04c30cd397cbde5e129097c8e3b0e3f7628d5c16dafdbd532"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ resolver = "2"
 
 [workspace.dependencies]
 caryatid_sdk = "0.14.0"
-caryatid_process = "0.13.1"
+caryatid_process = "0.14.0"
 caryatid_module_rest_server = "0.15.1"
 caryatid_module_clock = "0.13.1"
 caryatid_module_spy = "0.13.1"


### PR DESCRIPTION
## Description

Update caryatid_process to the latest version, 0.14. This adds an API to gracefully shut down a running Acropolis process, and fixes Windows support

## Related Issue(s)

https://github.com/input-output-hk/caryatid/issues/14

## How was this tested?

Checked it out on my Windows partition, tests are passing

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects

Changes are technically breaking, in that calling `process.run()` twice is now a compiler error. But it was already a logic error, so big whoop

## Reviewer notes / Areas to focus
