### PR TITLE
refactor: fix rollback alignment for asset and address states

### DIFF
--- a/modules/address_state/src/address_state.rs
+++ b/modules/address_state/src/address_state.rs
@@ -26,7 +26,7 @@ use anyhow::{bail, Result};
 use caryatid_sdk::{module, Context, Subscription};
 use config::Config;
 use tokio::sync::{mpsc, Mutex};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 mod immutable_address_store;
 mod state;
 mod volatile_addresses;
@@ -70,12 +70,13 @@ impl AddressState {
     ) -> Result<()> {
         if !is_snapshot_mode {
             match params_reader.read_with_rollbacks().await? {
-                RollbackWrapper::Normal(_) => {}
+                RollbackWrapper::Normal(_) => {
+                    debug!("Consumed initial genesis params from params_subscription");
+                }
                 RollbackWrapper::Rollback(_) => {
                     bail!("Unexpected rollback while reading initial params");
                 }
             };
-            info!("Consumed initial genesis params from params_subscription");
         }
 
         // Background task to persist epochs sequentialy
@@ -108,7 +109,7 @@ impl AddressState {
                 RollbackWrapper::Rollback(_) => None,
             };
 
-            // Read params message on epoch bounday to update rollback window
+            // Read params message on epoch bounday or rollback to update rollback window
             // length if needed and set epoch start block for volatile pruning
             if deltas_msg.as_ref().map(|(b, _)| b.new_epoch && b.epoch > 0).unwrap_or(true) {
                 match params_reader.read_with_rollbacks().await? {

--- a/modules/assets_state/src/assets_state.rs
+++ b/modules/assets_state/src/assets_state.rs
@@ -8,32 +8,51 @@ use crate::{
     state::{AssetsStorageConfig, State, StoreTransactions},
 };
 use acropolis_common::{
-    caryatid::SubscriptionExt,
-    messages::{CardanoMessage, Message, StateQuery, StateQueryResponse},
+    caryatid::RollbackWrapper,
+    declare_cardano_reader,
+    messages::{
+        AddressDeltasMessage, AssetDeltasMessage, CardanoMessage, Message, StateQuery,
+        StateQueryResponse, StateTransitionMessage, UTXODeltasMessage,
+    },
     queries::{
         assets::{AssetsStateQuery, AssetsStateQueryResponse, DEFAULT_ASSETS_QUERY_TOPIC},
         errors::QueryError,
     },
     state_history::{StateHistory, StateHistoryStore},
-    BlockInfo, BlockStatus,
+    BlockStatus,
 };
-use anyhow::Result;
+use anyhow::{bail, Result};
 use caryatid_sdk::{module, Context, Subscription};
 use config::Config;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, info_span, Instrument};
+use tracing::{debug, error, info, info_span, Instrument};
 mod address_state;
 pub mod asset_registry;
 mod state;
 
 // Subscription topics
-const DEFAULT_ASSET_DELTAS_SUBSCRIBE_TOPIC: (&str, &str) =
-    ("asset-deltas-subscribe-topic", "cardano.asset.deltas");
-const DEFAULT_UTXO_DELTAS_SUBSCRIBE_TOPIC: (&str, &str) =
-    ("utxo-deltas-subscribe-topic", "cardano.utxo.deltas");
-const DEFAULT_ADDRESS_DELTAS_SUBSCRIBE_TOPIC: (&str, &str) =
-    ("address-deltas-subscribe-topic", "cardano.address.deltas");
+declare_cardano_reader!(
+    AssetDeltasReader,
+    "asset-deltas-subscribe-topic",
+    "cardano.asset.deltas",
+    AssetDeltas,
+    AssetDeltasMessage
+);
+declare_cardano_reader!(
+    UTxODeltasReader,
+    "utxo-deltas-subscribe-topic",
+    "cardano.utxo.deltas",
+    UTXODeltas,
+    UTXODeltasMessage
+);
+declare_cardano_reader!(
+    AddressDeltasReader,
+    "address-deltas-subscribe-topic",
+    "cardano.address.deltas",
+    AddressDeltas,
+    AddressDeltasMessage
+);
 
 // Configuration defaults
 const DEFAULT_STORE_ASSETS: (&str, bool) = ("store-assets", false);
@@ -55,19 +74,31 @@ impl AssetsState {
     async fn run(
         history: Arc<Mutex<StateHistory<State>>>,
         address_state: Option<Arc<Mutex<AddressState>>>,
-        mut asset_deltas_subscription: Box<dyn Subscription<Message>>,
-        mut utxo_deltas_subscription: Option<Box<dyn Subscription<Message>>>,
-        mut address_deltas_subscription: Option<Box<dyn Subscription<Message>>>,
+        mut asset_deltas_reader: AssetDeltasReader,
+        mut utxo_deltas_reader: Option<UTxODeltasReader>,
+        mut address_deltas_reader: Option<AddressDeltasReader>,
         storage_config: AssetsStorageConfig,
         registry: Arc<Mutex<AssetRegistry>>,
     ) -> Result<()> {
-        if let Some(sub) = utxo_deltas_subscription.as_mut() {
-            let _ = sub.read_ignoring_rollbacks().await?;
-            info!("Consumed initial message from utxo_deltas_subscription");
+        if let Some(reader) = utxo_deltas_reader.as_mut() {
+            match reader.read_with_rollbacks().await? {
+                RollbackWrapper::Normal(_) => {
+                    debug!("Consumed initial message from utxo_deltas_subscription");
+                }
+                RollbackWrapper::Rollback(_) => {
+                    bail!("Unexpected rollback while reading initial UTxO deltas");
+                }
+            }
         }
-        if let Some(sub) = address_deltas_subscription.as_mut() {
-            let _ = sub.read_ignoring_rollbacks().await?;
-            info!("Consumed initial message from address_deltas_subscription");
+        if let Some(reader) = address_deltas_reader.as_mut() {
+            match reader.read_with_rollbacks().await? {
+                RollbackWrapper::Normal(_) => {
+                    debug!("Consumed initial message from address_deltas_subscription");
+                }
+                RollbackWrapper::Rollback(_) => {
+                    bail!("Unexpected rollback while reading initial address deltas");
+                }
+            }
         }
         // Main loop of synchronised messages
         loop {
@@ -76,17 +107,13 @@ impl AssetsState {
                 let mut h = history.lock().await;
                 h.get_or_init_with(|| State::new(storage_config))
             };
-            let current_block: BlockInfo;
 
             // Asset deltas are the synchroniser
-            let (_, asset_msg) = asset_deltas_subscription.read_ignoring_rollbacks().await?;
-            match asset_msg.as_ref() {
-                Message::Cardano((ref block_info, CardanoMessage::AssetDeltas(deltas_msg))) => {
-                    // rollback only on asset deltas
+            let block_info = match asset_deltas_reader.read_with_rollbacks().await? {
+                RollbackWrapper::Normal((block_info, deltas_msg)) => {
                     if block_info.status == BlockStatus::RolledBack {
                         state = history.lock().await.get_rolled_back_state(block_info.number);
                     }
-                    current_block = block_info.clone();
 
                     // Always handle the mint deltas (This is how assets get initialized)
                     {
@@ -123,23 +150,15 @@ impl AssetsState {
                             }
                         };
                     }
+                    Some(block_info)
                 }
-                other => {
-                    error!("Unexpected message on asset-deltas subscription: {other:?}");
-                    continue;
-                }
-            }
+                RollbackWrapper::Rollback(_) => None,
+            };
 
             // Handle UTxO deltas if subscription is registered (store-info or store-transactions enabled)
-            if let Some(sub) = utxo_deltas_subscription.as_mut() {
-                let (_, utxo_msg) = sub.read_ignoring_rollbacks().await?;
-                match utxo_msg.as_ref() {
-                    Message::Cardano((
-                        ref block_info,
-                        CardanoMessage::UTXODeltas(utxo_deltas_msg),
-                    )) => {
-                        Self::check_sync(&current_block, block_info, "utxo");
-
+            if let Some(reader) = utxo_deltas_reader.as_mut() {
+                match reader.read_with_rollbacks().await? {
+                    RollbackWrapper::Normal((_, utxo_deltas_msg)) => {
                         if storage_config.store_info {
                             let reg = registry.lock().await;
                             state = match state.handle_cip68_metadata(&utxo_deltas_msg.deltas, &reg)
@@ -163,19 +182,13 @@ impl AssetsState {
                             };
                         }
                     }
-                    other => error!("Unexpected message on utxo-deltas subscription: {other:?}"),
+                    RollbackWrapper::Rollback(_) => {}
                 }
             }
 
-            if let Some(sub) = address_deltas_subscription.as_mut() {
-                let (_, address_msg) = sub.read_ignoring_rollbacks().await?;
-                match address_msg.as_ref() {
-                    Message::Cardano((
-                        ref block_info,
-                        CardanoMessage::AddressDeltas(address_deltas_msg),
-                    )) => {
-                        Self::check_sync(&current_block, block_info, "address");
-
+            if let Some(reader) = address_deltas_reader.as_mut() {
+                match reader.read_with_rollbacks().await? {
+                    RollbackWrapper::Normal((_, address_deltas_msg)) => {
                         let reg = registry.lock().await;
                         if let Some(ref address_state) = address_state {
                             let mut address_state = address_state.lock().await;
@@ -187,34 +200,15 @@ impl AssetsState {
                             };
                         };
                     }
-                    other => error!("Unexpected message on address-deltas subscription: {other:?}"),
+                    RollbackWrapper::Rollback(_) => {}
                 }
             }
 
             // Commit state
-            {
+            if let Some(block_info) = block_info {
                 let mut h = history.lock().await;
-                h.commit(current_block.number, state);
+                h.commit(block_info.number, state);
             }
-        }
-    }
-
-    /// Check for synchronisation
-    fn check_sync(expected: &BlockInfo, actual: &BlockInfo, source: &str) {
-        if expected.number != actual.number {
-            error!(
-                expected = expected.number,
-                actual = actual.number,
-                source = source,
-                "Messages out of sync (expected block {}, got {} from {})",
-                expected.number,
-                actual.number,
-                source,
-            );
-            panic!(
-                "Message streams diverged: {} at {} vs {} from {}",
-                source, expected.number, actual.number, source,
-            );
         }
     }
 
@@ -252,26 +246,9 @@ impl AssetsState {
             index_by_policy: get_bool_flag(&config, DEFAULT_INDEX_BY_POLICY),
         };
 
-        let asset_deltas_subscribe_topic =
-            get_string_flag(&config, DEFAULT_ASSET_DELTAS_SUBSCRIBE_TOPIC);
-        info!("Creating subscriber on '{asset_deltas_subscribe_topic}'");
-
-        let utxo_deltas_subscribe_topic: Option<String> =
-            if storage_config.store_info || storage_config.store_transactions.is_enabled() {
-                let topic = get_string_flag(&config, DEFAULT_UTXO_DELTAS_SUBSCRIBE_TOPIC);
-                info!("Creating subscriber on '{topic}'");
-                Some(topic)
-            } else {
-                None
-            };
-
-        let address_deltas_subscribe_topic: Option<String> = if storage_config.store_addresses {
-            let topic = get_string_flag(&config, DEFAULT_ADDRESS_DELTAS_SUBSCRIBE_TOPIC);
-            info!("Creating subscriber on '{topic}'");
-            Some(topic)
-        } else {
-            None
-        };
+        let utxo_deltas_enabled =
+            storage_config.store_info || storage_config.store_transactions.is_enabled();
+        let address_deltas_enabled = storage_config.store_addresses;
 
         let assets_query_topic = get_string_flag(&config, DEFAULT_ASSETS_QUERY_TOPIC);
         info!("Creating asset query handler on '{assets_query_topic}'");
@@ -523,14 +500,14 @@ impl AssetsState {
         });
 
         // Subscribe to enabled topics
-        let asset_deltas_sub = context.subscribe(&asset_deltas_subscribe_topic).await?;
-        let utxo_deltas_sub = if let Some(topic) = &utxo_deltas_subscribe_topic {
-            Some(context.subscribe(topic).await?)
+        let asset_deltas_reader = AssetDeltasReader::new(&context, &config).await?;
+        let utxo_deltas_reader = if utxo_deltas_enabled {
+            Some(UTxODeltasReader::new(&context, &config).await?)
         } else {
             None
         };
-        let address_deltas_sub = if let Some(topic) = &address_deltas_subscribe_topic {
-            Some(context.subscribe(topic).await?)
+        let address_deltas_reader = if address_deltas_enabled {
+            Some(AddressDeltasReader::new(&context, &config).await?)
         } else {
             None
         };
@@ -540,9 +517,9 @@ impl AssetsState {
             Self::run(
                 history_run,
                 address_state_run,
-                asset_deltas_sub,
-                utxo_deltas_sub,
-                address_deltas_sub,
+                asset_deltas_reader,
+                utxo_deltas_reader,
+                address_deltas_reader,
                 storage_config,
                 registry_run,
             )


### PR DESCRIPTION
## Description

This PR refactors `asset_state` and `address_state` to replace `read_ignoring_rollbacks` usage with `read_with_rollbacks`.

## Related Issue(s)
Relates to #811

## How was this tested?
* Verified that sync progresses as expected

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
`asset_state` and `address_state` will now stay aligned after a rollback event.

## Reviewer notes / Areas to focus
N/A
