### PR TITLE
fix: add subscription configs to ledger-validation.toml

### DIFF
--- a/processes/omnibus/configs/ledger-validation.toml
+++ b/processes/omnibus/configs/ledger-validation.toml
@@ -66,6 +66,8 @@ network-name = "mainnet"
 [module.utxo-state]
 address-delta-topic = "cardano.address.deltas"
 block-totals-topic = "cardano.block.txs"
+pool-registration-updates-subscribe-topic = "cardano.pool.registration.updates"
+stake-registration-updates-subscribe-topic = "cardano.stake.registration.updates"
 
 [module.spo-state]
 

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -77,6 +77,7 @@ publish-tx-validation-topic = "cardano.validation.tx"
 store = "memory" # "memory", "dashmap", "fjall", "fjall-async", "sled", "sled-async", "fake"
 address-delta-topic = "cardano.address.deltas"
 block-totals-topic = "cardano.block.txs"
+# Subscriptions needed for validation
 pool-registration-updates-subscribe-topic = "cardano.pool.registration.updates"
 stake-registration-updates-subscribe-topic = "cardano.stake.registration.updates"
 


### PR DESCRIPTION
## Description

This PR fixes `ledger-validation.toml` to have `utxo-state` subscriptions needed for validation

## Related Issue(s)
None

## How was this tested?
Manually run omnibus process

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
None

## Reviewer notes / Areas to focus
`ledger-validation.toml`
