### PR TITLE
An approach to bootstrapping the block kes validator with op-cert counters

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,6 @@
 {
   "version": "0.2.0",
   "configurations": [
-  
     {
         "type": "lldb",
         "request": "launch",
@@ -49,6 +48,32 @@
       },
       "args": [],
       "cwd": "${workspaceFolder}/processes/omnibus"
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug executable 'acropolis_process_omnibus bootstrap'",
+      "cargo": {
+        "args": [
+          "build",
+          "--bin=acropolis_process_omnibus",
+          "--package=acropolis_process_omnibus"
+        ],
+        "filter": {
+          "name": "acropolis_process_omnibus",
+          "kind": "bin"
+        }
+      },
+      "args": [
+        "--config",
+        "omnibus.toml",
+        "--config",
+        "omnibus.bootstrap.toml"
+      ],
+      "cwd": "${workspaceFolder}/processes/omnibus",
+      "env": {
+        "RUST_LOG": "info"
+      }
     },
     {
         "type": "lldb",

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -509,6 +509,13 @@ pub struct SPOBootstrapMessage {
     pub spo_state: SPOState,
 }
 
+/// KES state bootstrap message containing opcert counters
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct KESStateBootstrapMessage {
+    pub block_number: u64,
+    pub opcert_counters: HashMap<PoolId, u64>,
+}
+
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum SnapshotStateMessage {
@@ -519,6 +526,7 @@ pub enum SnapshotStateMessage {
     DRepState(DRepBootstrapMessage),
     ParametersState(ProtocolParametersBootstrapMessage),
     GovernanceState(GovernanceBootstrapMessage),
+    KESState(KESStateBootstrapMessage),
 }
 
 // === Global message enum ===

--- a/modules/block_kes_validator/src/state.rs
+++ b/modules/block_kes_validator/src/state.rs
@@ -45,6 +45,17 @@ impl State {
         self.active_spos = msg.spos.iter().map(|spo| spo.operator).collect();
     }
 
+    /// Initialize opcert counters from snapshot bootstrap data
+    pub fn bootstrap_from_snapshot(
+        &mut self,
+        opcert_counters: &std::collections::HashMap<PoolId, u64>,
+    ) {
+        // Convert std::collections::HashMap to imbl::HashMap
+        self.ocert_counters = opcert_counters.iter().map(|(k, v)| (*k, *v)).collect();
+
+        eprintln!("Bootstrapped KES opcert counters for {} pools: {:?}", self.ocert_counters.len(), self.ocert_counters);
+    }
+
     pub fn update_ocert_counter(&mut self, pool_id: PoolId, declared_sequence_number: u64) {
         self.ocert_counters.insert(pool_id, declared_sequence_number);
     }

--- a/modules/snapshot_bootstrapper/src/bootstrapper.rs
+++ b/modules/snapshot_bootstrapper/src/bootstrapper.rs
@@ -128,6 +128,14 @@ impl SnapshotBootstrapper {
             .map_err(|e| BootstrapError::Parse(e.to_string()))?;
         info!("Parsed snapshot in {:.2?}", start.elapsed());
 
+        // Publish KES state bootstrap if opcert counters are available
+        publisher
+            .publish_kes_state(
+                bootstrap_ctx.opcert_counters.clone(),
+                bootstrap_ctx.block_info.number,
+            )
+            .await?;
+
         publisher.publish_snapshot_complete().await?;
         publisher.start_chain_sync(bootstrap_ctx.block_info.to_point()).await?;
 

--- a/modules/snapshot_bootstrapper/src/context.rs
+++ b/modules/snapshot_bootstrapper/src/context.rs
@@ -4,8 +4,9 @@ use crate::nonces::{NonceContext, NonceContextError};
 use crate::publisher::EpochContext;
 use acropolis_common::{
     genesis_values::GenesisValues, protocol_params::Nonces, BlockInfo, BlockIntent, BlockStatus,
-    Point,
+    Point, PoolId,
 };
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 
@@ -37,6 +38,7 @@ pub struct BootstrapContext {
     pub snapshot: Snapshot,
     pub nonces: Nonces,
     pub block_info: BlockInfo,
+    pub opcert_counters: Option<HashMap<PoolId, u64>>,
     network_dir: PathBuf,
 }
 
@@ -66,6 +68,9 @@ impl BootstrapContext {
             .unwrap_or_else(|| panic!("Origin point has no hash: {:?}", block_ctx.point));
         let slot = block_ctx.point.slot();
 
+        // Capture opcert counters from block if available
+        let opcert_counters = block_ctx.opcert_counters;
+
         // Build nonce
         let nonces = nonces_file.into_nonces(target_epoch, *hash);
 
@@ -90,6 +95,7 @@ impl BootstrapContext {
             snapshot,
             nonces,
             block_info,
+            opcert_counters,
             network_dir,
         })
     }


### PR DESCRIPTION
## Description

On the note of bootstrapping the op-cert counters…
* we have to get them from a block; they aren’t part of the NewEpochState snapshot
* we want the values of the last block of the bootstrapped epoch (e.g. last block of 507) the BlockContext can be extended to contain the op-cert counters and they can be forwarded to the block_kes_validator
* but the block cbor data we have only contains a single op-cert PoolId; there should be dozens of them

This only results in a single counter value. Instead, we probably want to load from the last block, which would contain all of the op-cert counters we need to bootstrap the kes validator module. Boot from the last block. @Matt what are the implications of this? It may mess up the point, etc.

## Related Issue(s)
TBD to make a ticket for this

## How was this tested?
I've run this in the debugger with breakpoints to validate the correct operation of the bootstrapping messages and initialization of the opcert counters. It also has a println to stderr for the experiment.

## Checklist

- [ ] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [ ] CI is green for this PR

## Impact / Side effects
Replacing the block.cbor data of 507 with the last block of the epoch may affect other parts of the bootstrapping process, as yet to be discovered.

## Reviewer notes / Areas to focus
Let's discuss the problems associated with using the last block of the epoch as opposed to the first block.
