### PR TITLE
chore: Optimize DRep deregistration with reverse delegation index

### DIFF
--- a/common/src/stake_addresses.rs
+++ b/common/src/stake_addresses.rs
@@ -7,6 +7,7 @@ use anyhow::{bail, Result};
 use dashmap::DashMap;
 use rayon::prelude::*;
 use serde_with::{hex::Hex, serde_as};
+use std::collections::HashSet;
 use std::{
     collections::{
         hash_map::{Entry, Iter, Values},
@@ -47,6 +48,9 @@ pub struct AccountState {
 #[derive(Default, Debug)]
 pub struct StakeAddressMap {
     inner: HashMap<StakeAddress, StakeAddressState>,
+
+    /// Reverse indexing for tracking which stake addresses delegate to a given DRep credential.
+    drep_delegates: HashMap<DRepCredential, HashSet<StakeAddress>>,
 }
 
 impl StakeAddressMap {
@@ -54,7 +58,40 @@ impl StakeAddressMap {
     pub fn new() -> Self {
         Self {
             inner: HashMap::new(),
+            drep_delegates: HashMap::new(),
         }
+    }
+
+    #[inline]
+    fn drep_choice_to_credential(choice: &DRepChoice) -> Option<DRepCredential> {
+        match choice {
+            DRepChoice::Key(hash) => Some(DRepCredential::AddrKeyHash(*hash)),
+            DRepChoice::Script(hash) => Some(DRepCredential::ScriptHash(*hash)),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    fn remove_drep_delegate(&mut self, stake_address: &StakeAddress, drep: Option<&DRepChoice>) {
+        let Some(drep_cred) = drep.and_then(Self::drep_choice_to_credential) else {
+            return;
+        };
+        let Some(stake_addresses) = self.drep_delegates.get_mut(&drep_cred) else {
+            return;
+        };
+        stake_addresses.remove(stake_address);
+        if stake_addresses.is_empty() {
+            self.drep_delegates.remove(&drep_cred);
+        }
+    }
+
+    #[inline]
+    fn add_drep_delegate(&mut self, stake_address: &StakeAddress, drep: Option<&DRepChoice>) {
+        let Some(drep_cred) = drep.and_then(Self::drep_choice_to_credential) else {
+            return;
+        };
+
+        self.drep_delegates.entry(drep_cred).or_default().insert(stake_address.clone());
     }
 
     #[inline]
@@ -73,12 +110,26 @@ impl StakeAddressMap {
         stake_address: StakeAddress,
         stake_address_state: StakeAddressState,
     ) -> Option<StakeAddressState> {
-        self.inner.insert(stake_address, stake_address_state)
+        let current_drep = stake_address_state.delegated_drep.clone();
+
+        let old_stake_address = self.inner.insert(stake_address.clone(), stake_address_state);
+
+        let old_drep = old_stake_address.as_ref().and_then(|s| s.delegated_drep.as_ref());
+        if old_drep != current_drep.as_ref() {
+            self.remove_drep_delegate(&stake_address, old_drep);
+            self.add_drep_delegate(&stake_address, current_drep.as_ref());
+        }
+        old_stake_address
     }
 
     #[inline]
     pub fn remove(&mut self, stake_address: &StakeAddress) -> Option<StakeAddressState> {
-        self.inner.remove(stake_address)
+        let old_stake_address_state = self.inner.remove(stake_address);
+        let old_drep = old_stake_address_state.as_ref().and_then(|s| s.delegated_drep.as_ref());
+        if old_drep.is_some() {
+            self.remove_drep_delegate(stake_address, old_drep);
+        }
+        old_stake_address_state
     }
 
     #[inline]
@@ -458,27 +509,18 @@ impl StakeAddressMap {
     }
 
     /// Deregister a DRep - clears all delegations to this DRep
-    ///
-    /// TODO: This currently iterates ALL stake addresses to find delegations (O(n)).
-    /// The Haskell ledger maintains a reverse index (`drepDelegs`) on each DRepState
-    /// that tracks which credentials delegated TO that DRep, enabling O(k) clearing
-    /// where k = number of delegators. We could consider adding similar reverse tracking for
-    /// better performance.
-    /// See: https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/conway/impl/src/Cardano/Ledger/Conway/Rules/GovCert.hs
-    /// `clearDRepDelegations` function.
+    /// Uses 'reverse index' for O(k) clearing, where k = number of delegators.
     pub fn deregister_drep(&mut self, drep_credential: &DRepCredential) {
-        for sas in self.inner.values_mut() {
-            if let Some(ref drep) = sas.delegated_drep {
-                let matches = match drep {
-                    DRepChoice::Key(hash) => {
-                        matches!(drep_credential, DRepCredential::AddrKeyHash(h) if h == hash)
-                    }
-                    DRepChoice::Script(hash) => {
-                        matches!(drep_credential, DRepCredential::ScriptHash(h) if h == hash)
-                    }
-                    _ => false,
-                };
-                if matches {
+        let Some(delegators) = self.drep_delegates.remove(drep_credential) else {
+            // If there are no delegators, there is nothing to remove from StakeAddressMap::inner
+            return;
+        };
+
+        for stake_address in delegators {
+            if let Some(sas) = self.inner.get_mut(&stake_address) {
+                if sas.delegated_drep.as_ref().and_then(Self::drep_choice_to_credential).as_ref()
+                    == Some(drep_credential)
+                {
                     sas.delegated_drep = None;
                 }
             }
@@ -491,24 +533,38 @@ impl StakeAddressMap {
         stake_address: &StakeAddress,
         drep: &DRepChoice,
     ) -> bool {
-        if let Some(sas) = self.get_mut(stake_address) {
-            if sas.registered {
-                sas.delegated_drep = Some(drep.clone());
-                true
-            } else {
+        // Read the needed fields.
+        let (registered, old_drep) = match self.inner.get(stake_address) {
+            Some(sas) => (sas.registered, sas.delegated_drep.clone()),
+            None => {
                 error!(
-                    "Unregistered stake address in DRep delegation: {}",
+                    "Unknown stake address in drep delegation: {}",
                     stake_address
                 );
-                false
+                return false;
             }
-        } else {
+        };
+
+        if !registered {
             error!(
-                "Unknown stake address in drep delegation: {}",
+                "Unregistered stake address in DRep delegation: {}",
                 stake_address
             );
-            false
+            return false;
         }
+
+        if old_drep.as_ref() != Some(drep) {
+            // Update the reverse index.
+            self.remove_drep_delegate(stake_address, old_drep.as_ref());
+            self.add_drep_delegate(stake_address, Some(drep));
+
+            // Write back the new delegation.
+            if let Some(sas) = self.inner.get_mut(stake_address) {
+                sas.delegated_drep = Some(drep.clone());
+            }
+        }
+
+        true
     }
 
     /// Add a reward to a reward account (by stake address)
@@ -598,6 +654,7 @@ mod tests {
     const SPO_HASH: PoolId = PoolId::new(Hash::new([0xbb_u8; 28]));
     const SPO_HASH_2: PoolId = PoolId::new(Hash::new([0x02_u8; 28]));
     const DREP_HASH: KeyHash = KeyHash::new([0xca; 28]);
+    const DREP_HASH_2: KeyHash = KeyHash::new([0xcd; 28]);
 
     fn create_stake_address(hash: KeyHash) -> StakeAddress {
         StakeAddress::new(StakeCredential::AddrKeyHash(hash), NetworkId::Mainnet)
@@ -790,6 +847,43 @@ mod tests {
             assert_eq!(
                 stake_addresses.get(&stake_address).unwrap().delegated_drep,
                 Some(DRepChoice::NoConfidence)
+            );
+        }
+
+        #[test]
+        fn test_drep_deregister_clears_delegators() {
+            let mut stake_addresses = StakeAddressMap::new();
+            let address1 = create_stake_address(STAKE_KEY_HASH);
+            let address2 = create_stake_address(STAKE_KEY_HASH_2);
+
+            stake_addresses.register_stake_address(&address1);
+            stake_addresses.register_stake_address(&address2);
+
+            let drep_choice = DRepChoice::Key(DREP_HASH);
+            stake_addresses.record_drep_delegation(&address1, &drep_choice);
+            stake_addresses.record_drep_delegation(&address2, &drep_choice);
+
+            stake_addresses.deregister_drep(&DRepCredential::AddrKeyHash(DREP_HASH));
+            assert_eq!(stake_addresses.get(&address1).unwrap().delegated_drep, None);
+            assert_eq!(stake_addresses.get(&address2).unwrap().delegated_drep, None);
+        }
+
+        #[test]
+        fn test_drep_deregister_does_not_clear_after_redelegation() {
+            let mut stake_addresses = StakeAddressMap::new();
+            let address = create_stake_address(STAKE_KEY_HASH);
+
+            stake_addresses.register_stake_address(&address);
+
+            // Delegate to one DRep then re-delegate to another.
+            stake_addresses.record_drep_delegation(&address, &DRepChoice::Key(DREP_HASH));
+            stake_addresses.record_drep_delegation(&address, &DRepChoice::Key(DREP_HASH_2));
+
+            // Deregistering first DRep must not clear the current delegation.
+            stake_addresses.deregister_drep(&DRepCredential::AddrKeyHash(DREP_HASH));
+            assert_eq!(
+                stake_addresses.get(&address).unwrap().delegated_drep,
+                Some(DRepChoice::Key(DREP_HASH_2))
             );
         }
     }


### PR DESCRIPTION
## Description

Adds a reverse index that tracks which stake addresses have delegated to each DRep. This enables O(k) clearing where k = number of delegators to that specific DRep.

## Related Issue(s)
#588 

## How was this tested?
Added unit tests

## Checklist

- [x] My code builds and passes local tests
- [x] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [ ] CI is green for this PR

## Impact / Side effects

## Reviewer notes / Areas to focus
