### PR TITLE
feat: implement round-trip-friendly FromStr on Point

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "serde_with 3.16.1",
  "sha2 0.10.9",
  "tempfile",
+ "test-case",
  "thiserror 2.0.17",
  "tokio",
  "tracing",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -45,6 +45,7 @@ sha2 = "0.10.8"
 
 [dev-dependencies]
 tempfile = "3.23"
+test-case = "3.3.1"
 config = { workspace = true }
 caryatid_process = { workspace = true }
 env_logger = "0.10"

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -13,7 +13,7 @@ use crate::{
     declare_hash_type, declare_hash_type_with_bech32, protocol_params,
     rational_number::RationalNumber,
 };
-use anyhow::{anyhow, bail, Error, Result};
+use anyhow::{anyhow, bail, Context, Error, Result};
 use bech32::{Bech32, Hrp};
 use bitmask_enum::bitmask;
 use hex::decode;
@@ -1107,8 +1107,24 @@ impl Display for Point {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Origin => write!(f, "origin"),
-            Self::Specific { hash, slot } => write!(f, "{hash}@{slot}"),
+            Self::Specific { hash, slot } => write!(f, "{slot}.{hash}"),
         }
+    }
+}
+
+impl FromStr for Point {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == "origin" {
+            return Ok(Self::Origin);
+        }
+        let Some((slot_str, hash_str)) = s.split_once(".") else {
+            bail!("invalid point: missing \".\"");
+        };
+        let slot = slot_str.parse().context("invalid slot")?;
+        let hash = hash_str.parse().context("invalid hash")?;
+        Ok(Self::Specific { hash, slot })
     }
 }
 
@@ -2788,6 +2804,7 @@ mod tests {
     use super::*;
     use crate::hash::Hash;
     use anyhow::Result;
+    use test_case::test_case;
 
     #[test]
     fn era_order() -> Result<()> {
@@ -2922,7 +2939,7 @@ mod tests {
     }
 
     #[test]
-    fn serialize_stake_addres() -> Result<()> {
+    fn serialize_stake_address() -> Result<()> {
         let serialized = "{\
             \"network\":\"Mainnet\",\
             \"credential\":{\
@@ -2958,5 +2975,29 @@ mod tests {
             ScriptHash::from_str("c3a33acb8903cf42611e26b15c7731f537867c6469f5bf69c837e4a3")
                 .unwrap()
         );
+    }
+
+    #[test_case("origin")]
+    #[test_case("48460699.7bfb6a677df577d2f0371236ecf63554b54b35b663d3ad9159695a609306e629")]
+    #[test_case("123665404.5acee019d5550554aff5a044ed3b700decf29460e100218381f85a767af8c09f")]
+    fn should_round_trip_points(point_str: &str) {
+        let point: Point = point_str.parse().expect("invalid point");
+        assert_eq!(point.to_string(), point_str);
+    }
+
+    #[test_case("onigiri", "invalid point: missing \".\"")]
+    #[test_case(
+        "4846069a.7bfb6a677df577d2f0371236ecf63554b54b35b663d3ad9159695a609306e629",
+        "invalid slot"
+    )]
+    #[test_case(
+        "123665404.5acee019d5550554aff5a044ed3b700decf29460e100218381f85a767af8c09fff",
+        "invalid hash"
+    )]
+    fn should_report_errors_parsing_points(point_str: &str, message: &str) {
+        let Err(error) = point_str.parse::<Point>() else {
+            panic!("expected parsing error, got success");
+        };
+        assert_eq!(error.to_string(), message);
     }
 }


### PR DESCRIPTION
## Description

Update the `Point` struct from commons to
 - Implement `FromStr` (meaning you can call `"origin".parse()?` to get a point from a string)
 - Implement `Display` so that it outputs data in the same format that `FromStr` expects.

The format is `slot.hash`, because that is the format used by [Kupo](https://cardanosolutions.github.io/kupo/#section/Getting-started/-since-slot-no.header_hash) and the only standard way to stringify a point that I have seen

## Related Issue(s)

Scooper work, not ticketed here

## How was this tested?

Unit tests

## Checklist

- [x] My code builds and passes local tests
- [x] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
N/A