### PR TITLE
fix: only log request stats if changed

### DIFF
--- a/modules/midnight_state/src/grpc/server.rs
+++ b/modules/midnight_state/src/grpc/server.rs
@@ -30,8 +30,9 @@ pub async fn run(
     tokio::spawn(async move {
         loop {
             sleep(Duration::from_secs(60)).await;
-            let stats = stats_service.stats();
-            tracing::info!("gRPC request stats: {}", stats);
+            if let Some(stats) = stats_service.stats() {
+                tracing::info!("gRPC request stats: {}", stats);
+            }
         }
     });
 

--- a/modules/midnight_state/src/grpc/service.rs
+++ b/modules/midnight_state/src/grpc/service.rs
@@ -52,7 +52,7 @@ impl MidnightStateService {
         }
     }
 
-    pub fn stats(&self) -> RequestStatsSnapshot {
+    pub fn stats(&self) -> Option<RequestStatsSnapshot> {
         self.stats.snapshot()
     }
 }

--- a/modules/midnight_state/src/grpc/stats.rs
+++ b/modules/midnight_state/src/grpc/stats.rs
@@ -1,6 +1,9 @@
 use std::{
     fmt,
-    sync::atomic::{AtomicU64, Ordering},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Mutex,
+    },
 };
 
 #[derive(Default)]
@@ -15,9 +18,11 @@ pub struct RequestStats {
     pub latest_stable_block: AtomicU64,
     pub stable_block_by_hash: AtomicU64,
     pub latest_block: AtomicU64,
+
+    last_snapshot: Mutex<Option<RequestStatsSnapshot>>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct RequestStatsSnapshot {
     pub utxo_events: u64,
     pub council_datum: u64,
@@ -53,8 +58,8 @@ impl fmt::Display for RequestStatsSnapshot {
 }
 
 impl RequestStats {
-    pub fn snapshot(&self) -> RequestStatsSnapshot {
-        RequestStatsSnapshot {
+    pub fn snapshot(&self) -> Option<RequestStatsSnapshot> {
+        let current = RequestStatsSnapshot {
             utxo_events: self.utxo_events.load(Ordering::Relaxed),
             council_datum: self.council_datum.load(Ordering::Relaxed),
             technical_committee_datum: self.technical_committee_datum.load(Ordering::Relaxed),
@@ -65,6 +70,18 @@ impl RequestStats {
             latest_stable_block: self.latest_stable_block.load(Ordering::Relaxed),
             stable_block_by_hash: self.stable_block_by_hash.load(Ordering::Relaxed),
             latest_block: self.latest_block.load(Ordering::Relaxed),
+        };
+
+        let mut last = match self.last_snapshot.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+
+        if last.as_ref() == Some(&current) {
+            return None;
         }
+
+        *last = Some(current.clone());
+        Some(current)
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the request statistics spam by only logging when the stats have changed. This will make the logs clearer and help debug the out of sync messages issue. 

## Related Issue(s)
Relates to #734

## How was this tested?
* Verified that logging is skipped when no new requests were made within the 60 second interval. 
* Verified that logging is performed when a new request is made within the 60 second interval. 

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
Reduces log spam

## Reviewer notes / Areas to focus
N/A