### PR TITLE
feat: implement GetBlockByHash gRPC handler

### DIFF
--- a/common/src/queries/blocks.rs
+++ b/common/src/queries/blocks.rs
@@ -41,6 +41,9 @@ pub enum BlocksStateQuery {
     GetBlockBySlot {
         slot: u64,
     },
+    GetBlockByHash {
+        block_hash: BlockHash,
+    },
     GetBlockByEpochSlot {
         epoch: u64,
         slot: u64,
@@ -95,6 +98,7 @@ pub enum BlocksStateQueryResponse {
     NextBlocks(NextBlocks),
     PreviousBlocks(PreviousBlocks),
     BlockBySlot(BlockInfo),
+    BlockByHash(BlockInfo),
     BlockByEpochSlot(BlockInfo),
     BlockTransactions(BlockTransactions),
     BlockTransactionsCBOR(BlockTransactionsCBOR),

--- a/modules/chain_store/src/chain_store.rs
+++ b/modules/chain_store/src/chain_store.rs
@@ -261,6 +261,16 @@ impl ChainStore {
                 let info = Self::to_block_info(block, store, state, false)?;
                 Ok(BlocksStateQueryResponse::BlockBySlot(info))
             }
+            BlocksStateQuery::GetBlockByHash { block_hash } => {
+                let Some(block) = store.get_block_by_hash(block_hash.as_ref())? else {
+                    return Ok(BlocksStateQueryResponse::Error(QueryError::not_found(
+                        format!("{} not found", block_hash),
+                    )));
+                };
+
+                let info = Self::to_block_info(block, store, state, false)?;
+                Ok(BlocksStateQueryResponse::BlockByHash(info))
+            }
             BlocksStateQuery::GetBlockByEpochSlot { epoch, slot } => {
                 let Some(block) = store.get_block_by_epoch_slot(*epoch, *slot)? else {
                     return Ok(BlocksStateQueryResponse::Error(QueryError::not_found(

--- a/modules/midnight_state/proto/midnight_state.proto
+++ b/modules/midnight_state/proto/midnight_state.proto
@@ -14,6 +14,7 @@ service MidnightState {
   rpc GetTechnicalCommitteeDatum (TechnicalCommitteeDatumRequest) returns (TechnicalCommitteeDatumResponse);
   rpc GetCouncilDatum (CouncilDatumRequest) returns (CouncilDatumResponse);
   rpc GetAriadneParameters (AriadneParametersRequest) returns (AriadneParametersResponse);
+  rpc GetBlockByHash (BlockByHashRequest) returns (BlockByHashResponse);
 }
 
 message AssetCreatesRequest {
@@ -123,4 +124,12 @@ message AriadneParametersRequest {
 message AriadneParametersResponse {
   uint64 source_epoch = 1;
   bytes datum = 2;
+}
+
+message BlockByHashRequest {
+  bytes block_hash = 1;
+}
+message BlockByHashResponse {
+  uint64 block_number = 1;
+  int64 block_timestamp_unix = 3;
 }

--- a/modules/midnight_state/src/grpc/server.rs
+++ b/modules/midnight_state/src/grpc/server.rs
@@ -1,7 +1,9 @@
 use std::{net::SocketAddr, sync::Arc};
 
+use acropolis_common::messages::Message;
 use acropolis_common::state_history::StateHistory;
 use anyhow::Result;
+use caryatid_sdk::Context;
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
 use tonic::transport::Server;
@@ -11,12 +13,16 @@ use crate::grpc::midnight_state_proto::FILE_DESCRIPTOR_SET;
 use crate::grpc::service::MidnightStateService;
 use crate::state::State;
 
-pub async fn run(history: Arc<Mutex<StateHistory<State>>>, addr: SocketAddr) -> Result<()> {
+pub async fn run(
+    history: Arc<Mutex<StateHistory<State>>>,
+    context: Arc<Context<Message>>,
+    addr: SocketAddr,
+) -> Result<()> {
     tracing::info!("Starting gRPC server on {}", addr);
     let listener = TcpListener::bind(addr).await?;
     tracing::info!("gRPC server listening on {}", addr);
 
-    let service = MidnightStateService::new(history);
+    let service = MidnightStateService::new(history, context);
     let reflection = tonic_reflection::server::Builder::configure()
         .register_encoded_file_descriptor_set(FILE_DESCRIPTOR_SET)
         .build_v1()?;

--- a/modules/midnight_state/src/grpc/service.rs
+++ b/modules/midnight_state/src/grpc/service.rs
@@ -4,23 +4,35 @@ use crate::{
     grpc::midnight_state_proto::{
         self, midnight_state_server::MidnightState, AriadneParametersRequest,
         AriadneParametersResponse, AssetCreatesRequest, AssetCreatesResponse, AssetSpendsRequest,
-        AssetSpendsResponse, CouncilDatumRequest, CouncilDatumResponse, DeregistrationsRequest,
-        DeregistrationsResponse, RegistrationsRequest, RegistrationsResponse,
-        TechnicalCommitteeDatumRequest, TechnicalCommitteeDatumResponse,
+        AssetSpendsResponse, BlockByHashRequest, BlockByHashResponse, CouncilDatumRequest,
+        CouncilDatumResponse, DeregistrationsRequest, DeregistrationsResponse,
+        RegistrationsRequest, RegistrationsResponse, TechnicalCommitteeDatumRequest,
+        TechnicalCommitteeDatumResponse,
     },
     state::State,
 };
-use acropolis_common::state_history::StateHistory;
+use acropolis_common::{
+    messages::{Message, StateQuery, StateQueryResponse},
+    queries::{
+        blocks::{BlocksStateQuery, BlocksStateQueryResponse},
+        errors::QueryError,
+        utils::query_state,
+    },
+    state_history::StateHistory,
+    BlockHash,
+};
+use caryatid_sdk::Context;
 use tokio::sync::Mutex;
 use tonic::{Request, Response, Status};
 
 pub struct MidnightStateService {
     history: Arc<Mutex<StateHistory<State>>>,
+    context: Arc<Context<Message>>,
 }
 
 impl MidnightStateService {
-    pub fn new(history: Arc<Mutex<StateHistory<State>>>) -> Self {
-        Self { history }
+    pub fn new(history: Arc<Mutex<StateHistory<State>>>, context: Arc<Context<Message>>) -> Self {
+        Self { history, context }
     }
 }
 
@@ -304,11 +316,50 @@ impl MidnightState for MidnightStateService {
             datum,
         }))
     }
+
+    async fn get_block_by_hash(
+        &self,
+        request: Request<BlockByHashRequest>,
+    ) -> Result<Response<BlockByHashResponse>, Status> {
+        let req = request.into_inner();
+        let block_hash = BlockHash::try_from(req.block_hash)
+            .map_err(|_| Status::invalid_argument("invalid block hash"))?;
+
+        let msg = Arc::new(Message::StateQuery(StateQuery::Blocks(
+            BlocksStateQuery::GetBlockByHash { block_hash },
+        )));
+
+        let block_info =
+            query_state(
+                &self.context,
+                "cardano.query.blocks",
+                msg,
+                |message| match message {
+                    Message::StateQueryResponse(StateQueryResponse::Blocks(
+                        BlocksStateQueryResponse::BlockByHash(block_info),
+                    )) => Ok(block_info),
+                    Message::StateQueryResponse(StateQueryResponse::Blocks(
+                        BlocksStateQueryResponse::Error(e),
+                    )) => Err(e),
+                    _ => Err(QueryError::internal_error(
+                        "Unexpected message type while retrieving block info",
+                    )),
+                },
+            )
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(BlockByHashResponse {
+            block_number: block_info.number,
+            block_timestamp_unix: i64::try_from(block_info.timestamp)
+                .map_err(|_| Status::internal("timestamp overflow"))?,
+        }))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, sync::Arc};
+    use std::{collections::HashMap, sync::Arc, time::Duration};
 
     use acropolis_common::{
         messages::AddressDeltasMessage,
@@ -317,6 +368,8 @@ mod tests {
         Datum, DatumHash, Era, ExtendedAddressDelta, PolicyId, TxHash, TxIdentifier,
         UTxOIdentifier, ValueMap,
     };
+    use caryatid_sdk::{async_trait, Context, MessageBounds, MessageBus, Subscription};
+    use config::Config;
     use tokio::sync::Mutex;
     use tonic::{Code, Request};
 
@@ -327,6 +380,26 @@ mod tests {
 
     use super::{MidnightState, MidnightStateService};
 
+    pub struct DummyBus;
+
+    #[async_trait]
+    impl<M: MessageBounds> MessageBus<M> for DummyBus {
+        async fn publish(&self, _topic: &str, _message: Arc<M>) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        fn request_timeout(&self) -> Duration {
+            Duration::from_secs(1)
+        }
+
+        async fn subscribe(&self, _topic: &str) -> anyhow::Result<Box<dyn Subscription<M>>> {
+            Err(anyhow::anyhow!("subscriptions not supported in tests"))
+        }
+
+        async fn shutdown(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+    }
     fn test_block_info(number: u64, epoch: u64) -> BlockInfo {
         BlockInfo {
             status: BlockStatus::Volatile,
@@ -381,7 +454,16 @@ mod tests {
     fn service_with_committed_state(state: State, block_number: u64) -> MidnightStateService {
         let mut history = StateHistory::new("midnight-state", StateHistoryStore::Unbounded);
         history.commit(block_number, state);
-        MidnightStateService::new(Arc::new(Mutex::new(history)))
+
+        let (_, startup_watch) = tokio::sync::watch::channel(true);
+        MidnightStateService::new(
+            Arc::new(Mutex::new(history)),
+            Arc::new(Context::new(
+                Arc::new(Config::default()),
+                Arc::new(DummyBus),
+                startup_watch,
+            )),
+        )
     }
 
     #[tokio::test]

--- a/modules/midnight_state/src/midnight_state.rs
+++ b/modules/midnight_state/src/midnight_state.rs
@@ -96,7 +96,7 @@ impl MidnightState {
             StateHistoryStore::Unbounded,
         )));
         let grpc_history = history.clone();
-
+        let grpc_context = context.clone();
         // Start the main run loop
         context.run(async move {
             Self::run(history, cfg, address_deltas_reader)
@@ -106,7 +106,7 @@ impl MidnightState {
 
         // Start the gRPC server
         context.run(async move {
-            crate::grpc::server::run(grpc_history, addr)
+            crate::grpc::server::run(grpc_history, grpc_context, addr)
                 .await
                 .unwrap_or_else(|e| error!("gRPC server failed: {e}"));
         });


### PR DESCRIPTION
## Description
Adds the gRPC handler for retrieving the block number and timestamp from block hash.

## Related Issue(s)
Relates to #734

## How was this tested?
* Verified that the gRPC handler returns the correct block number and timestamp for a given block hash. 

## Checklist

- [x] My code builds and passes local tests
- [x] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
Adds a new gRPC request/response needed for integration with `midnight_node`

## Reviewer notes / Areas to focus
gRPC handler in `modules/midnight_state/src/grpc/service.rs`
