### PR TITLE
refactor: publish StartMithril from custom_indexer when in Mithril mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,6 +556,7 @@ dependencies = [
  "acropolis_module_block_unpacker",
  "acropolis_module_custom_indexer",
  "acropolis_module_genesis_bootstrapper",
+ "acropolis_module_mithril_snapshot_fetcher",
  "acropolis_module_peer_network_interface",
  "anyhow",
  "bincode 1.3.3",

--- a/modules/custom_indexer/src/configuration.rs
+++ b/modules/custom_indexer/src/configuration.rs
@@ -25,6 +25,7 @@ pub struct GlobalConfig {
 
 #[derive(serde::Deserialize)]
 pub struct StartupConfig {
+    #[serde(rename = "sync-mode")]
     pub sync_mode: SyncMode,
 }
 

--- a/modules/custom_indexer/src/custom_indexer.rs
+++ b/modules/custom_indexer/src/custom_indexer.rs
@@ -145,6 +145,13 @@ impl<CS: CursorStore> CustomIndexer<CS> {
                 &cfg.sync_command_publisher_topic,
             )
             .await?;
+        } else {
+            utils::start_mithril(
+                sync_points.back().unwrap().clone(),
+                context,
+                &cfg.sync_command_publisher_topic,
+            )
+            .await?;
         }
 
         loop {

--- a/modules/custom_indexer/src/utils.rs
+++ b/modules/custom_indexer/src/utils.rs
@@ -24,3 +24,21 @@ pub async fn change_sync_point(
 
     Ok(())
 }
+
+pub async fn start_mithril(
+    point: Point,
+    context: Arc<Context<Message>>,
+    topic: &String,
+) -> Result<()> {
+    let msg = Message::Command(Command::ChainSync(ChainSyncCommand::StartMithril(
+        point.clone(),
+    )));
+    context.publish(topic, Arc::new(msg)).await?;
+    info!(
+        "Publishing sync command on {} for slot {}",
+        topic,
+        point.slot()
+    );
+
+    Ok(())
+}

--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -417,14 +417,14 @@ impl MithrilSnapshotFetcher {
             .get_string(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.0)
             .unwrap_or(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.1.to_string());
         info!("Creating subscriber for bootstrapped on '{bootstrapped_subscribe_topic}'");
-        let sync_command_topic = config
-            .get_string(DEFAULT_SYNC_COMMAND_TOPIC.0)
-            .unwrap_or(DEFAULT_SYNC_COMMAND_TOPIC.1.to_string());
-        info!("Publishing completion on '{sync_command_topic}'");
 
         let mut bootstrapped_subscription =
             context.subscribe(&bootstrapped_subscribe_topic).await?;
         let mut sync_command_subscription = if StartupMode::from_config(&config).is_snapshot() {
+            let sync_command_topic = config
+                .get_string(DEFAULT_SYNC_COMMAND_TOPIC.0)
+                .unwrap_or(DEFAULT_SYNC_COMMAND_TOPIC.1.to_string());
+
             Some(context.subscribe(&sync_command_topic).await?)
         } else {
             None

--- a/processes/indexer/Cargo.toml
+++ b/processes/indexer/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 acropolis_codec = { path = "../../codec" }
 acropolis_common = { path = "../../common" }
 acropolis_module_genesis_bootstrapper = { path = "../../modules/genesis_bootstrapper" }
+acropolis_module_mithril_snapshot_fetcher = { path = "../../modules/mithril_snapshot_fetcher" }
 acropolis_module_peer_network_interface = { path = "../../modules/peer_network_interface" }
 acropolis_module_block_unpacker = { path = "../../modules/block_unpacker" }
 acropolis_module_custom_indexer = { path = "../../modules/custom_indexer" }

--- a/processes/indexer/indexer.toml
+++ b/processes/indexer/indexer.toml
@@ -2,10 +2,18 @@
 
 [global.startup]
 network = "mainnet"
-method = "snapshot"  # Options: "mithril" | "snapshot"
+startup-mode = "snapshot"
+sync-mode = "upstream"      # Options: "mithril" | "upstream"
 topic = "cardano.sequence.start"
 
 [module.genesis-bootstrapper]
+
+[module.mithril-snapshot-fetcher]
+aggregator-url = "https://aggregator.release-mainnet.api.mithril.network/aggregator"
+genesis-key = "5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"
+# Download max age in hours. E.g. 8 means 8 hours (if there isn't any snapshot within this time range download from Mithril)
+download-max-age = "never"
+block-publish-topic = "cardano.block.proposed"
 
 [module.peer-network-interface]
 block-topic = "cardano.block.proposed" # Skip validation for indexer


### PR DESCRIPTION
## Description
This PR moves responsibility for publishing the `StartMithril` sync command into `CustomIndexer` when `
sync-mode = mithril`. By centralizing this behavior, index implementation no longer need to include custom startup logic to trigger the `mithril_snapshot_fetcher`. 

## Related Issue(s)
N/A

## How was this tested?
* Verified that `mithril_snapshot_fetcher` correctly publishes blocks when `sync-mode` = mithril using the example indexer.
* Confirmed that upstream sync mode flow is unaffected.

## Checklist
- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
* Indexer implementations no longer need to publish `StartMithril` themselves.

## Reviewer notes / Areas to focus
The only functional change is the call to `start_mithril` in `custom_indexer.rs`. 