### PR TITLE
feat: add latest block info gRPC handler

### DIFF
--- a/modules/midnight_state/proto/midnight_state.proto
+++ b/modules/midnight_state/proto/midnight_state.proto
@@ -20,6 +20,7 @@ service MidnightState {
   rpc GetEpochCandidates (EpochCandidatesRequest) returns (EpochCandidatesResponse);
   rpc GetStableBlock (StableBlockRequest) returns (StableBlockResponse);
   rpc GetLatestStableBlock (LatestStableBlockRequest) returns (LatestStableBlockResponse);
+  rpc GetLatestBlock (LatestBlockRequest) returns (LatestBlockResponse);
 }
 
 message AssetCreatesRequest {
@@ -212,6 +213,12 @@ message LatestStableBlockRequest {
 message LatestStableBlockResponse {
   optional Block block = 1;
 }
+
+message LatestBlockRequest {}
+message LatestBlockResponse {
+  Block block = 1;
+}
+
 
 message StableBlockRequest {
   bytes block_hash = 1;

--- a/modules/midnight_state/src/grpc/service.rs
+++ b/modules/midnight_state/src/grpc/service.rs
@@ -8,9 +8,9 @@ use crate::{
             AssetSpendsRequest, AssetSpendsResponse, Block, BlockByHashRequest,
             BlockByHashResponse, CouncilDatumRequest, CouncilDatumResponse, DeregistrationsRequest,
             DeregistrationsResponse, EpochCandidatesRequest, EpochCandidatesResponse,
-            EpochNonceRequest, EpochNonceResponse, LatestStableBlockRequest,
-            LatestStableBlockResponse, RegistrationsRequest, RegistrationsResponse,
-            StableBlockRequest, StableBlockResponse, StakePoolEntry,
+            EpochNonceRequest, EpochNonceResponse, LatestBlockRequest, LatestBlockResponse,
+            LatestStableBlockRequest, LatestStableBlockResponse, RegistrationsRequest,
+            RegistrationsResponse, StableBlockRequest, StableBlockResponse, StakePoolEntry,
             TechnicalCommitteeDatumRequest, TechnicalCommitteeDatumResponse, UtxoEvent,
             UtxoEventsRequest, UtxoEventsResponse,
         },
@@ -570,6 +570,54 @@ impl MidnightState for MidnightStateService {
 
         Ok(Response::new(LatestStableBlockResponse {
             block: block_proto,
+        }))
+    }
+
+    async fn get_latest_block(
+        &self,
+        _request: Request<LatestBlockRequest>,
+    ) -> Result<Response<LatestBlockResponse>, Status> {
+        self.stats.latest_block.fetch_add(1, Ordering::Relaxed);
+
+        let msg = Arc::new(Message::StateQuery(StateQuery::Blocks(
+            BlocksStateQuery::GetBlockByTipOffset { offset: 0 },
+        )));
+
+        let block_info =
+            query_state(
+                &self.context,
+                "cardano.query.blocks",
+                msg,
+                |message| match message {
+                    Message::StateQueryResponse(StateQueryResponse::Blocks(
+                        BlocksStateQueryResponse::BlockByTipOffset(Some(block_info)),
+                    )) => Ok(block_info),
+                    Message::StateQueryResponse(StateQueryResponse::Blocks(
+                        BlocksStateQueryResponse::BlockByTipOffset(None),
+                    )) => Err(QueryError::not_found("No blocks available")),
+                    Message::StateQueryResponse(StateQueryResponse::Blocks(
+                        BlocksStateQueryResponse::Error(e),
+                    )) => Err(e),
+                    _ => Err(QueryError::internal_error(
+                        "Unexpected message type while retrieving block info",
+                    )),
+                },
+            )
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let block_proto = Block {
+            block_number: u32::try_from(block_info.number)
+                .map_err(|_| Status::internal("block number overflow"))?,
+            block_hash: block_info.hash.to_vec(),
+            epoch_number: u32::try_from(block_info.epoch)
+                .map_err(|_| Status::internal("epoch overflow"))?,
+            slot_number: block_info.slot,
+            block_timestamp_unix: block_info.timestamp,
+        };
+
+        Ok(Response::new(LatestBlockResponse {
+            block: Some(block_proto),
         }))
     }
 }

--- a/modules/midnight_state/src/grpc/stats.rs
+++ b/modules/midnight_state/src/grpc/stats.rs
@@ -14,6 +14,7 @@ pub struct RequestStats {
     pub epoch_candidates: AtomicU64,
     pub latest_stable_block: AtomicU64,
     pub stable_block_by_hash: AtomicU64,
+    pub latest_block: AtomicU64,
 }
 
 #[derive(Debug)]
@@ -27,6 +28,7 @@ pub struct RequestStatsSnapshot {
     pub epoch_candidates: u64,
     pub latest_stable_block: u64,
     pub stable_block_by_hash: u64,
+    pub latest_block: u64,
 }
 
 impl fmt::Display for RequestStatsSnapshot {
@@ -35,7 +37,7 @@ impl fmt::Display for RequestStatsSnapshot {
             f,
             "utxo_events={} council_datum={} technical_committee_datum={} \
              ariadne_parameters={} block_by_hash={} epoch_nonce={} epoch_candidates={} \
-             latest_stable_block={} stable_block_by_hash={}",
+             latest_stable_block={} stable_block_by_hash={} latest_block={}",
             self.utxo_events,
             self.council_datum,
             self.technical_committee_datum,
@@ -44,7 +46,8 @@ impl fmt::Display for RequestStatsSnapshot {
             self.epoch_nonce,
             self.epoch_candidates,
             self.latest_stable_block,
-            self.stable_block_by_hash
+            self.stable_block_by_hash,
+            self.latest_block,
         )
     }
 }
@@ -61,6 +64,7 @@ impl RequestStats {
             epoch_candidates: self.epoch_candidates.load(Ordering::Relaxed),
             latest_stable_block: self.latest_stable_block.load(Ordering::Relaxed),
             stable_block_by_hash: self.stable_block_by_hash.load(Ordering::Relaxed),
+            latest_block: self.latest_block.load(Ordering::Relaxed),
         }
     }
 }


### PR DESCRIPTION
## Description
This PR adds a new gRPC handler `get_latest_block` to retrieve information about the tip block. 

## Related Issue(s)
Relates to #734 

## How was this tested?
* Verified that making a request returned the current tip block info. 

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
Adds a new query which is needed to implement the `SidechainRpcDataSource` in `midnight-node`

## Reviewer notes / Areas to focus
N/A
