### PR TITLE
feat: add script to fetch opcerts from db-sync

### DIFF
--- a/scripts/bootstrap/.env.example
+++ b/scripts/bootstrap/.env.example
@@ -1,0 +1,2 @@
+DBSYNC_URL=postgres://user:pass@localhost:5432/cexplorer
+OPCERTS_EPOCH=507

--- a/scripts/bootstrap/.gitignore
+++ b/scripts/bootstrap/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+.env

--- a/scripts/bootstrap/fetch_opcerts.ts
+++ b/scripts/bootstrap/fetch_opcerts.ts
@@ -1,0 +1,77 @@
+import "dotenv/config";
+import { Client } from "pg";
+import { bech32 } from "bech32";
+import fs from "fs";
+import path from "path";
+
+const DBSYNC_URL = process.env.DBSYNC_URL!;
+if (!DBSYNC_URL) {
+    throw new Error("Missing DBSYNC_URL");
+}
+
+const TARGET_EPOCH = Number(process.env.OPCERTS_EPOCH);
+if (Number.isNaN(TARGET_EPOCH)) {
+    throw new Error("OPCERTS_EPOCH must be a number");
+}
+
+function toPoolBech32(hex: string): string {
+    const words = bech32.toWords(Buffer.from(hex, "hex"));
+    return bech32.encode("pool", words);
+}
+
+async function fetchOpCerts(db: Client, epoch: number) {
+    const { rows } = await db.query(
+        `
+        SELECT DISTINCT ON (ph.hash_raw)
+            encode(ph.hash_raw::bytea, 'hex') AS pool_key_hash_hex,
+            b.op_cert_counter
+        FROM block b
+        JOIN slot_leader sl ON sl.id = b.slot_leader_id
+        JOIN pool_hash ph ON ph.id = sl.pool_hash_id
+        WHERE b.epoch_no <= $1
+        ORDER BY ph.hash_raw, b.block_no DESC;
+        `,
+        [epoch]
+    );
+
+    return rows.map((r) => ({
+        pool_id: toPoolBech32(r.pool_key_hash_hex),
+        op_cert_counter: Number(r.op_cert_counter ?? 0),
+    }));
+}
+
+async function run() {
+    const db = new Client({ connectionString: DBSYNC_URL });
+    await db.connect();
+
+    console.log(
+        `Fetching latest op certs at or before epoch ${TARGET_EPOCH}...`
+    );
+
+    const data = await fetchOpCerts(db, TARGET_EPOCH);
+
+    // Sort lexicographically by pool_id
+    data.sort((a, b) => a.pool_id.localeCompare(b.pool_id));
+
+    const outputPath = path.join(
+        process.cwd(),
+        `op_cert_counters.csv`
+    );
+
+    const header = `"pool_id","latest_op_cert_counter"\n`;
+
+    const rows = data
+        .map((r) => `"${r.pool_id}","${r.op_cert_counter}"`)
+        .join("\n");
+
+    fs.writeFileSync(outputPath, header + rows + "\n");
+
+    console.log(`Wrote ${data.length} pools to ${outputPath}`);
+
+    await db.end();
+}
+
+run().catch((err) => {
+    console.error(err.message || err);
+    process.exit(1);
+});

--- a/scripts/bootstrap/package.json
+++ b/scripts/bootstrap/package.json
@@ -1,0 +1,16 @@
+{
+  "dependencies": {
+    "bech32": "^2.0.0",
+    "dotenv": "^17.2.4",
+    "pg": "^8.18.0"
+  },
+  "scripts": {
+    "fetch:opcerts": "ts-node fetch_opcerts.ts"
+  },
+  "devDependencies": {
+    "@types/node": "^25.2.3",
+    "@types/pg": "^8.16.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.0"
+  }
+}

--- a/scripts/bootstrap/tsconfig.json
+++ b/scripts/bootstrap/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  }
+}


### PR DESCRIPTION
## Description
This PR adds a script which fetches the opcerts needed for snapshot bootstrapping at a specified epoch. 

## Related Issue(s)
N/A

## How was this tested?
* Used to script to generate mainnet opcerts at epoch 507 and verified that no opcert validation errors occured when replacing our existing opcert file with the one generated by this script. 

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] CI is green for this PR

## Impact / Side effects
Opcerts for any epoch or network can now be easily generated to change the bootstrap starting point. 

## Reviewer notes / Areas to focus
Query used to fetch opcerts in `/scripts/bootstrap/fetch_opcerts.ts`
