### PR TITLE
fix: only pass pools retiring in E to accounts state

### DIFF
--- a/common/src/snapshot/streaming_snapshot.rs
+++ b/common/src/snapshot/streaming_snapshot.rs
@@ -1259,7 +1259,12 @@ impl StreamingSnapshotParser {
 
         // Build pool registrations list for AccountsBootstrapMessage
         let pool_registrations: Vec<PoolRegistration> = pools.pools.values().cloned().collect();
-        let retiring_pools: Vec<PoolId> = pools.retiring.keys().cloned().collect();
+        let retiring_pools: Vec<PoolId> = pools
+            .retiring
+            .iter()
+            .filter(|(_, retiring_epoch)| **retiring_epoch == epoch)
+            .map(|(pool_id, _)| *pool_id)
+            .collect();
 
         info!(
             "Pools: {} registered, {} retiring, {} DReps",

--- a/tests/integration/package.json
+++ b/tests/integration/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "scripts": {
-    "test:spdd": "ts-node spdd.test.ts"
+    "test:spdd": "node --loader ts-node/esm spdd.test.ts"
   },
   "dependencies": {
     "axios": "^1.12.2",


### PR DESCRIPTION
## Description
This PR fixes the deposits mismatch for snapshot bootstrapping in epoch 508 by passing only the pools retiring in 508 to accounts state. I've also included a change to the spdd test to log the smallest diff pool as well as the mismatched pool with the lowest total active stake for tracking down additional bugs. 

## Related Issue(s)
Relates to #525

## How was this tested?
* Verified that deposits pot now passes our verifier in `accounts_state`

## Checklist

- [x] My code builds and passes local tests
- [x] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
Deposits pot is now correct when snapshot bootstrapping. 

## Reviewer notes / Areas to focus
N/A
