### PR TITLE
feat: cumulative midnight indexer stats

### DIFF
--- a/modules/midnight_state/src/epoch_totals.rs
+++ b/modules/midnight_state/src/epoch_totals.rs
@@ -1,94 +1,90 @@
-use acropolis_common::{BlockInfo, Era};
+use acropolis_common::BlockInfo;
 
 /// Epoch summary emitted by midnight-state logging runtime.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct EpochSummary {
-    pub epoch: u64,
-    pub era: Era,
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
+pub struct StatsSummary {
     pub indexed_night_utxo_creations: usize,
     pub indexed_night_utxo_spends: usize,
+    pub indexed_candidate_registrations: usize,
+    pub indexed_candidate_deregistrations: usize,
     pub indexed_parameter_datums: usize,
     pub indexed_governance_technical_committee_datums: usize,
     pub indexed_governance_council_datums: usize,
 }
 
+impl StatsSummary {
+    fn accumulate(&mut self, other: &StatsSummary) {
+        self.indexed_night_utxo_creations += other.indexed_night_utxo_creations;
+        self.indexed_night_utxo_spends += other.indexed_night_utxo_spends;
+        self.indexed_candidate_registrations += other.indexed_candidate_registrations;
+        self.indexed_candidate_deregistrations += other.indexed_candidate_deregistrations;
+        self.indexed_parameter_datums += other.indexed_parameter_datums;
+        self.indexed_governance_technical_committee_datums +=
+            other.indexed_governance_technical_committee_datums;
+        self.indexed_governance_council_datums += other.indexed_governance_council_datums;
+    }
+}
+
 #[derive(Clone, Default)]
 pub struct EpochTotals {
-    indexed_night_utxo_creations: usize,
-    indexed_night_utxo_spends: usize,
-    indexed_parameter_datums: usize,
-    indexed_governance_technical_committee_datums: usize,
-    indexed_governance_council_datums: usize,
-    last_checkpoint: Option<EpochCheckpoint>,
-}
-
-#[derive(Clone)]
-struct EpochCheckpoint {
-    epoch: u64,
-    era: Era,
-}
-
-impl EpochCheckpoint {
-    fn from_block(block: &BlockInfo) -> Self {
-        Self {
-            epoch: block.epoch,
-            era: block.era,
-        }
-    }
+    // Contains the cumulative summary
+    cumulative: StatsSummary,
+    // Contains the current epoch summary
+    current: StatsSummary,
 }
 
 impl EpochTotals {
     pub fn add_indexed_night_utxos(&mut self, creations: usize, spends: usize) {
-        self.indexed_night_utxo_creations += creations;
-        self.indexed_night_utxo_spends += spends;
+        self.current.indexed_night_utxo_creations += creations;
+        self.current.indexed_night_utxo_spends += spends;
+    }
+
+    pub fn add_indexed_candidates(&mut self, registrations: usize, deregistrations: usize) {
+        self.current.indexed_candidate_registrations += registrations;
+        self.current.indexed_candidate_deregistrations += deregistrations;
     }
 
     pub fn add_indexed_parameter_datums(&mut self, indexed: usize) {
-        self.indexed_parameter_datums += indexed;
+        self.current.indexed_parameter_datums += indexed;
     }
 
     pub fn add_indexed_governance_datums(&mut self, technical_committee: usize, council: usize) {
-        self.indexed_governance_technical_committee_datums += technical_committee;
-        self.indexed_governance_council_datums += council;
+        self.current.indexed_governance_technical_committee_datums += technical_committee;
+        self.current.indexed_governance_council_datums += council;
     }
 
-    pub fn finalise_block(&mut self, block: &BlockInfo) {
-        self.last_checkpoint = Some(EpochCheckpoint::from_block(block));
-    }
+    pub fn summarise_completed_epoch(&mut self, boundary_block: &BlockInfo) {
+        let epoch = boundary_block.epoch.saturating_sub(1);
 
-    pub fn summarise_completed_epoch(&self, boundary_block: &BlockInfo) -> EpochSummary {
-        let (epoch, era) = if let Some(checkpoint) = self.last_checkpoint.as_ref() {
-            (checkpoint.epoch, checkpoint.era)
-        } else {
-            (boundary_block.epoch.saturating_sub(1), boundary_block.era)
-        };
+        self.cumulative.accumulate(&self.current);
 
-        EpochSummary {
+        tracing::info!(
+            "epoch={} | creations=+{}/{} spends=+{}/{} regs=+{}/{} deregs=+{}/{} council=+{}/{} committee=+{}/{} params=+{}/{}",
             epoch,
-            era,
-            indexed_night_utxo_creations: self.indexed_night_utxo_creations,
-            indexed_night_utxo_spends: self.indexed_night_utxo_spends,
-            indexed_parameter_datums: self.indexed_parameter_datums,
-            indexed_governance_technical_committee_datums: self
-                .indexed_governance_technical_committee_datums,
-            indexed_governance_council_datums: self.indexed_governance_council_datums,
-        }
-    }
+            self.current.indexed_night_utxo_creations,
+            self.cumulative.indexed_night_utxo_creations,
+            self.current.indexed_night_utxo_spends,
+            self.cumulative.indexed_night_utxo_spends,
+            self.current.indexed_candidate_registrations,
+            self.cumulative.indexed_candidate_registrations,
+            self.current.indexed_candidate_deregistrations,
+            self.cumulative.indexed_candidate_deregistrations,
+            self.current.indexed_governance_council_datums,
+            self.cumulative.indexed_governance_council_datums,
+            self.current.indexed_governance_technical_committee_datums,
+            self.cumulative.indexed_governance_technical_committee_datums,
+            self.current.indexed_parameter_datums,
+            self.cumulative.indexed_parameter_datums,
+        );
 
-    pub fn reset_epoch(&mut self) {
-        self.indexed_night_utxo_creations = 0;
-        self.indexed_night_utxo_spends = 0;
-        self.indexed_parameter_datums = 0;
-        self.indexed_governance_technical_committee_datums = 0;
-        self.indexed_governance_council_datums = 0;
-        self.last_checkpoint = None;
+        self.current = StatsSummary::default();
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use acropolis_common::{BlockHash, BlockIntent, BlockStatus};
+    use acropolis_common::{BlockHash, BlockIntent, BlockStatus, Era};
 
     fn mk_block(number: u64, epoch: u64, era: Era) -> BlockInfo {
         BlockInfo {
@@ -110,41 +106,21 @@ mod tests {
     #[test]
     fn tracks_indexed_night_utxos_for_epoch() {
         let mut totals = EpochTotals::default();
-        let block = mk_block(10, 100, Era::Conway);
 
         totals.add_indexed_night_utxos(2, 0);
         totals.add_indexed_night_utxos(1, 4);
         totals.add_indexed_parameter_datums(5);
         totals.add_indexed_governance_datums(2, 6);
-        totals.finalise_block(&block);
 
         let boundary = mk_block(11, 101, Era::Conway);
-        let summary = totals.summarise_completed_epoch(&boundary);
-        assert_eq!(summary.epoch, 100);
-        assert_eq!(summary.era, Era::Conway);
-        assert_eq!(summary.indexed_night_utxo_creations, 3);
-        assert_eq!(summary.indexed_night_utxo_spends, 4);
-        assert_eq!(summary.indexed_governance_technical_committee_datums, 2);
-        assert_eq!(summary.indexed_governance_council_datums, 6);
-        assert_eq!(summary.indexed_parameter_datums, 5);
-    }
-
-    #[test]
-    fn summarise_uses_boundary_epoch_when_checkpoint_absent() {
-        let mut totals = EpochTotals::default();
-        totals.add_indexed_night_utxos(7, 2);
-        totals.add_indexed_parameter_datums(3);
-        totals.add_indexed_governance_datums(4, 1);
-
-        let boundary = mk_block(99, 501, Era::Conway);
-        let summary = totals.summarise_completed_epoch(&boundary);
-
-        assert_eq!(summary.epoch, 500);
-        assert_eq!(summary.era, Era::Conway);
-        assert_eq!(summary.indexed_night_utxo_creations, 7);
-        assert_eq!(summary.indexed_night_utxo_spends, 2);
-        assert_eq!(summary.indexed_parameter_datums, 3);
-        assert_eq!(summary.indexed_governance_technical_committee_datums, 4);
-        assert_eq!(summary.indexed_governance_council_datums, 1);
+        totals.summarise_completed_epoch(&boundary);
+        assert_eq!(totals.cumulative.indexed_night_utxo_creations, 3);
+        assert_eq!(totals.cumulative.indexed_night_utxo_spends, 4);
+        assert_eq!(
+            totals.cumulative.indexed_governance_technical_committee_datums,
+            2
+        );
+        assert_eq!(totals.cumulative.indexed_governance_council_datums, 6);
+        assert_eq!(totals.cumulative.indexed_parameter_datums, 5);
     }
 }

--- a/modules/midnight_state/src/midnight_state.rs
+++ b/modules/midnight_state/src/midnight_state.rs
@@ -65,23 +65,10 @@ impl MidnightState {
                     }
 
                     if blk_info.new_epoch {
-                        let summary = state.handle_new_epoch(blk_info.as_ref())?;
-                        info!(
-                            epoch = summary.epoch,
-                            era = ?summary.era,
-                            indexed_night_utxo_creations = summary.indexed_night_utxo_creations,
-                            indexed_night_utxo_spends = summary.indexed_night_utxo_spends,
-                            indexed_parameter_datums = summary.indexed_parameter_datums,
-                            indexed_governance_technical_committee_datums =
-                                summary.indexed_governance_technical_committee_datums,
-                            indexed_governance_council_datums =
-                                summary.indexed_governance_council_datums,
-                            "epoch checkpoint"
-                        );
+                        state.handle_new_epoch(blk_info.as_ref());
                     }
 
                     state.handle_address_deltas(&blk_info, deltas.as_ref())?;
-                    state.finalise_block(blk_info.as_ref());
 
                     history.lock().await.commit(blk_info.number, state);
                 }


### PR DESCRIPTION
## Description
Expands the midnight_state stats epoch summary with cumulative totals information.

## Related Issue(s)
N/A

## How was this tested?
N/A

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
N/A

## Reviewer notes / Areas to focus
Logging format
