### PR TITLE
feat: add guardnet midnight_indexer config and make target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,8 @@ COPY --from=builder-midnight-indexer /app/processes/midnight_indexer/config.main
 COPY --from=builder-midnight-indexer /app/processes/midnight_indexer/config.mainnet.docker.toml /app/processes/midnight_indexer/config.mainnet.docker.toml
 COPY --from=builder-midnight-indexer /app/processes/midnight_indexer/config.preview.toml /app/processes/midnight_indexer/config.preview.toml
 COPY --from=builder-midnight-indexer /app/processes/midnight_indexer/config.preview.docker.toml /app/processes/midnight_indexer/config.preview.docker.toml
+COPY --from=builder-midnight-indexer /app/processes/midnight_indexer/config.guardnet.toml /app/processes/midnight_indexer/config.guardnet.toml
+COPY --from=builder-midnight-indexer /app/processes/midnight_indexer/config.guardnet.docker.toml /app/processes/midnight_indexer/config.guardnet.docker.toml
 COPY --from=builder-midnight-indexer /app/modules/accounts_state/test-data/pots.mainnet.csv /app/modules/accounts_state/test-data/pots.mainnet.csv
 COPY --from=builder-midnight-indexer /app/modules/accounts_state/test-data/pots.preview.csv /app/modules/accounts_state/test-data/pots.preview.csv
 
@@ -113,4 +115,4 @@ RUN mkdir -p /app/modules/mithril_snapshot_fetcher/downloads \
 USER acropolis:acropolis
 
 ENTRYPOINT ["acropolis_process_midnight_indexer"]
-CMD ["--config", "config.preview.toml"]
+CMD ["--config", "config.guardnet.toml"]

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ help:
 	@echo "  run-bootstrap-preview    Run the omnibus (preview) with bootstrap config"
 	@echo "  run-midnight-mainnet     Run the midnight indexer (mainnet)"
 	@echo "  run-midnight-preview     Run the midnight indexer (preview)"
+	@echo "  run-midnight-guardnet    Run the midnight indexer (guardnet)"
 	@echo "  test                     Run all tests"
 	@echo "  fmt                      Run cargo fmt"
 	@echo "  clippy                   Run cargo clippy -D warnings"
@@ -77,6 +78,9 @@ run-midnight-mainnet:
 
 run-midnight-preview:
 	cd processes/midnight_indexer && $(CARGO) run --release --bin acropolis_process_midnight_indexer -- --config config.preview.toml
+
+run-midnight-guardnet:
+	cd processes/midnight_indexer && $(CARGO) run --release --bin acropolis_process_midnight_indexer -- --config config.guardnet.toml
 	
 fmt:
 	$(CARGO) fmt --all

--- a/processes/midnight_indexer/config.guardnet.docker.toml
+++ b/processes/midnight_indexer/config.guardnet.docker.toml
@@ -1,0 +1,5 @@
+# Docker-specific overrides for the Midnight indexer (guardnet).
+# Keep persistent mounts intact across restarts.
+
+[module.chain-store]
+clear-on-start = false

--- a/processes/midnight_indexer/config.guardnet.toml
+++ b/processes/midnight_indexer/config.guardnet.toml
@@ -1,0 +1,131 @@
+# Top-level configuration for Acropolis Midnight process
+
+# ============================================================================
+# Startup Configuration
+# ============================================================================
+[global.startup]
+network-name = "preview"
+startup-mode = "genesis"   # Options: "genesis" | "snapshot"
+sync-mode = "mithril"      # Options: "mithril" | "upstream"
+topic = "cardano.sequence.start"
+
+# ============================================================================
+# Bootstrap Module Configurations
+# ============================================================================
+[module.genesis-bootstrapper]
+
+[module.mithril-snapshot-fetcher]
+aggregator-url = "https://aggregator.pre-release-preview.api.mithril.network/aggregator"
+genesis-key = "5b3132372c37332c3132342c3136312c362c3133372c3133312c3231332c3230372c3131372c3139382c38352c3137362c3139392c3136322c3234312c36382c3132332c3131392c3134352c31332c3233322c3234332c34392c3232392c322c3234392c3230352c3230352c33392c3233352c34345d"
+# Download max age in hours. E.g. 8 means 8 hours (if there isn't any snapshot within this time range download from Mithril)
+download-max-age = "never"
+# Pause constraint E.g. "epoch:100", "block:1200"
+pause = "none"
+# Stop constraint likewise
+stop = "none"
+
+[module.snapshot-bootstrapper]
+epoch = 507
+data-dir = "../../modules/snapshot_bootstrapper/data"
+
+# ============================================================================
+# Core Module Configurations
+# ============================================================================
+[module.peer-network-interface]
+sync-point = "dynamic"
+node-addresses = [
+    "preview-node.play.dev.cardano.org:3001",
+]
+
+[module.midnight-state]
+address-deltas-topic = "cardano.address.deltas"
+
+# The below configuration is for `guardnet`: https://github.com/midnightntwrk/midnight-node/tree/main/res/guardnet
+# Config for CNight asset
+cnight-policy-id = "03cf16101d110dcad9cacb225f0d1e63a8809979e7feb60426995414"
+cnight-asset-name = ""
+
+# Config for Midnight candidates
+mapping-validator-address = "addr_test1wpztklvv6scgyzne56ky0va0x5dmje56lf39eshxdha68rclu8fje"
+auth-token-asset-name = ""
+
+# Config for Midnight governance
+technical-committee-address = "addr_test1wpj3t7yvs489kjgzlayd37ft6wg9eu6vguem8jgdgu2kengayhe62"
+technical-committee-policy-id = "6515f88c854e5b4902ff48d8f92bd3905cf34c4733b3c90d47156ccd"
+council-address = "addr_test1wz28tz6e9zdpvr6f7qsxmyyw5zq0520h334087984ttskpcnczun7"
+council-policy-id = "94758b59289a160f49f0206d908ea080fa29f78c6af3f8a7aad70b07"
+
+# Config for Midnight Ariadne parameters
+permissioned-candidate-policy = "8ae135f279da14076cf1df73fb38df707fbe2143ccfe05057ca4c030"
+
+# Config for Midnight gRPC server
+grpc-bind-address = "0.0.0.0:50051"
+
+[module.block-unpacker]
+
+[module.tx-unpacker]
+# Subscriptions needed for validation
+bootstrapped-subscribe-topic = "cardano.sequence.bootstrapped"
+protocol-parameters-subscribe-topic = "cardano.protocol.parameters"
+phase2-enabled = false
+
+publish-utxo-deltas-topic = "cardano.utxo.deltas"
+publish-withdrawals-topic = "cardano.withdrawals"
+publish-certificates-topic = "cardano.certificates"
+publish-governance-topic = "cardano.governance"
+publish-tx-validation-topic = "cardano.validation.tx"
+
+[module.utxo-state]
+address-delta-topic = "cardano.address.deltas"
+block-totals-topic = "cardano.block.txs"
+address-delta-publish-mode = "extended"
+pool-registration-updates-subscribe-topic = "cardano.pool.registration.updates"
+stake-registration-updates-subscribe-topic = "cardano.stake.registration.updates"
+
+[module.spo-state]
+
+[module.spdd-state]
+store-spdd = true
+
+[module.drep-state]
+
+[module.governance-state]
+
+[module.parameters-state]
+
+[module.stake-delta-filter]
+
+[module.epochs-state]
+
+[module.accounts-state]
+
+[module.consensus]
+
+#[module.block-vrf-validator]
+
+#[module.block-kes-validator]
+
+[module.chain-store]
+
+[module.clock]
+
+# Enable for message spying
+#[module.spy]
+#topic = "cardano.#"
+
+# ============================================================================
+# Message Bus Configuration
+# ============================================================================
+# Enable if external routing required
+#[message-bus.external]
+#class = "rabbit-mq"
+#url = "amqp://127.0.0.1:5672/%2f"
+#exchange = "caryatid"
+
+[message-bus.internal]
+class = "in-memory"
+
+# Message routing
+[[message-router.route]]  # Everything is internal only
+pattern = "#"
+bus = "internal"


### PR DESCRIPTION
## Description

This PR adds a make target to run the `midnight_indexer` process on the `guardnet` network. 

## Related Issue(s)
Relates to #767 

## How was this tested?
* Verified that updated `midnight_state` toml fields match the `chain-spec.json` defined in `midnight-node`. 

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
Adds a new make target for midnight's `guardnet` network. 

## Reviewer notes / Areas to focus
N/A
