### PR TITLE
refactor: use `BTreemap` wrapper for genesis delegs in shelley params

### DIFF
--- a/codec/src/block.rs
+++ b/codec/src/block.rs
@@ -1,5 +1,5 @@
 use acropolis_common::{
-    GenesisDelegate, HeavyDelegate, PoolId, crypto::keyhash_224, queries::blocks::BlockIssuer,
+    GenesisDelegates, HeavyDelegate, PoolId, crypto::keyhash_224, queries::blocks::BlockIssuer,
 };
 use pallas_primitives::byron::BlockSig::DlgSig;
 use pallas_traverse::MultiEraHeader;
@@ -8,13 +8,14 @@ use std::collections::HashMap;
 pub fn map_to_block_issuer(
     header: &MultiEraHeader,
     byron_heavy_delegates: &HashMap<PoolId, HeavyDelegate>,
-    shelley_genesis_delegates: &HashMap<PoolId, GenesisDelegate>,
+    shelley_genesis_delegates: &GenesisDelegates,
 ) -> Option<BlockIssuer> {
     match header.issuer_vkey() {
         Some(vkey) => match header {
             MultiEraHeader::ShelleyCompatible(_) => {
                 let digest = keyhash_224(vkey);
                 if let Some(issuer) = shelley_genesis_delegates
+                    .as_ref()
                     .values()
                     .find(|v| v.delegate == digest)
                     .map(|i| BlockIssuer::GenesisDelegate(i.clone()))

--- a/common/src/protocol_params.rs
+++ b/common/src/protocol_params.rs
@@ -2,13 +2,13 @@ use crate::{
     genesis_values::GenesisValues,
     rational_number::{ChameleonFraction, RationalNumber},
     BlockHash, BlockVersionData, Committee, Constitution, CostModel, DRepVotingThresholds, Era,
-    ExUnitPrices, ExUnits, GenesisDelegate, HeavyDelegate, NetworkId, PoolId, PoolVotingThresholds,
-    ProtocolConsts,
+    ExUnitPrices, ExUnits, GenesisDelegates, HeavyDelegate, NetworkId, PoolId,
+    PoolVotingThresholds, ProtocolConsts,
 };
 use anyhow::{bail, Result};
 use blake2::{digest::consts::U32, Blake2b, Digest};
 use chrono::{DateTime, Utc};
-use serde_with::{hex::Hex, serde_as};
+use serde_with::serde_as;
 use std::fmt::Formatter;
 use std::ops::Deref;
 use std::{collections::HashMap, fmt::Display};
@@ -142,8 +142,7 @@ pub struct ShelleyParams {
     pub system_start: DateTime<Utc>,
     pub update_quorum: u32,
 
-    #[serde_as(as = "HashMap<Hex, _>")]
-    pub gen_delegs: HashMap<PoolId, GenesisDelegate>,
+    pub gen_delegs: GenesisDelegates,
 }
 
 impl ShelleyParams {

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1703,7 +1703,7 @@ pub struct HeavyDelegate {
 }
 
 #[serde_as]
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct GenesisDelegate {
     #[serde_as(as = "Hex")]
     pub delegate: Hash<28>,
@@ -1711,8 +1711,11 @@ pub struct GenesisDelegate {
     pub vrf: VrfKeyHash,
 }
 
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct GenesisDelegates(pub BTreeMap<GenesisKeyhash, GenesisDelegate>);
+#[serde_as]
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct GenesisDelegates(
+    #[serde_as(as = "BTreeMap<Hex, _>")] pub BTreeMap<GenesisKeyhash, GenesisDelegate>,
+);
 
 impl TryFrom<Vec<(&str, (&str, &str))>> for GenesisDelegates {
     type Error = anyhow::Error;

--- a/modules/accounts_state/src/monetary.rs
+++ b/modules/accounts_state/src/monetary.rs
@@ -108,14 +108,12 @@ fn calculate_monetary_expansion(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use acropolis_common::rational_number::rational_number_from_f32;
-    use acropolis_common::{
-        protocol_params::{Nonce, NonceVariant, ProtocolVersion, ShelleyProtocolParams},
-        GenesisDelegate,
+    use acropolis_common::protocol_params::{
+        Nonce, NonceVariant, ProtocolVersion, ShelleyProtocolParams,
     };
-    use acropolis_common::{NetworkId, PoolId};
+    use acropolis_common::rational_number::rational_number_from_f32;
+    use acropolis_common::{GenesisDelegates, NetworkId};
     use chrono::{DateTime, Utc};
-    use std::collections::HashMap;
 
     // Known values at start of Shelley - from Java reference and DBSync
     const EPOCH_208_RESERVES: Lovelace = 13_888_022_852_926_644;
@@ -176,7 +174,7 @@ mod tests {
             slots_per_kes_period: 129600,
             system_start: DateTime::<Utc>::default(),
             update_quorum: 5,
-            gen_delegs: HashMap::<PoolId, GenesisDelegate>::new(),
+            gen_delegs: GenesisDelegates::default(),
         }
     }
 

--- a/modules/chain_store/src/chain_store.rs
+++ b/modules/chain_store/src/chain_store.rs
@@ -3,6 +3,7 @@ mod stores;
 use crate::stores::{fjall::FjallStore, Block, Store, Tx};
 use acropolis_common::queries::blocks::TransactionHashesAndTimeStamps;
 use acropolis_common::queries::errors::QueryError;
+use acropolis_common::GenesisDelegates;
 use acropolis_common::{
     caryatid::SubscriptionExt,
     crypto::keyhash_224,
@@ -26,8 +27,8 @@ use acropolis_common::{
         misc::Order,
     },
     state_history::{StateHistory, StateHistoryStore},
-    AssetName, BechOrdAddress, BlockHash, GenesisDelegate, HeavyDelegate,
-    InstantaneousRewardSource, NativeAsset, NetworkId, PoolId, StakeAddress, TxHash,
+    AssetName, BechOrdAddress, BlockHash, HeavyDelegate, InstantaneousRewardSource, NativeAsset,
+    NetworkId, PoolId, StakeAddress, TxHash,
 };
 use anyhow::{anyhow, bail, Result};
 use caryatid_sdk::{module, Context};
@@ -1293,14 +1294,14 @@ impl ChainStore {
 #[derive(Default, Debug, Clone)]
 pub struct State {
     pub byron_heavy_delegates: HashMap<PoolId, HeavyDelegate>,
-    pub shelley_genesis_delegates: HashMap<PoolId, GenesisDelegate>,
+    pub shelley_genesis_delegates: GenesisDelegates,
 }
 
 impl State {
     pub fn new() -> Self {
         Self {
             byron_heavy_delegates: HashMap::new(),
-            shelley_genesis_delegates: HashMap::new(),
+            shelley_genesis_delegates: GenesisDelegates::default(),
         }
     }
 }


### PR DESCRIPTION
## Description

Update Shelley param's `genesis_delegs` to use `GenesisDelegates` type which is wrapper of `BTreeMap`.

## Related Issue(s)
None

## How was this tested?
`cargo test --verbose` working

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
No side effects

## Reviewer notes / Areas to focus
`common/src/protocol_params.rs` -> `ShelleyParams` type
