### PR TITLE
feat: add governance procedures and outcomes handling in accounts state

### DIFF
--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -366,13 +366,6 @@ pub struct ProtocolParametersBootstrapMessage {
     pub era: Era,
     pub params: ProtocolParamUpdate,
     pub epoch: u64,
-    /// Previous epoch's reward parameters, needed for reward calculation at first epoch boundary.
-    /// At bootstrap, rewards for epoch N are calculated using protocol params from epoch N-1.
-    #[serde(default)]
-    pub previous_reward_params: Option<RewardParams>,
-    /// Current epoch's reward parameters.
-    #[serde(default)]
-    pub current_reward_params: Option<RewardParams>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -2004,7 +2004,7 @@ pub enum ProtocolParamType {
     SecurityProperty,
 }
 
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Default, Clone)]
 pub struct RewardParams {
     pub expansion_rate: RationalNumber,
     pub treasury_growth_rate: RationalNumber,

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -657,14 +657,7 @@ impl State {
 
         if different {
             info!("New parameter set: {:?}", params_msg.params);
-            // Rotate: previous = current, current = new.
-            // Special case: if both are None (first message), set previous to new params
-            // instead of None so reward calculations have valid params.
-            if self.previous_protocol_parameters.is_none() && self.protocol_parameters.is_none() {
-                self.previous_protocol_parameters = Some(params_msg.params.clone());
-            } else {
-                self.previous_protocol_parameters = self.protocol_parameters.clone();
-            }
+            self.previous_protocol_parameters = self.protocol_parameters.clone();
             self.protocol_parameters = Some(params_msg.params.clone());
         }
 

--- a/modules/snapshot_bootstrapper/src/publisher.rs
+++ b/modules/snapshot_bootstrapper/src/publisher.rs
@@ -429,8 +429,8 @@ impl GovernanceProtocolParametersCallback for SnapshotPublisher {
     fn on_gs_protocol_parameters(
         &mut self,
         epoch: u64,
-        previous_reward_params: RewardParams,
-        current_reward_params: RewardParams,
+        _: RewardParams,
+        _: RewardParams,
         params: ProtocolParamUpdate,
     ) -> Result<()> {
         publish_gov_state(
@@ -440,15 +440,12 @@ impl GovernanceProtocolParametersCallback for SnapshotPublisher {
             self.epoch_context.era,
             self.epoch_context.magic_number.clone(),
             params,
-            previous_reward_params,
-            current_reward_params,
         );
 
         Ok(())
     }
 }
 
-#[allow(clippy::too_many_arguments)]
 fn publish_gov_state(
     context: &Arc<Context<Message>>,
     topic: &str,
@@ -456,18 +453,8 @@ fn publish_gov_state(
     era: Era,
     magic_number: MagicNumber,
     params: ProtocolParamUpdate,
-    previous_reward_params: RewardParams,
-    current_reward_params: RewardParams,
 ) {
-    info!(
-        "Received governance protocol parameters for epoch {epoch} \
-         (previous_reward_params: k={}, a0={}, rho={}, tau={}, min_pool_cost={})",
-        previous_reward_params.desired_number_of_stake_pools,
-        previous_reward_params.pool_pledge_influence,
-        previous_reward_params.expansion_rate,
-        previous_reward_params.treasury_growth_rate,
-        previous_reward_params.min_pool_cost,
-    );
+    info!("Received governance protocol parameters for epoch {epoch}",);
     // Send a message to the protocol parameters state, one per slice
     let message = Arc::new(Message::Snapshot(SnapshotMessage::Bootstrap(
         SnapshotStateMessage::ParametersState(ProtocolParametersBootstrapMessage {
@@ -475,8 +462,6 @@ fn publish_gov_state(
             params,
             era,
             network_name: magic_number.to_network_name().to_string(),
-            previous_reward_params: Some(previous_reward_params),
-            current_reward_params: Some(current_reward_params),
         }),
     )));
 


### PR DESCRIPTION
##  Description

  Adds Conway-era governance support to the accounts_state module:

1. Governance outcomes handling: Processes enacted/expired proposals at epoch boundaries:
    - Refunds proposal deposits to proposer's reward account (or treasury if unregistered)
    - Executes treasury withdrawals for enacted TreasuryWithdrawal actions
 2. DRep certificate handling:
    - Tracks DRep registrations/deregistrations
    - Clears delegations when a DRep deregisters (implements clearDRepDelegations from Haskell ledger)

##  Related Issue(s)

## How was this tested?

  - Unit tests
  - Manual verification against mainnet governance actions

##  Checklist

  - [x] My code builds and passes local tests
  - [ ] I added/updated tests for my changes, where applicable
  - [ ] I updated documentation (if applicable)
  - [x] CI is green for this PR

##  Impact / Side effects

  - New topic subscriptions required: cardano.governance, cardano.enact.state
  - Treasury balance now affected by governance withdrawals
  - Stake addresses delegated to deregistered DReps will have their delegation cleared

##  Reviewer notes / Areas to focus

  - modules/accounts_state/src/state.rs:1088-1217: Core governance handling logic
  - common/src/stake_addresses.rs:461-489: DRep deregistration delegation clearing (O(n) - see TODO)
  - Governance deposits are tracked separately from pots.deposits per Cardano ledger spec