### PR TITLE
fix: drep state module bootstrap

### DIFF
--- a/modules/drep_state/src/drep_state.rs
+++ b/modules/drep_state/src/drep_state.rs
@@ -111,6 +111,7 @@ impl DRepState {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run(
         history: Arc<Mutex<StateHistory<State>>>,
         snapshot_subscription: Option<Box<dyn Subscription<Message>>>,


### PR DESCRIPTION
## Description

Fixes DRep state bootstrap persistence issue. When bootstrapping from a CBOR snapshot, the DRep state was not being persisted because:

1. The snapshot handler ran in a separate parallel task from the main run loop
2. The snapshot handler committed using `epoch` (e.g., 507) as the history index
3. The main run loop committed using `block_info.number` (e.g., 11000000) as the index
4. `StateHistory` with `Bounded(2160)` evicted entries where the index difference exceeded 2160
5. The bootstrap entry was immediately evicted when the first block was processed

**Fix:** Refactored to match the `accounts_state` pattern:
- Added `wait_for_bootstrap()` helper that runs at the start of `run()`
- Bootstrap now happens sequentially before the main loop processes any blocks
- Uses `commit_forced()` to avoid index-based eviction issues
- Added logging for vis into progress of drep state module

## Related Issue(s)

Fixes #264 

## How was this tested?

- Manual testing with epoch 507 snapshot - verified DReps are now persisted:
```
2025-12-16T17:13:47.331171Z  INFO acropolis_module_drep_state: Received bootstrap message with 278 DReps for epoch 507
2025-12-16T17:13:47.332476Z  INFO acropolis_module_drep_state: Bootstrap complete - 278 DReps committed to state
...
2025-12-16T17:14:33.524817Z  INFO acropolis_module_drep_state::state: count=278
```
- Verified tick logs now show non-zero DRep count after bootstrap

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [x] I updated documentation (if applicable)
- [ ] CI is green for this PR

## Impact / Side effects

- `run()` function signature changed to accept `snapshot_subscription` parameter
- Bootstrap now blocks the main run loop until complete (by design - ensures state is populated before processing blocks)
- Uses `commit_forced()` which bypasses bounded history eviction - appropriate for bootstrap since we want this initial state to persist

## Reviewer notes / Areas to focus

- `modules/drep_state/src/drep_state.rs:64-110`: New `wait_for_bootstrap()` helper - follows same pattern as `accounts_state`
- `modules/drep_state/src/drep_state.rs:119-125`: Call to `wait_for_bootstrap()` at start of `run()`
- The key fix is using `commit_forced()` instead of `commit(epoch, state)` to avoid the epoch/block number mismatch