### PR TITLE
refactor: use imbl structures for midnight_state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,6 +366,7 @@ dependencies = [
  "caryatid_sdk",
  "chrono",
  "config",
+ "imbl",
  "prost",
  "protoc-bin-vendored",
  "serde",

--- a/modules/midnight_state/Cargo.toml
+++ b/modules/midnight_state/Cargo.toml
@@ -16,6 +16,7 @@ caryatid_sdk = { workspace = true }
 anyhow = { workspace = true }
 config = { workspace = true }
 chrono = { workspace = true }
+imbl = { workspace = true }
 prost = "0.13"
 serde = { workspace = true }
 tokio = { workspace = true }

--- a/modules/midnight_state/src/indexes/candidate_state.rs
+++ b/modules/midnight_state/src/indexes/candidate_state.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, HashMap};
+use imbl::{HashMap, OrdMap};
 
 use acropolis_common::{BlockNumber, UTxOIdentifier};
 
@@ -7,9 +7,9 @@ use crate::types::{Deregistration, DeregistrationEvent, Registration, Registrati
 #[derive(Clone, Default)]
 pub struct CandidateState {
     // Candidate registrations by block enabling range lookups
-    registrations: BTreeMap<BlockNumber, Vec<UTxOIdentifier>>,
+    registrations: OrdMap<BlockNumber, Vec<UTxOIdentifier>>,
     // Candidate deregistrations by block enabling range lookups
-    deregistrations: BTreeMap<BlockNumber, Vec<DeregistrationEvent>>,
+    deregistrations: OrdMap<BlockNumber, Vec<DeregistrationEvent>>,
     // Registration index to avoid duplicating in deregistrations
     pub registration_index: HashMap<UTxOIdentifier, RegistrationEvent>,
 }

--- a/modules/midnight_state/src/indexes/cnight_utxo_state.rs
+++ b/modules/midnight_state/src/indexes/cnight_utxo_state.rs
@@ -1,16 +1,16 @@
 use anyhow::{anyhow, Result};
-use std::collections::{BTreeMap, HashMap};
 
 use acropolis_common::{BlockNumber, UTxOIdentifier};
+use imbl::{HashMap, OrdMap};
 
 use crate::types::{AssetCreate, AssetSpend, CNightCreation, CNightSpend, UTxOMeta};
 
 #[derive(Clone, Default)]
 pub struct CNightUTxOState {
     // Created UTxOs receiving CNight indexed by block
-    created_utxos: BTreeMap<BlockNumber, Vec<UTxOIdentifier>>,
+    created_utxos: OrdMap<BlockNumber, Vec<UTxOIdentifier>>,
     // Spent UTxOs sending CNight indexed by block
-    spent_utxos: BTreeMap<BlockNumber, Vec<UTxOIdentifier>>,
+    spent_utxos: OrdMap<BlockNumber, Vec<UTxOIdentifier>>,
     // An index mapping UTxO identifiers to their corresponding metadata
     pub utxo_index: HashMap<UTxOIdentifier, UTxOMeta>,
 }

--- a/modules/midnight_state/src/indexes/governance_state.rs
+++ b/modules/midnight_state/src/indexes/governance_state.rs
@@ -1,13 +1,12 @@
-use std::collections::BTreeMap;
-
 use acropolis_common::{BlockNumber, Datum};
+use imbl::OrdMap;
 
 #[derive(Clone, Default)]
 pub struct GovernanceState {
     /// Technical Committee datum mapped to the block number it was created
-    pub technical_committee: BTreeMap<BlockNumber, Datum>,
+    pub technical_committee: OrdMap<BlockNumber, Datum>,
     /// Council datum mapped to the block number it was created
-    pub council: BTreeMap<BlockNumber, Datum>,
+    pub council: OrdMap<BlockNumber, Datum>,
 }
 
 impl GovernanceState {

--- a/modules/midnight_state/src/indexes/parameters_state.rs
+++ b/modules/midnight_state/src/indexes/parameters_state.rs
@@ -1,11 +1,10 @@
-use std::collections::BTreeMap;
-
 use acropolis_common::{Datum, Epoch};
+use imbl::OrdMap;
 
 #[derive(Clone, Default)]
 pub struct ParametersState {
     /// Ariadne parameters keyed by epoch
-    pub permissioned_candidates: BTreeMap<Epoch, Datum>,
+    pub permissioned_candidates: OrdMap<Epoch, Datum>,
 }
 
 impl ParametersState {
@@ -13,7 +12,7 @@ impl ParametersState {
     /// Insert the parameters for an epoch on change, overwriting existing entry if multiple
     /// updates in the same epoch
     pub fn add_parameter_datum(&mut self, epoch: Epoch, datum: Datum) -> bool {
-        if self.permissioned_candidates.last_key_value().map(|(_, v)| v) != Some(&datum) {
+        if self.permissioned_candidates.iter().next_back().map(|(_, v)| v) != Some(&datum) {
             self.permissioned_candidates.insert(epoch, datum);
             true
         } else {


### PR DESCRIPTION
## Description
This PR switches all indexes in `midnight_state` to use `imbl` structures.

## Related Issue(s)
Relates to #699

## How was this tested?
* Verified that sync progresses as expected
* Verified that RSS drops from ~40GB to ~12GB when running the `midnight_indexer` process to tip on preview. 

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
RAM usage is now reasonable for the `midnight_indexer` process

## Reviewer notes / Areas to focus
N/A
