### PR TITLE
Fix KES and VRF failing verification with post-shelly at epoch 0

### DIFF
--- a/modules/block_kes_validator/src/block_kes_validator.rs
+++ b/modules/block_kes_validator/src/block_kes_validator.rs
@@ -17,7 +17,7 @@ use caryatid_sdk::{module, Context, Subscription};
 use config::Config;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, info_span, Instrument};
+use tracing::{debug, error, info, info_span, Instrument};
 mod state;
 use state::State;
 mod ouroboros;
@@ -192,19 +192,28 @@ impl BlockKesValidator {
                     let span =
                         info_span!("block_kes_validator.validate", block = block_info.number);
                     async {
-                        let result_opt = ctx.handle(
-                            "validate",
-                            state
-                                .validate(&block_info, &block_msg.header, &genesis)
-                                .map_err(anyhow::Error::from),
-                        );
+                        if state.is_validation_ready(&block_info, &genesis) {
+                            let result_opt = ctx.handle(
+                                "validate",
+                                state
+                                    .validate(&block_info, &block_msg.header, &genesis)
+                                    .map_err(anyhow::Error::from),
+                            );
 
-                        if let Some((pool_id, updated_sequence_number)) = result_opt {
-                            // Update the operational certificate counter
-                            // When block is validated successfully
-                            // Reference
-                            // https://github.com/IntersectMBO/ouroboros-consensus/blob/e3c52b7c583bdb6708fac4fdaa8bf0b9588f5a88/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs#L508
-                            state.update_ocert_counter(pool_id, updated_sequence_number);
+                            if let Some((pool_id, updated_sequence_number)) = result_opt {
+                                // Update the operational certificate counter
+                                // When block is validated successfully
+                                // Reference
+                                // https://github.com/IntersectMBO/ouroboros-consensus/blob/e3c52b7c583bdb6708fac4fdaa8bf0b9588f5a88/ouroboros-consensus-protocol/src/ouroboros-consensus-protocol/Ouroboros/Consensus/Protocol/Praos.hs#L508
+                                state.update_ocert_counter(pool_id, updated_sequence_number);
+                            }
+                        } else {
+                            debug!(
+                                block = block_info.number,
+                                slot = block_info.slot,
+                                epoch = block_info.epoch,
+                                "Skipping KES validation until epoch context is available"
+                            );
                         }
                     }
                     .instrument(span)

--- a/modules/block_kes_validator/src/state.rs
+++ b/modules/block_kes_validator/src/state.rs
@@ -22,6 +22,10 @@ pub struct State {
     pub max_kes_evolutions: Option<u64>,
 
     pub active_spos: HashSet<PoolId>,
+
+    /// True once at least one SPO state message has been consumed.
+    /// KES validation depends on the active SPO set for the relevant epoch.
+    pub spo_state_ready: bool,
 }
 
 impl State {
@@ -31,6 +35,7 @@ impl State {
             slots_per_kes_period: None,
             max_kes_evolutions: None,
             active_spos: HashSet::new(),
+            spo_state_ready: false,
         }
     }
 
@@ -47,6 +52,24 @@ impl State {
 
     pub fn handle_spo_state(&mut self, msg: &SPOStateMessage) {
         self.active_spos = msg.spos.iter().map(|spo| spo.operator).collect();
+        self.spo_state_ready = true;
+    }
+
+    /// Returns true when we have enough state to perform KES validation for this block.
+    ///
+    /// Some networks can start directly in Shelley/Conway at epoch 0. In that case the
+    /// first validated blocks may arrive before any SPO state has been published, so KES
+    /// validation must wait until the first SPO state becomes available.
+    pub fn is_validation_ready(&self, block_info: &BlockInfo, genesis: &GenesisValues) -> bool {
+        // KES validation is not required in the pre-Shelley era
+        if block_info.epoch < genesis.shelley_epoch {
+            return true;
+        }
+
+        // KES validation is required, so readiness matters
+        self.slots_per_kes_period.is_some()
+            && self.max_kes_evolutions.is_some()
+            && self.spo_state_ready
     }
 
     pub fn update_ocert_counter(&mut self, pool_id: PoolId, declared_sequence_number: u64) {

--- a/modules/block_vrf_validator/src/block_vrf_validator.rs
+++ b/modules/block_vrf_validator/src/block_vrf_validator.rs
@@ -18,7 +18,7 @@ use caryatid_sdk::{module, Context, Subscription};
 use config::Config;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, info_span, Instrument};
+use tracing::{debug, error, info, info_span, Instrument};
 mod state;
 use state::State;
 mod ouroboros;
@@ -250,12 +250,21 @@ impl BlockVrfValidator {
                     let span =
                         info_span!("block_vrf_validator.validate", block = block_info.number);
                     async {
-                        ctx.handle(
-                            "validate",
-                            state
-                                .validate(&block_info, &block_msg.header, &genesis)
-                                .map_err(anyhow::Error::from),
-                        );
+                        if state.is_validation_ready(&block_info, &genesis) {
+                            ctx.handle(
+                                "validate",
+                                state
+                                    .validate(&block_info, &block_msg.header, &genesis)
+                                    .map_err(anyhow::Error::from),
+                            );
+                        } else {
+                            debug!(
+                                block = block_info.number,
+                                slot = block_info.slot,
+                                epoch = block_info.epoch,
+                                "Skipping VRF validation until epoch context is available"
+                            );
+                        }
                     }
                     .instrument(span)
                     .await;

--- a/modules/block_vrf_validator/src/state.rs
+++ b/modules/block_vrf_validator/src/state.rs
@@ -43,6 +43,10 @@ pub struct State {
 
     /// epoch snapshots
     pub epoch_snapshots: EpochSnapshots,
+
+    /// True once we have consumed at least one SPO/SPDD snapshot pair.
+    /// VRF validation for Praos/TPraos depends on this previous-epoch snapshot state.
+    pub epoch_snapshot_ready: bool,
 }
 
 impl State {
@@ -52,6 +56,7 @@ impl State {
             decentralisation_param: None,
             epoch_nonce: None,
             epoch_snapshots: EpochSnapshots::default(),
+            epoch_snapshot_ready: false,
         }
     }
 
@@ -80,6 +85,25 @@ impl State {
     ) {
         let new_snapshot = Snapshot::from((spo_state_msg, spdd_msg));
         self.epoch_snapshots.push(new_snapshot);
+        self.epoch_snapshot_ready = true;
+    }
+
+    /// Returns true when we have enough state to perform VRF validation for this block.
+    ///
+    /// Some networks can start directly in Shelley/Conway at epoch 0. In that case the
+    /// first validated blocks may arrive before any epoch snapshot has been published, so
+    /// VRF validation must wait until the first SPO/SPDD snapshot pair becomes available.
+    pub fn is_validation_ready(&self, block_info: &BlockInfo, genesis: &GenesisValues) -> bool {
+        // VRF validation is not required in the pre-Shelley era
+        if block_info.epoch < genesis.shelley_epoch {
+            return true;
+        }
+
+        // VRF validation is required, so readiness matters
+        self.decentralisation_param.is_some()
+            && self.active_slots_coeff.is_some()
+            && self.epoch_nonce.is_some()
+            && self.epoch_snapshot_ready
     }
 
     pub fn validate(


### PR DESCRIPTION
## Description

Currently VRF and KES validators are assuming epoch 0 is pre-shelly. This works well with booting from genesis in mainnet or preview networks, but fails when booting from local testnets (e.g. generated by 'testnet-generation-tool').

The fix is to allow post-shelly at epoch 0.

## Related Issue(s)


## How was this tested?
Describe the tests that you ran to verify your changes. Include instructions
so reviewers can reproduce. Examples:

- manual steps

## Checklist

- [ ] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [ ] branch has ≤ 5 commits (honor system)
- [ ] commit messages tell a coherent story
- [ ] branch is up to date with main (rebased on main; fast-forward possible)
- [ ] CI/CD passes on the merged-with-main result

## Impact / Side effects
Potential impact or rollbacks.

## Reviewer notes / Areas to focus

