### PR TITLE
Fixes incorrect reading of DRep and SPO config

### DIFF
--- a/common/src/caryatid.rs
+++ b/common/src/caryatid.rs
@@ -128,7 +128,7 @@ macro_rules! declare_cardano_reader {
                 ctx: &Context<Message>,
                 cfg: &Arc<Config>,
             ) -> Result<Option<Self>> {
-                match cfg.get::<&str>($param) {
+                match cfg.get::<String>($param) {
                     Ok(topic_name) => {
                         if !$def_topic.is_empty() {
                             bail!(
@@ -142,9 +142,9 @@ macro_rules! declare_cardano_reader {
                             sub: ctx.subscribe(&topic_name).await?,
                         }))
                     }
-                    Err(_) => {
+                    Err(e) => {
                         info!(
-                            "Skipping subscriber creation for '{}', no topic in config",
+                            "Skipping subscriber creation for '{}': parameter not found, get error '{e}'",
                             $param
                         );
                         Ok(None)


### PR DESCRIPTION
## Description

Governance voting at epoch 536 does not produce a correct result in Mainnet. The problem was in incorrect config parsing, so SPO and DRep cannot be properly read.

## Related Issue(s)
Fixes # 650

## How was this tested?
* integration test (governance back to normal)

## Checklist

- [x] My code builds and passes local tests
- [x] I added/updated tests for my changes, where applicable
- [x] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects

## Reviewer notes / Areas to focus
