### PR TITLE
fix: add completion message to cardano.snapshot topic

### DIFF
--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -346,6 +346,7 @@ pub enum CardanoMessage {
 pub enum SnapshotMessage {
     Startup, // subscribers should listen for incremental snapshot data
     Bootstrap(SnapshotStateMessage),
+    Complete, // all bootstrap data has been sent on this topic
     DumpRequest(SnapshotDumpMessage),
     Dump(SnapshotStateMessage),
 }

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -57,9 +57,6 @@ const DEFAULT_STAKE_REWARD_DELTAS_TOPIC: &str = "cardano.stake.reward.deltas";
 /// Topic for receiving bootstrap data when starting from a CBOR dump snapshot
 const DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC: (&str, &str) =
     ("snapshot-subscribe-topic", "cardano.snapshot");
-/// Topic signaling that the snapshot bootstrap is complete
-const DEFAULT_SNAPSHOT_COMPLETION_TOPIC: (&str, &str) =
-    ("snapshot-completion-topic", "cardano.snapshot.complete");
 
 const DEFAULT_SPDD_DB_PATH: (&str, &str) = ("spdd-db-path", "./fjall-spdd");
 const DEFAULT_SPDD_RETENTION_EPOCHS: (&str, u64) = ("spdd-retention-epochs", 0);
@@ -89,11 +86,9 @@ impl AccountsState {
     }
 
     /// Wait for and process snapshot bootstrap messages
-    /// Returns the BlockInfo from SnapshotComplete if bootstrap occurred, None otherwise
     async fn wait_for_bootstrap(
         history: Arc<Mutex<StateHistory<State>>>,
         mut snapshot_subscription: Option<Box<dyn Subscription<Message>>>,
-        mut completion_subscription: Option<Box<dyn Subscription<Message>>>,
     ) -> Result<()> {
         let snapshot_subscription = match snapshot_subscription.as_mut() {
             Some(sub) => sub,
@@ -121,38 +116,14 @@ impl AccountsState {
                     Self::handle_bootstrap(&mut state, accounts_data);
                     history.lock().await.commit(epoch, state);
                     info!("Accounts state bootstrap complete");
-                    break;
+                }
+                Message::Snapshot(SnapshotMessage::Complete) => {
+                    info!("Snapshot complete, exiting accounts state bootstrap loop");
+                    return Ok(());
                 }
                 _ => {
                     // Ignore other messages (e.g., EpochState, SPOState bootstrap messages)
                 }
-            }
-        }
-
-        let completion_subscription = match completion_subscription.as_mut() {
-            Some(sub) => sub,
-            None => {
-                info!("No completion subscription available");
-                return Ok(());
-            }
-        };
-
-        info!("Waiting for snapshot complete message...");
-        let (_, message) = completion_subscription.read().await?;
-        match message.as_ref() {
-            Message::Cardano((_, CardanoMessage::SnapshotComplete)) => {
-                info!("Received snapshot complete message");
-                Ok(())
-            }
-            other => {
-                error!(
-                    "Unexpected message on completion topic: {:?}",
-                    std::any::type_name_of_val(other)
-                );
-                Err(anyhow::anyhow!(format!(
-                    "Unexpected message on completion topic: {:?}",
-                    other
-                )))
             }
         }
     }
@@ -163,7 +134,6 @@ impl AccountsState {
         history: Arc<Mutex<StateHistory<State>>>,
         spdd_store: Option<Arc<Mutex<SPDDStore>>>,
         snapshot_subscription: Option<Box<dyn Subscription<Message>>>,
-        completion_subscription: Option<Box<dyn Subscription<Message>>>,
         mut drep_publisher: DRepDistributionPublisher,
         mut spo_publisher: SPODistributionPublisher,
         mut spo_rewards_publisher: SPORewardsPublisher,
@@ -179,12 +149,7 @@ impl AccountsState {
         verifier: &Verifier,
     ) -> Result<()> {
         // Wait for the snapshot bootstrap (if available)
-        Self::wait_for_bootstrap(
-            history.clone(),
-            snapshot_subscription,
-            completion_subscription,
-        )
-        .await?;
+        Self::wait_for_bootstrap(history.clone(), snapshot_subscription).await?;
 
         // Get the stake address deltas from the genesis bootstrap, which we know
         // don't contain any stake, plus an extra parameter state (!unexplained)
@@ -545,10 +510,6 @@ impl AccountsState {
             .get_string(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.0)
             .unwrap_or(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.1.to_string());
 
-        let snapshot_completion_topic = config
-            .get_string(DEFAULT_SNAPSHOT_COMPLETION_TOPIC.0)
-            .unwrap_or(DEFAULT_SNAPSHOT_COMPLETION_TOPIC.1.to_string());
-
         // Publishing topics
         let drep_distribution_topic = config
             .get_string("publish-drep-distribution-topic")
@@ -838,20 +799,13 @@ impl AccountsState {
         let parameters_subscription = context.subscribe(&parameters_topic).await?;
 
         // Only subscribe to Snapshot if we're using Snapshot to start-up
-        let (snapshot_subscription, completion_subscription) =
-            if StartupMethod::from_config(config.as_ref()).is_snapshot() {
-                info!("Creating subscriber for snapshot on '{snapshot_subscribe_topic}'");
-                info!(
-                    "Creating subscriber for snapshot completion on '{snapshot_completion_topic}'"
-                );
-                (
-                    Some(context.subscribe(&snapshot_subscribe_topic).await?),
-                    Some(context.subscribe(&snapshot_completion_topic).await?),
-                )
-            } else {
-                info!("Skipping snapshot subscription (startup method is not snapshot)");
-                (None, None)
-            };
+        let snapshot_subscription = if StartupMethod::from_config(config.as_ref()).is_snapshot() {
+            info!("Creating subscriber for snapshot on '{snapshot_subscribe_topic}'");
+            Some(context.subscribe(&snapshot_subscribe_topic).await?)
+        } else {
+            info!("Skipping snapshot subscription (startup method is not snapshot)");
+            None
+        };
 
         // Start run task
         context.run(async move {
@@ -859,7 +813,6 @@ impl AccountsState {
                 history,
                 spdd_store,
                 snapshot_subscription,
-                completion_subscription,
                 drep_publisher,
                 spo_publisher,
                 spo_rewards_publisher,

--- a/modules/drep_state/src/drep_state.rs
+++ b/modules/drep_state/src/drep_state.rs
@@ -102,9 +102,11 @@ impl DRepState {
                         "Bootstrap complete - {} DReps committed to state",
                         drep_count
                     );
+                }
+                Message::Snapshot(SnapshotMessage::Complete) => {
+                    info!("Snapshot complete, exiting DRep state bootstrap loop");
                     return Ok(());
                 }
-                // Ignore other snapshot messages while waiting for DRepState
                 _ => (),
             }
         }

--- a/modules/epochs_state/src/epochs_state.rs
+++ b/modules/epochs_state/src/epochs_state.rs
@@ -102,10 +102,9 @@ impl EpochsState {
                     Self::handle_bootstrap(&mut state, epoch_data);
                     history.lock().await.commit(epoch_data.epoch, state);
                     info!("Epoch state bootstrap complete");
-                    return Ok(());
                 }
-                Message::Cardano((_, CardanoMessage::SnapshotComplete)) => {
-                    warn!("Snapshot complete without epoch bootstrap data, using default state");
+                Message::Snapshot(SnapshotMessage::Complete) => {
+                    info!("Snapshot complete, exiting bootstrap loop");
                     return Ok(());
                 }
                 _ => {}

--- a/modules/snapshot_bootstrapper/src/bootstrapper.rs
+++ b/modules/snapshot_bootstrapper/src/bootstrapper.rs
@@ -129,6 +129,7 @@ impl SnapshotBootstrapper {
             .map_err(|e| BootstrapError::Parse(e.to_string()))?;
         info!("Parsed snapshot in {:.2?}", start.elapsed());
 
+        publisher.publish_snapshot_complete().await?;
         publisher.publish_completion(bootstrap_ctx.block_info).await?;
 
         info!("Snapshot bootstrap completed");

--- a/modules/snapshot_bootstrapper/src/publisher.rs
+++ b/modules/snapshot_bootstrapper/src/publisher.rs
@@ -127,6 +127,15 @@ impl SnapshotPublisher {
         Ok(())
     }
 
+    pub async fn publish_snapshot_complete(&self) -> Result<()> {
+        info!("Publishing Snapshot Complete on '{}'", self.snapshot_topic);
+        let message = Arc::new(Message::Snapshot(SnapshotMessage::Complete));
+        self.context.publish(&self.snapshot_topic, message).await.unwrap_or_else(|e| {
+            tracing::error!("Failed to publish snapshot complete message: {}", e);
+        });
+        Ok(())
+    }
+
     pub async fn publish_completion(&self, block_info: BlockInfo) -> Result<()> {
         info!(
             "Publishing SnapshotComplete on '{}' for block {} slot {} epoch {}",

--- a/modules/spo_state/src/spo_state.rs
+++ b/modules/spo_state/src/spo_state.rs
@@ -878,7 +878,10 @@ impl SPOState {
                                     .unwrap_or_else(|e| error!("failed to publish snapshot dump: {e}"))
                             }
                         }
-                        // There will be other snapshot messages that we're not interested in
+                        Message::Snapshot(SnapshotMessage::Complete) => {
+                            info!("Snapshot complete, exiting SPO state bootstrap loop");
+                            return;
+                        }
                         _ => ()
                     }
                 }

--- a/modules/utxo_state/src/utxo_state.rs
+++ b/modules/utxo_state/src/utxo_state.rs
@@ -174,10 +174,11 @@ impl UTXOState {
                                 }
                             }
                         }
-                        other => {
-                            info!("UTXO state received other snapshot message: {:?} (total so far: {} UTxOs in {} batches)",
-                                  std::mem::discriminant(other), total_utxos_received, batch_count);
+                        Message::Snapshot(SnapshotMessage::Complete) => {
+                            info!("UTXO state snapshot complete: {} UTxOs in {} batches", total_utxos_received, batch_count);
+                            return;
                         }
+                        _ => {}
                     }
                 }
             });


### PR DESCRIPTION
## Description

Adds a `SnapshotMessage::Complete` variant to signal when all bootstrap data has been published on the `cardano.snapshot` topic. Previously, state modules had inconsistent ways of detecting bootstrap completion - some waited indefinitely, some relied on receiving their specific bootstrap data, and `accounts_state` additionally waited for `SnapshotComplete` on a separate completion topic.

Now the flow is:
1. `cardano.snapshot`: `Startup` → bootstrap data messages → `Complete`
2. `cardano.snapshot.complete`: `SnapshotComplete` with block info (for peer network only)

All state modules now consistently exit their bootstrap loops when they receive `SnapshotMessage::Complete`.

## Related Issue(s)

Fixes bootstrap stalling issues where state modules would hang waiting for messages that never arrived.

## How was this tested?
- Manual testing with snapshot bootstrap flow

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [x] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects

- State modules now exit their snapshot subscription loops cleanly instead of running indefinitely or hanging
- `accounts_state` no longer subscribes to `cardano.snapshot.complete` topic (was redundant)
- Modules that don't receive their specific bootstrap data will still proceed (with default/empty state) once `Complete` is received

## Reviewer notes / Areas to focus

- `common/src/messages.rs` - new `Complete` variant added to `SnapshotMessage`
- `modules/snapshot_bootstrapper/src/publisher.rs` - publishes `Complete` before `SnapshotComplete`
- State modules (`epochs_state`, `utxo_state`, `spo_state`, `drep_state`, `accounts_state`) - all updated to handle `Complete` consistently