### PR TITLE
[fix] simplify cNIGHT grpc utxo events request

### DIFF
--- a/modules/midnight_state/proto/midnight_state.proto
+++ b/modules/midnight_state/proto/midnight_state.proto
@@ -173,11 +173,9 @@ message EpochCandidatesResponse {
 }
 
 message UtxoEventsRequest {
-  uint32 start_block = 1;
-  uint32 start_tx_index = 2;
-  uint32 tx_capacity = 3;
-  bytes end_block_hash = 4;
-  CardanoPosition start_position = 5;
+  uint32 tx_capacity = 1;
+  bytes end_block_hash = 2;
+  CardanoPosition start_position = 3;
 }
 message UtxoEvent {
   oneof kind {

--- a/modules/midnight_state/src/grpc/service.rs
+++ b/modules/midnight_state/src/grpc/service.rs
@@ -1436,8 +1436,6 @@ mod tests {
         let service = service_with_committed_state(state, block.number);
         let response = service
             .get_utxo_events(Request::new(UtxoEventsRequest {
-                start_block: 0,
-                start_tx_index: 0,
                 tx_capacity: 10,
                 end_block_hash: [9u8; 32].to_vec(),
                 start_position: Some(CardanoPosition {
@@ -1515,8 +1513,6 @@ mod tests {
         let service = service_with_committed_state(state, block.number);
         let response = service
             .get_utxo_events(Request::new(UtxoEventsRequest {
-                start_block: 0,
-                start_tx_index: 0,
                 tx_capacity: 1,
                 end_block_hash: [9u8; 32].to_vec(),
                 start_position: Some(start_position.clone()),


### PR DESCRIPTION
## Summary
This is a small follow-up to the merged cNIGHT gRPC endpoint work. It removes the dead scalar start fields from `GetUtxoEvents` and renumbers the remaining request fields to keep the API clean before release.

## Context
`[fix] make cNIGHT grpc utxo queries deterministic (#796)` already moved the Acropolis cNIGHT endpoint to use `start_position` as the authoritative continuation input. After that change, `start_block` and `start_tx_index` were no longer used by the server, but they were still present in the request message.

## Changes
This PR:
- removes `start_block` and `start_tx_index` from `UtxoEventsRequest`
- renumbers the live fields so the request becomes:
  - `tx_capacity = 1`
  - `end_block_hash = 2`
  - `start_position = 3`
- updates the Acropolis service tests to construct the new request shape

## Why this is separate
This is intentionally a small cleanup-only follow-up on top of the already merged endpoint behavior. It does not change the server logic, only the in-development wire contract for `GetUtxoEvents`.

## Validation
- `cargo test -p acropolis_module_midnight_state`
- `cargo clippy -p acropolis_module_midnight_state -- -D warnings`
