### PR TITLE
fix: ensure protocol parameters update whenever new parameter set is received

### DIFF
--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -718,9 +718,9 @@ impl State {
 
         if different {
             info!("New parameter set: {:?}", params_msg.params);
-            self.previous_protocol_parameters = self.protocol_parameters.clone();
-            self.protocol_parameters = Some(params_msg.params.clone());
         }
+        self.previous_protocol_parameters = self.protocol_parameters.clone();
+        self.protocol_parameters = Some(params_msg.params.clone());
 
         Ok(())
     }


### PR DESCRIPTION
## Description

This PR simply shifts the parameter set out of the `!different` check, so that we always update the parameters. This is actually necessary as a precursor to the AVVM work that will follow to cancel the unredeemed utxos. 

```
Epoch 232: ✅ 1343 match, ⚠️ 0 mismatch, ❌ 0 missing, 🌀 0 extra (total 1343)
Epoch 233: ✅ 1370 match, ⚠️ 0 mismatch, ❌ 0 missing, 🌀 0 extra (total 1370)
Epoch 234: ✅ 1414 match, ⚠️ 0 mismatch, ❌ 0 missing, 🌀 0 extra (total 1414)
Epoch 235: ✅ 1437 match, ⚠️ 0 mismatch, ❌ 0 missing, 🌀 0 extra (total 1437)                 
Epoch 236: ✅ 741 match, ⚠️ 705 mismatch, ❌ 0 missing, 🌀 0 extra (total 1446)
❌ Total active stake mismatch for epoch 236:
   DB: 20598560072620853
   SPDD: 20598164296210085                                                                     
   Mismatched pool with smallest difference:                                                      - pool1m2tgjxn880a3v6w4v3uf3kz9kduhvtr97slmpwnppd6r63230sm (db: 124800898117, spdd: 124800897919, diff: 198)
   Mismatched pool with smallest total stake:
   - pool15amxxauxh409wcuc87e0tusfzuka0wfvxhxmpt6vugqgsw6j4d6 (db: 1408680263, spdd: 1407685829, diff: 994434)
```

## Related Issue(s)


## How was this tested?
- manually ran the sync process from Genesis up to 236

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
None, this change is additive. 
