### PR TITLE
feat: dockerize omnibus process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -17,6 +17,10 @@
 # Re-ignore local/runtime-heavy paths inside allowed trees
 modules/mithril_snapshot_fetcher/downloads/**
 processes/omnibus/downloads/**
+processes/omnibus/cache/**
+processes/omnibus/fjall-*/**
+processes/omnibus/fjall*/**
+modules/snapshot_bootstrapper/data/**
 modules/accounts_state/test-data/**
 !modules/accounts_state/test-data/pots.mainnet.csv
 **/target/**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,50 @@
+x-omnibus-base: &omnibus-base
+  build:
+    context: .
+    dockerfile: Dockerfile
+  working_dir: /app/processes/omnibus
+  environment:
+    RUST_LOG: ${RUST_LOG:-info}
+  user: "${OMNIBUS_UID:-0}:${OMNIBUS_GID:-0}"
+  restart: unless-stopped
+
 services:
-  omnibus:
-    build:
-      context: .
-      dockerfile: Dockerfile
-    working_dir: /app/processes/omnibus
-    environment:
-      RUST_LOG: ${RUST_LOG:-info}
-    command: ["--config", "${OMNIBUS_CONFIG:-omnibus-preview.toml}"]
+  omnibus-preview:
+    <<: *omnibus-base
+    container_name: omnibus-preview
+    command: ["--config", "omnibus-preview.toml"]
     ports:
-      - "${OMNIBUS_REST_PORT:-4340}:4340"
-      - "${OMNIBUS_MCP_PORT:-4341}:4341"
+      - "${OMNIBUS_PREVIEW_REST_PORT:-4340}:4340"
+      - "${OMNIBUS_PREVIEW_MCP_PORT:-4341}:4341"
     volumes:
-      - ${MITHRIL_DOWNLOADS_DIR:-omnibus_downloads}:/app/modules/mithril_snapshot_fetcher/downloads
-      - omnibus_spdd:/app/processes/omnibus/fjall-spdd
-    restart: unless-stopped
+      - ${MITHRIL_DOWNLOADS_DIR_PREVIEW:-omnibus_preview_downloads}:/app/modules/mithril_snapshot_fetcher/downloads
+      - ${SNAPSHOT_DATA_DIR_PREVIEW:-omnibus_preview_snapshot_data}:/app/modules/snapshot_bootstrapper/data
+      - ${ADDRESS_STATE_DB_DIR_PREVIEW:-omnibus_preview_address_state_db}:/app/modules/address_state/db
+      - ${HISTORICAL_ACCOUNTS_DB_DIR_PREVIEW:-omnibus_preview_historical_accounts_state_db}:/app/modules/historical_accounts_state/db
+      - omnibus_preview_spdd:/app/processes/omnibus/fjall-spdd
+
+  omnibus-mainnet:
+    <<: *omnibus-base
+    container_name: omnibus-mainnet
+    command: ["--config", "omnibus.toml"]
+    ports:
+      - "${OMNIBUS_MAINNET_REST_PORT:-5340}:4340"
+      - "${OMNIBUS_MAINNET_MCP_PORT:-5341}:4341"
+    volumes:
+      - ${MITHRIL_DOWNLOADS_DIR_MAINNET:-omnibus_mainnet_downloads}:/app/modules/mithril_snapshot_fetcher/downloads
+      - ${SNAPSHOT_DATA_DIR_MAINNET:-omnibus_mainnet_snapshot_data}:/app/modules/snapshot_bootstrapper/data
+      - ${ADDRESS_STATE_DB_DIR_MAINNET:-omnibus_mainnet_address_state_db}:/app/modules/address_state/db
+      - ${HISTORICAL_ACCOUNTS_DB_DIR_MAINNET:-omnibus_mainnet_historical_accounts_state_db}:/app/modules/historical_accounts_state/db
+      - omnibus_mainnet_spdd:/app/processes/omnibus/fjall-spdd
 
 volumes:
-  omnibus_spdd:
-  omnibus_downloads:
+  omnibus_preview_spdd:
+  omnibus_preview_downloads:
+  omnibus_preview_snapshot_data:
+  omnibus_preview_address_state_db:
+  omnibus_preview_historical_accounts_state_db:
+  omnibus_mainnet_spdd:
+  omnibus_mainnet_downloads:
+  omnibus_mainnet_snapshot_data:
+  omnibus_mainnet_address_state_db:
+  omnibus_mainnet_historical_accounts_state_db:

--- a/processes/omnibus/README.md
+++ b/processes/omnibus/README.md
@@ -31,26 +31,14 @@ $ ulimit -n 4096
 
 ## Docker Compose
 
-Build and run with preview config (default):
+Build and run preview:
 
 ```shell
-docker compose up --build
+docker compose up --build omnibus-preview
 ```
 
-Run with mainnet config:
+Build and run mainnet:
 
 ```shell
-OMNIBUS_CONFIG=omnibus.toml docker compose up --build
+docker compose up --build omnibus-mainnet
 ```
-
-Choose another omnibus config at runtime:
-
-```shell
-OMNIBUS_CONFIG=omnibus-preview.toml docker compose up --build
-```
-
-Notes:
-- Relative paths in config resolve from `/app/processes/omnibus` in the container.
-- Mithril downloads persist by default in the named volume `omnibus_downloads`.
-- To persist Mithril downloads on the host instead, set `MITHRIL_DOWNLOADS_DIR` to a host path (for example `MITHRIL_DOWNLOADS_DIR=./modules/mithril_snapshot_fetcher/downloads`).
-- Mithril snapshot downloads are network-namespaced by the module default path: `.../downloads/<network-name>`.


### PR DESCRIPTION
## Summary
This PR adds Dockerized runtime support for the omnibus process, including explicit Compose services for preview and mainnet.

## Changes
- Added `.dockerignore` to keep Docker build context minimal and exclude large runtime data.
- Added a multi-stage `Dockerfile` for `acropolis_process_omnibus` with improved build caching and a slim runtime image.
- Updated `docker-compose.yml` to provide two explicit services:
  - `omnibus-preview` (preview config)
  - `omnibus-mainnet` (mainnet config)
- Added dedicated persisted volumes for Mithril downloads, snapshot data, module DB directories, and SPDD state per network.
- Updated `processes/omnibus/README.md` with concise run instructions for preview and mainnet.

## Testing
- Ran docker compose up and observed that the process was built correctly and running as expected.
