### PR TITLE
chore: standardize module config getters

### DIFF
--- a/common/src/configuration.rs
+++ b/common/src/configuration.rs
@@ -6,6 +6,28 @@ pub const CONFIG_KEY_STARTUP_MODE: &str = "startup.startup-mode";
 pub const CONFIG_KEY_SYNC_MODE: &str = "startup.sync-mode";
 pub const CONFIG_KEY_BLOCK_FLOW_MODE: &str = "startup.block-flow-mode";
 
+pub fn get_bool_flag(config: &Config, key: (&str, bool)) -> bool {
+    config.get_bool(key.0).unwrap_or(key.1)
+}
+
+pub fn get_string_flag(config: &Config, key: (&str, &str)) -> String {
+    config.get_string(key.0).unwrap_or_else(|_| key.1.to_string())
+}
+
+pub fn get_u64_flag(config: &Config, key: (&str, u64)) -> u64 {
+    config.get_int(key.0).ok().and_then(|v| u64::try_from(v).ok()).unwrap_or(key.1)
+}
+
+pub fn conf_enum<'a, T: Deserialize<'a>>(config: &Config, keydef: (&str, T)) -> anyhow::Result<T> {
+    if config.get_string(keydef.0).is_ok() {
+        config
+            .get::<T>(keydef.0)
+            .map_err(|e| anyhow::anyhow!("cannot parse {} value: {e}", keydef.0))
+    } else {
+        Ok(keydef.1)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SyncMode {

--- a/modules/address_state/src/address_state.rs
+++ b/modules/address_state/src/address_state.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper},
-    configuration::StartupMode,
+    configuration::{get_bool_flag, get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{AddressDeltasMessage, ProtocolParamsMessage, StateTransitionMessage},
     queries::errors::QueryError,
@@ -162,14 +162,6 @@ impl AddressState {
     }
 
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        fn get_bool_flag(config: &Config, key: (&str, bool)) -> bool {
-            config.get_bool(key.0).unwrap_or(key.1)
-        }
-
-        fn get_string_flag(config: &Config, key: (&str, &str)) -> String {
-            config.get_string(key.0).unwrap_or_else(|_| key.1.to_string())
-        }
-
         // Get configuration flags and query topic
         let storage_config = AddressStorageConfig {
             db_path: get_string_flag(&config, DEFAULT_ADDRESS_DB_PATH),

--- a/modules/assets_state/src/assets_state.rs
+++ b/modules/assets_state/src/assets_state.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper},
+    configuration::{get_bool_flag, get_string_flag},
     declare_cardano_reader,
     messages::{
         AddressDeltasMessage, AssetDeltasMessage, CardanoMessage, Message, StateQuery,
@@ -209,14 +210,6 @@ impl AssetsState {
     }
 
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        fn get_bool_flag(config: &Config, key: (&str, bool)) -> bool {
-            config.get_bool(key.0).unwrap_or(key.1)
-        }
-
-        fn get_string_flag(config: &Config, key: (&str, &str)) -> String {
-            config.get_string(key.0).unwrap_or_else(|_| key.1.to_string())
-        }
-
         fn get_transactions_flag(config: &Config, key: (&str, &str)) -> StoreTransactions {
             let val = get_string_flag(config, key);
             match val.as_str() {

--- a/modules/block_kes_validator/src/block_kes_validator.rs
+++ b/modules/block_kes_validator/src/block_kes_validator.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::StartupMode,
+    configuration::{get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
         BlockKesValidatorBootstrapMessage, CardanoMessage, Message, ProtocolParamsMessage,
@@ -228,20 +228,15 @@ impl BlockKesValidator {
 
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         // Publish topics
-        let kes_validation_topic = config
-            .get_string(DEFAULT_VALIDATION_KES_PUBLISHER_TOPIC.0)
-            .unwrap_or(DEFAULT_VALIDATION_KES_PUBLISHER_TOPIC.1.to_string());
+        let kes_validation_topic = get_string_flag(&config, DEFAULT_VALIDATION_KES_PUBLISHER_TOPIC);
         info!("Creating validation KES publisher on '{kes_validation_topic}'");
 
         // Subscribe topics
-        let bootstrapped_subscribe_topic = config
-            .get_string(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.1.to_string());
+        let bootstrapped_subscribe_topic =
+            get_string_flag(&config, DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC);
         info!("Creating subscriber for bootstrapped on '{bootstrapped_subscribe_topic}'");
 
-        let snapshot_subscribe_topic = config
-            .get_string(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.1.to_string());
+        let snapshot_subscribe_topic = get_string_flag(&config, DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC);
 
         // Subscribers
         let snapshot_subscription = if StartupMode::from_config(config.as_ref()).is_snapshot() {

--- a/modules/block_unpacker/src/block_unpacker.rs
+++ b/modules/block_unpacker/src/block_unpacker.rs
@@ -1,7 +1,10 @@
 //! Acropolis Block unpacker module for Caryatid
 //! Unpacks block bodies into transactions
 
-use acropolis_common::messages::{CardanoMessage, Message, RawTxsMessage, StateTransitionMessage};
+use acropolis_common::{
+    configuration::get_string_flag,
+    messages::{CardanoMessage, Message, RawTxsMessage, StateTransitionMessage},
+};
 use anyhow::Result;
 use caryatid_sdk::{module, Context};
 use config::Config;
@@ -9,8 +12,8 @@ use pallas::ledger::traverse::MultiEraBlock;
 use std::sync::Arc;
 use tracing::{debug, error, info, info_span, Instrument};
 
-const DEFAULT_SUBSCRIBE_TOPIC: &str = "cardano.block.proposed";
-const DEFAULT_PUBLISH_TOPIC: &str = "cardano.txs";
+const DEFAULT_SUBSCRIBE_TOPIC: (&str, &str) = ("subscribe-topic", "cardano.block.proposed");
+const DEFAULT_PUBLISH_TOPIC: (&str, &str) = ("publish-topic", "cardano.txs");
 
 /// Block unpacker module
 /// Parameterised by the outer message enum used on the bus
@@ -26,12 +29,10 @@ impl BlockUnpacker {
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         // Subscribe for block body messages
         // Get configuration
-        let subscribe_topic =
-            config.get_string("subscribe-topic").unwrap_or(DEFAULT_SUBSCRIBE_TOPIC.to_string());
+        let subscribe_topic = get_string_flag(&config, DEFAULT_SUBSCRIBE_TOPIC);
         info!("Creating subscriber on '{subscribe_topic}'");
 
-        let publish_topic =
-            config.get_string("publish-topic").unwrap_or(DEFAULT_PUBLISH_TOPIC.to_string());
+        let publish_topic = get_string_flag(&config, DEFAULT_PUBLISH_TOPIC);
         info!("Publishing on '{publish_topic}'");
 
         let mut subscription = context.subscribe(&subscribe_topic).await?;

--- a/modules/block_vrf_validator/src/block_vrf_validator.rs
+++ b/modules/block_vrf_validator/src/block_vrf_validator.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::StartupMode,
+    configuration::{get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
         AccountsBootstrapMessage, CardanoMessage, Message, ProtocolParamsMessage, RawBlockMessage,
@@ -270,20 +270,16 @@ impl BlockVrfValidator {
 
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         // Publish topics
-        let validation_vrf_publisher_topic = config
-            .get_string(DEFAULT_VALIDATION_VRF_PUBLISHER_TOPIC.0)
-            .unwrap_or(DEFAULT_VALIDATION_VRF_PUBLISHER_TOPIC.1.to_string());
+        let validation_vrf_publisher_topic =
+            get_string_flag(&config, DEFAULT_VALIDATION_VRF_PUBLISHER_TOPIC);
         info!("Creating validation VRF publisher on '{validation_vrf_publisher_topic}'");
 
         // Subscribe topics
-        let bootstrapped_subscribe_topic = config
-            .get_string(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.1.to_string());
+        let bootstrapped_subscribe_topic =
+            get_string_flag(&config, DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC);
         info!("Creating subscriber for bootstrapped on '{bootstrapped_subscribe_topic}'");
 
-        let snapshot_subscribe_topic = config
-            .get_string(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.1.to_string());
+        let snapshot_subscribe_topic = get_string_flag(&config, DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC);
 
         // Subscribers
         let snapshot_subscription = if StartupMode::from_config(config.as_ref()).is_snapshot() {

--- a/modules/chain_store/src/chain_store.rs
+++ b/modules/chain_store/src/chain_store.rs
@@ -4,6 +4,7 @@ use crate::queries::{handle_blocks_query, handle_txs_query};
 use crate::state::State;
 use crate::stores::{fjall::FjallStore, Store};
 
+use acropolis_common::configuration::get_string_flag;
 use acropolis_common::queries::errors::QueryError;
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
@@ -29,7 +30,7 @@ mod helpers;
 mod queries;
 mod state;
 
-const DEFAULT_STORE: &str = "fjall";
+const DEFAULT_STORE: (&str, &str) = ("store", "fjall");
 const DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC: (&str, &str) =
     ("validation-publish-topic", "cardano.validation.chainstore");
 
@@ -58,21 +59,15 @@ pub struct ChainStore;
 
 impl ChainStore {
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        let block_queries_topic = config
-            .get_string(DEFAULT_BLOCKS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_BLOCKS_QUERY_TOPIC.1.to_string());
-        let txs_queries_topic = config
-            .get_string(DEFAULT_TRANSACTIONS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_TRANSACTIONS_QUERY_TOPIC.1.to_string());
-        let validation_topic = config
-            .get_string(DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC.0)
-            .unwrap_or(DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC.1.to_string());
+        let block_queries_topic = get_string_flag(&config, DEFAULT_BLOCKS_QUERY_TOPIC);
+        let txs_queries_topic = get_string_flag(&config, DEFAULT_TRANSACTIONS_QUERY_TOPIC);
+        let validation_topic = get_string_flag(&config, DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC);
         info!("Publishing validation outcomes on '{validation_topic}'");
 
         let network_id: NetworkId =
             config.get_string("network-id").unwrap_or("mainnet".to_string()).into();
 
-        let store_type = config.get_string("store").unwrap_or(DEFAULT_STORE.to_string());
+        let store_type = get_string_flag(&config, DEFAULT_STORE);
         let store: Arc<dyn Store> = match store_type.as_str() {
             "fjall" => Arc::new(FjallStore::new(config.clone())?),
             _ => bail!("Unknown store type {store_type}"),

--- a/modules/consensus/src/consensus.rs
+++ b/modules/consensus/src/consensus.rs
@@ -7,7 +7,7 @@ pub mod tree_error;
 pub mod tree_observer;
 
 use acropolis_common::{
-    configuration::BlockFlowMode,
+    configuration::{get_bool_flag, get_string_flag, get_u64_flag, BlockFlowMode},
     messages::{
         BlockRejectedMessage, BlockWantedMessage, CardanoMessage, ConsensusMessage, Message,
         RawBlockMessage, StateTransitionMessage,
@@ -28,12 +28,17 @@ use tracing::{debug, error, info, info_span, warn, Instrument};
 use tree_error::ConsensusTreeError;
 use tree_observer::ConsensusTreeObserver;
 
-const DEFAULT_BLOCKS_AVAILABLE_TOPIC: &str = "cardano.block.available";
-const DEFAULT_BLOCKS_PROPOSED_TOPIC: &str = "cardano.block.proposed";
-const DEFAULT_CONSENSUS_OFFERS_TOPIC: &str = "cardano.consensus.offers";
-const DEFAULT_CONSENSUS_WANTS_TOPIC: &str = "cardano.consensus.wants";
-const DEFAULT_VALIDATION_TIMEOUT: i64 = 60; // seconds
-const DEFAULT_SECURITY_PARAMETER: u64 = 2160; // TODO: This should come from the protocol params message security_param
+const DEFAULT_BLOCKS_AVAILABLE_TOPIC: (&str, &str) =
+    ("blocks-available-topic", "cardano.block.available");
+const DEFAULT_BLOCKS_PROPOSED_TOPIC: (&str, &str) =
+    ("blocks-proposed-topic", "cardano.block.proposed");
+const DEFAULT_CONSENSUS_OFFERS_TOPIC: (&str, &str) =
+    ("consensus-offers-topic", "cardano.consensus.offers");
+const DEFAULT_CONSENSUS_WANTS_TOPIC: (&str, &str) =
+    ("consensus-wants-topic", "cardano.consensus.wants");
+const DEFAULT_FORCE_VALIDATION: (&str, bool) = ("force-validation", true);
+const DEFAULT_VALIDATION_TIMEOUT: (&str, u64) = ("validation-timeout", 60); // seconds
+const DEFAULT_SECURITY_PARAMETER: (&str, u64) = ("security-parameter", 2160); // TODO: This should come from the protocol params message security_param
 
 /// Events emitted by the consensus tree observer, queued for async publishing.
 enum ObserverEvent {
@@ -154,24 +159,16 @@ impl Consensus {
     /// Main init function
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         // Get configuration
-        let blocks_available_topic = config
-            .get_string("blocks-available-topic")
-            .unwrap_or(DEFAULT_BLOCKS_AVAILABLE_TOPIC.to_string());
+        let blocks_available_topic = get_string_flag(&config, DEFAULT_BLOCKS_AVAILABLE_TOPIC);
         info!("Subscribing to blocks on '{blocks_available_topic}'");
 
-        let blocks_proposed_topic = config
-            .get_string("blocks-proposed-topic")
-            .unwrap_or(DEFAULT_BLOCKS_PROPOSED_TOPIC.to_string());
+        let blocks_proposed_topic = get_string_flag(&config, DEFAULT_BLOCKS_PROPOSED_TOPIC);
         info!("Publishing proposed blocks on '{blocks_proposed_topic}'");
 
-        let consensus_offers_topic = config
-            .get_string("consensus-offers-topic")
-            .unwrap_or(DEFAULT_CONSENSUS_OFFERS_TOPIC.to_string());
+        let consensus_offers_topic = get_string_flag(&config, DEFAULT_CONSENSUS_OFFERS_TOPIC);
         info!("Subscribing to consensus offers on '{consensus_offers_topic}'");
 
-        let consensus_wants_topic = config
-            .get_string("consensus-wants-topic")
-            .unwrap_or(DEFAULT_CONSENSUS_WANTS_TOPIC.to_string());
+        let consensus_wants_topic = get_string_flag(&config, DEFAULT_CONSENSUS_WANTS_TOPIC);
 
         let validator_topics: Vec<String> =
             config.get::<Vec<String>>("validators").unwrap_or_default();
@@ -182,17 +179,14 @@ impl Consensus {
         let flow_mode = BlockFlowMode::from_config(&config);
         info!("Consensus flow mode: {flow_mode}");
 
-        let validation_timeout = Duration::from_secs(
-            config.get_int("validation-timeout").unwrap_or(DEFAULT_VALIDATION_TIMEOUT) as u64,
-        );
+        let validation_timeout =
+            Duration::from_secs(get_u64_flag(&config, DEFAULT_VALIDATION_TIMEOUT));
         info!("Validation timeout {validation_timeout:?}");
 
-        let force_validation = config.get_bool("force-validation").unwrap_or(true);
+        let force_validation = get_bool_flag(&config, DEFAULT_FORCE_VALIDATION);
         info!("Force validation and chain selection: {force_validation}");
 
-        let security_parameter = config
-            .get_int("security-parameter")
-            .unwrap_or(DEFAULT_SECURITY_PARAMETER as i64) as u64;
+        let security_parameter = get_u64_flag(&config, DEFAULT_SECURITY_PARAMETER);
         info!("Security parameter k={security_parameter}");
 
         // Subscribe for incoming blocks (BlockAvailable)
@@ -1041,7 +1035,7 @@ mod tests {
 
         let event_queue: EventQueue = Arc::new(std::sync::Mutex::new(Vec::new()));
         let mut tree = ConsensusTree::new(
-            DEFAULT_SECURITY_PARAMETER,
+            DEFAULT_SECURITY_PARAMETER.1,
             Box::new(QueuingConsensusTreeObserver {
                 events: event_queue.clone(),
             }),
@@ -1056,8 +1050,8 @@ mod tests {
 
         ConsensusRuntime {
             context,
-            blocks_proposed_topic: DEFAULT_BLOCKS_PROPOSED_TOPIC.to_string(),
-            consensus_wants_topic: DEFAULT_CONSENSUS_WANTS_TOPIC.to_string(),
+            blocks_proposed_topic: DEFAULT_BLOCKS_PROPOSED_TOPIC.1.to_string(),
+            consensus_wants_topic: DEFAULT_CONSENSUS_WANTS_TOPIC.1.to_string(),
             event_queue,
             pending_post_rollback_marker: None,
             tree,

--- a/modules/drdd_state/src/drdd_state.rs
+++ b/modules/drdd_state/src/drdd_state.rs
@@ -2,6 +2,7 @@
 //! Stores historical DRep delegation distributions
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper},
+    configuration::{get_bool_flag, get_string_flag},
     declare_cardano_reader,
     messages::{CardanoMessage, DRepStakeDistributionMessage, Message, StateTransitionMessage},
     rest_helper::handle_rest_with_query_parameters,
@@ -65,12 +66,10 @@ impl DRDDState {
 
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         // Get configuration
-        let handle_drdd_topic = config
-            .get_string(DEFAULT_HANDLE_DRDD_TOPIC.0)
-            .unwrap_or(DEFAULT_HANDLE_DRDD_TOPIC.1.to_string());
+        let handle_drdd_topic = get_string_flag(&config, DEFAULT_HANDLE_DRDD_TOPIC);
         info!("Creating request handler on '{}'", handle_drdd_topic);
 
-        let store_drdd = config.get_bool(DEFAULT_STORE_DRDD.0).unwrap_or(DEFAULT_STORE_DRDD.1);
+        let store_drdd = get_bool_flag(&config, DEFAULT_STORE_DRDD);
 
         let history_opt = if store_drdd {
             let history = Arc::new(Mutex::new(StateHistory::<State>::new(

--- a/modules/drep_state/src/drep_state.rs
+++ b/modules/drep_state/src/drep_state.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::StartupMode,
+    configuration::{StartupMode, get_bool_flag, get_string_flag},
     declare_cardano_reader,
     messages::{
         CardanoMessage, GovernanceProceduresMessage, Message, ProtocolParamsMessage,
@@ -62,7 +62,7 @@ const DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC: (&str, &str) =
     ("snapshot-subscribe-topic", "cardano.snapshot");
 
 // Publisher topic
-const DEFAULT_DREP_STATE_TOPIC: &str = "cardano.drep.state";
+const DEFAULT_DREP_STATE_TOPIC: (&str, &str) = ("publish-drep-state-topic", "cardano.drep.state");
 
 const DEFAULT_VALIDATION_OUTPUT_TOPIC: (&str, &str) =
     ("validation-output-topic", "cardano.validation.drep");
@@ -298,14 +298,6 @@ impl DRepState {
     }
 
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        fn get_bool_flag(config: &Config, key: (&str, bool)) -> bool {
-            config.get_bool(key.0).unwrap_or(key.1)
-        }
-
-        fn get_string_flag(config: &Config, key: (&str, &str)) -> String {
-            config.get_string(key.0).unwrap_or_else(|_| key.1.to_string())
-        }
-
         // Get configuration flags and topis
         let storage_config = DRepStorageConfig {
             store_info: get_bool_flag(&config, DEFAULT_STORE_INFO),
@@ -318,9 +310,7 @@ impl DRepState {
         let is_bootstrap_mode = StartupMode::from_config(config.as_ref()).is_snapshot();
 
         // Subscribe for snapshot messages if bootstrapping from snapshot
-        let snapshot_subscribe_topic = config
-            .get_string(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.1.to_string());
+        let snapshot_subscribe_topic = get_string_flag(&config, DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC);
 
         let subscriptions = DRepSubscriptions {
             snapshot: if is_bootstrap_mode {
@@ -334,9 +324,7 @@ impl DRepState {
             params_reader: ParamReader::new(&context, &config).await?,
         };
 
-        let drep_state_topic = config
-            .get_string("publish-drep-state-topic")
-            .unwrap_or(DEFAULT_DREP_STATE_TOPIC.to_string());
+        let drep_state_topic = get_string_flag(&config, DEFAULT_DREP_STATE_TOPIC);
         info!("Creating DRep state publisher on '{drep_state_topic}'");
 
         let drep_query_topic = get_string_flag(&config, DEFAULT_DREPS_QUERY_TOPIC);

--- a/modules/drep_state/src/drep_state.rs
+++ b/modules/drep_state/src/drep_state.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::{StartupMode, get_bool_flag, get_string_flag},
+    configuration::{get_bool_flag, get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
         CardanoMessage, GovernanceProceduresMessage, Message, ProtocolParamsMessage,

--- a/modules/epochs_state/src/epochs_state.rs
+++ b/modules/epochs_state/src/epochs_state.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::StartupMode,
+    configuration::{get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
         BlockTxsMessage, CardanoMessage, EpochBootstrapMessage, GenesisCompleteMessage, Message,
@@ -306,31 +306,23 @@ impl EpochsState {
         let txs_reader = TxsReader::new(&context, &config).await?;
         let block_reader = BlockReader::new(&context, &config).await?;
 
-        let snapshot_subscribe_topic = config
-            .get_string(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.1.to_string());
+        let snapshot_subscribe_topic = get_string_flag(&config, DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC);
         info!("Creating subscriber for snapshot on '{snapshot_subscribe_topic}'");
 
         // Publish topic
-        let epoch_activity_publish_topic = config
-            .get_string(DEFAULT_EPOCH_ACTIVITY_PUBLISH_TOPIC.0)
-            .unwrap_or(DEFAULT_EPOCH_ACTIVITY_PUBLISH_TOPIC.1.to_string());
+        let epoch_activity_publish_topic =
+            get_string_flag(&config, DEFAULT_EPOCH_ACTIVITY_PUBLISH_TOPIC);
         info!("Publishing EpochActivityMessage on '{epoch_activity_publish_topic}'");
 
-        let epoch_nonce_publish_topic = config
-            .get_string(DEFAULT_EPOCH_NONCE_PUBLISH_TOPIC.0)
-            .unwrap_or(DEFAULT_EPOCH_NONCE_PUBLISH_TOPIC.1.to_string());
+        let epoch_nonce_publish_topic = get_string_flag(&config, DEFAULT_EPOCH_NONCE_PUBLISH_TOPIC);
         info!("Publishing EpochNonceMessage on '{epoch_nonce_publish_topic}'");
 
-        let validation_outcome_topic = config
-            .get_string(DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC.0)
-            .unwrap_or(DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC.1.to_string());
+        let validation_outcome_topic =
+            get_string_flag(&config, DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC);
         info!("Publishing validation outcomes on '{validation_outcome_topic}'");
 
         // query topic
-        let epochs_query_topic = config
-            .get_string(DEFAULT_EPOCHS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_EPOCHS_QUERY_TOPIC.1.to_string());
+        let epochs_query_topic = get_string_flag(&config, DEFAULT_EPOCHS_QUERY_TOPIC);
         info!("Creating query handler on '{}'", epochs_query_topic);
 
         // state history

--- a/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
+++ b/modules/genesis_bootstrapper/src/genesis_bootstrapper.rs
@@ -2,7 +2,7 @@
 //! Reads genesis files and outputs initial UTXO events
 
 use acropolis_common::{
-    configuration::StartupMode,
+    configuration::{get_string_flag, get_u64_flag, StartupMode},
     genesis_values::GenesisValues,
     hash::Hash,
     messages::{
@@ -25,12 +25,18 @@ use std::borrow::Cow;
 use std::sync::Arc;
 use tracing::{error, info, info_span, Instrument};
 
-const DEFAULT_STARTUP_TOPIC: &str = "cardano.sequence.start";
-const DEFAULT_PUBLISH_UTXO_DELTAS_TOPIC: &str = "cardano.utxo.deltas";
-const DEFAULT_PUBLISH_POT_DELTAS_TOPIC: &str = "cardano.pot.deltas";
-const DEFAULT_PUBLISH_GENESIS_UTXO_REGISTRY_TOPIC: &str = "cardano.genesis.utxos";
-const DEFAULT_COMPLETION_TOPIC: &str = "cardano.sequence.bootstrapped";
-const DEFAULT_NETWORK_NAME: &str = "mainnet";
+const DEFAULT_STARTUP_TOPIC: (&str, &str) = ("startup-topic", "cardano.sequence.start");
+const DEFAULT_PUBLISH_UTXO_DELTAS_TOPIC: (&str, &str) =
+    ("publish-utxo-deltas-topic", "cardano.utxo.deltas");
+const DEFAULT_PUBLISH_POT_DELTAS_TOPIC: (&str, &str) =
+    ("publish-pot-deltas-topic", "cardano.pot.deltas");
+const DEFAULT_PUBLISH_GENESIS_UTXO_REGISTRY_TOPIC: (&str, &str) =
+    ("publish-genesis-utxos-topic", "cardano.genesis.utxos");
+const DEFAULT_COMPLETION_TOPIC: (&str, &str) =
+    ("completion-topic", "cardano.sequence.bootstrapped");
+const DEFAULT_NETWORK_NAME: (&str, &str) = ("startup.network-name", "mainnet");
+const DEFAULT_SHELLEY_START_EPOCH: (&str, u64) = ("shelley-start-epoch", 0);
+const DEFAULT_FIRST_BLOCK_ERA: (&str, &str) = ("first-block-era", "byron");
 
 // Include genesis data (downloaded by build.rs)
 const MAINNET_BYRON_GENESIS: &[u8] = include_bytes!("../downloads/mainnet-byron-genesis.json");
@@ -74,8 +80,7 @@ pub struct GenesisBootstrapper;
 impl GenesisBootstrapper {
     /// Main init function
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        let startup_topic =
-            config.get_string("startup-topic").unwrap_or(DEFAULT_STARTUP_TOPIC.to_string());
+        let startup_topic = get_string_flag(&config, DEFAULT_STARTUP_TOPIC);
         info!("Creating startup subscriber on '{startup_topic}'");
 
         let snapshot_bootstrap = StartupMode::from_config(config.as_ref()).is_snapshot();
@@ -89,14 +94,10 @@ impl GenesisBootstrapper {
             async {
                 info!("Received startup message");
 
-                let completion_topic = config
-                    .get_string("completion-topic")
-                    .unwrap_or(DEFAULT_COMPLETION_TOPIC.to_string());
+                let completion_topic = get_string_flag(&config, DEFAULT_COMPLETION_TOPIC);
                 info!("Completing with '{completion_topic}'");
 
-                let network_name = config
-                    .get_string("startup.network-name")
-                    .unwrap_or(DEFAULT_NETWORK_NAME.to_string());
+                let network_name = get_string_flag(&config, DEFAULT_NETWORK_NAME);
 
                 let (byron_genesis_bytes, shelley_genesis_bytes, shelley_start_epoch, first_block_era):
                     (Cow<'static, [u8]>, Cow<'static, [u8]>, u64, Era) = match network_name.as_ref()
@@ -133,20 +134,17 @@ impl GenesisBootstrapper {
                                     Ok(data) => data,
                                     Err(e) => { error!("Cannot read shelley genesis file {sp}: {e}"); return; }
                                 };
-                                let shelley_start_epoch = config.get::<u64>("shelley-start-epoch").unwrap_or(0);
-                                let first_block_era = config.get_string("first-block-era")
-                                    .ok()
-                                    .and_then(|s| match s.as_ref() {
-                                        "byron" => Some(Era::Byron),
-                                        "shelley" => Some(Era::Shelley),
-                                        "allegra" => Some(Era::Allegra),
-                                        "mary" => Some(Era::Mary),
-                                        "alonzo" => Some(Era::Alonzo),
-                                        "babbage" => Some(Era::Babbage),
-                                        "conway" => Some(Era::Conway),
-                                        _ => None,
-                                    })
-                                    .unwrap_or(Era::Byron);
+                                let shelley_start_epoch = get_u64_flag(&config,DEFAULT_SHELLEY_START_EPOCH);
+                                let first_block_era = match get_string_flag(&config, DEFAULT_FIRST_BLOCK_ERA).as_str() {
+                                    "byron" => Era::Byron,
+                                    "shelley" => Era::Shelley,
+                                    "allegra" => Era::Allegra,
+                                    "mary" => Era::Mary,
+                                    "alonzo" => Era::Alonzo,
+                                    "babbage" => Era::Babbage,
+                                    "conway" => Era::Conway,
+                                    _ => Era::Byron,
+                                };
                                 (Cow::Owned(byron), Cow::Owned(shelley), shelley_start_epoch, first_block_era)
                             }
                             _ => {
@@ -186,19 +184,13 @@ impl GenesisBootstrapper {
                 };
 
                 if !snapshot_bootstrap {
-                    let publish_utxo_deltas_topic = config
-                        .get_string("publish-utxo-deltas-topic")
-                        .unwrap_or(DEFAULT_PUBLISH_UTXO_DELTAS_TOPIC.to_string());
+                    let publish_utxo_deltas_topic = get_string_flag(&config, DEFAULT_PUBLISH_UTXO_DELTAS_TOPIC);
                     info!("Publishing UTXO deltas on '{publish_utxo_deltas_topic}'");
 
-                    let publish_pot_deltas_topic = config
-                        .get_string("publish-pot-deltas-topic")
-                        .unwrap_or(DEFAULT_PUBLISH_POT_DELTAS_TOPIC.to_string());
+                    let publish_pot_deltas_topic = get_string_flag(&config, DEFAULT_PUBLISH_POT_DELTAS_TOPIC);
                     info!("Publishing pot deltas on '{publish_pot_deltas_topic}'");
 
-                    let publish_genesis_utxos_topic = config
-                        .get_string("publish-genesis-utxos-topic")
-                        .unwrap_or(DEFAULT_PUBLISH_GENESIS_UTXO_REGISTRY_TOPIC.to_string());
+                    let publish_genesis_utxos_topic = get_string_flag(&config, DEFAULT_PUBLISH_GENESIS_UTXO_REGISTRY_TOPIC);
                     info!("Publishing genesis transactions on '{publish_genesis_utxos_topic}'");
 
                     let mut utxo_deltas_message = UTXODeltasMessage { deltas: Vec::new() };

--- a/modules/governance_state/src/governance_state.rs
+++ b/modules/governance_state/src/governance_state.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::StartupMode,
+    configuration::{get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
         CardanoMessage, DRepStakeDistributionMessage, DRepStateMessage,
@@ -11,10 +11,12 @@ use acropolis_common::{
         SnapshotMessage, SnapshotStateMessage, StateQuery, StateQueryResponse,
         StateTransitionMessage,
     },
-    queries::errors::QueryError,
-    queries::governance::{
-        GovernanceStateQuery, GovernanceStateQueryResponse, ProposalInfo, ProposalVotes,
-        ProposalsList, DEFAULT_GOVERNANCE_QUERY_TOPIC,
+    queries::{
+        errors::QueryError,
+        governance::{
+            GovernanceStateQuery, GovernanceStateQueryResponse, ProposalInfo, ProposalVotes,
+            ProposalsList, DEFAULT_GOVERNANCE_QUERY_TOPIC,
+        },
     },
 };
 use anyhow::{anyhow, bail, Result};
@@ -107,21 +109,12 @@ struct Readers {
 }
 
 impl GovernanceStateConfig {
-    fn conf(config: &Arc<Config>, keydef: (&str, &str)) -> String {
-        let actual = config.get_string(keydef.0).unwrap_or(keydef.1.to_string());
-        info!(
-            "Creating subscriber/publisher on '{}' for {}",
-            actual, keydef.0
-        );
-        actual
-    }
-
     pub fn new(config: &Arc<Config>) -> Arc<Self> {
         Arc::new(Self {
-            enact_publish_topic: Self::conf(config, CONFIG_ENACT_STATE_TOPIC),
-            governance_query_topic: Self::conf(config, DEFAULT_GOVERNANCE_QUERY_TOPIC),
-            validation_outcome_topic: Self::conf(config, CONFIG_VALIDATION_OUTCOME_TOPIC),
-            snapshot_subscribe_topic: Self::conf(config, CONFIG_SNAPSHOT_SUBSCRIBE_TOPIC),
+            enact_publish_topic: get_string_flag(config, CONFIG_ENACT_STATE_TOPIC),
+            governance_query_topic: get_string_flag(config, DEFAULT_GOVERNANCE_QUERY_TOPIC),
+            validation_outcome_topic: get_string_flag(config, CONFIG_VALIDATION_OUTCOME_TOPIC),
+            snapshot_subscribe_topic: get_string_flag(config, CONFIG_SNAPSHOT_SUBSCRIBE_TOPIC),
             verification_output_file: config
                 .get_string(VERIFICATION_OUTPUT_FILE)
                 .map(Some)

--- a/modules/historical_accounts_state/src/historical_accounts_state.rs
+++ b/modules/historical_accounts_state/src/historical_accounts_state.rs
@@ -2,7 +2,7 @@
 //! Manages optional state data needed for Blockfrost alignment
 
 use acropolis_common::caryatid::{PrimaryRead, RollbackWrapper};
-use acropolis_common::configuration::StartupMode;
+use acropolis_common::configuration::{get_bool_flag, get_string_flag, StartupMode};
 use acropolis_common::declare_cardano_reader;
 use acropolis_common::messages::{CardanoMessage, Message, StateQuery, StateQueryResponse};
 use acropolis_common::messages::{
@@ -223,45 +223,24 @@ impl HistoricalAccountsState {
         let is_snapshot_mode = StartupMode::from_config(config.as_ref()).is_snapshot();
 
         // Query topics
-        let historical_accounts_query_topic = config
-            .get_string(DEFAULT_HISTORICAL_ACCOUNTS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_HISTORICAL_ACCOUNTS_QUERY_TOPIC.1.to_string());
+        let historical_accounts_query_topic =
+            get_string_flag(&config, DEFAULT_HISTORICAL_ACCOUNTS_QUERY_TOPIC);
         info!(
             "Creating query handler on '{}'",
             historical_accounts_query_topic
         );
 
         let storage_config = HistoricalAccountsConfig {
-            db_path: config
-                .get_string(DEFAULT_HISTORICAL_ACCOUNTS_DB_PATH.0)
-                .unwrap_or(DEFAULT_HISTORICAL_ACCOUNTS_DB_PATH.1.to_string()),
-            clear_on_start: config
-                .get_bool(DEFAULT_CLEAR_ON_START.0)
-                .unwrap_or(DEFAULT_CLEAR_ON_START.1),
-            store_rewards_history: config
-                .get_bool(DEFAULT_STORE_REWARDS_HISTORY.0)
-                .unwrap_or(DEFAULT_STORE_REWARDS_HISTORY.1),
-            store_active_stake_history: config
-                .get_bool(DEFAULT_STORE_ACTIVE_STAKE_HISTORY.0)
-                .unwrap_or(DEFAULT_STORE_ACTIVE_STAKE_HISTORY.1),
-            store_delegation_history: config
-                .get_bool(DEFAULT_STORE_DELEGATION_HISTORY.0)
-                .unwrap_or(DEFAULT_STORE_DELEGATION_HISTORY.1),
-            store_registration_history: config
-                .get_bool(DEFAULT_STORE_REGISTRATION_HISTORY.0)
-                .unwrap_or(DEFAULT_STORE_REGISTRATION_HISTORY.1),
-            store_withdrawal_history: config
-                .get_bool(DEFAULT_STORE_WITHDRAWAL_HISTORY.0)
-                .unwrap_or(DEFAULT_STORE_WITHDRAWAL_HISTORY.1),
-            store_mir_history: config
-                .get_bool(DEFAULT_STORE_MIR_HISTORY.0)
-                .unwrap_or(DEFAULT_STORE_MIR_HISTORY.1),
-            store_addresses: config
-                .get_bool(DEFAULT_STORE_ADDRESSES.0)
-                .unwrap_or(DEFAULT_STORE_ADDRESSES.1),
-            store_tx_count: config
-                .get_bool(DEFAULT_STORE_TX_COUNT.0)
-                .unwrap_or(DEFAULT_STORE_TX_COUNT.1),
+            db_path: get_string_flag(&config, DEFAULT_HISTORICAL_ACCOUNTS_DB_PATH),
+            clear_on_start: get_bool_flag(&config, DEFAULT_CLEAR_ON_START),
+            store_rewards_history: get_bool_flag(&config, DEFAULT_STORE_REWARDS_HISTORY),
+            store_active_stake_history: get_bool_flag(&config, DEFAULT_STORE_ACTIVE_STAKE_HISTORY),
+            store_delegation_history: get_bool_flag(&config, DEFAULT_STORE_DELEGATION_HISTORY),
+            store_registration_history: get_bool_flag(&config, DEFAULT_STORE_REGISTRATION_HISTORY),
+            store_withdrawal_history: get_bool_flag(&config, DEFAULT_STORE_WITHDRAWAL_HISTORY),
+            store_mir_history: get_bool_flag(&config, DEFAULT_STORE_MIR_HISTORY),
+            store_addresses: get_bool_flag(&config, DEFAULT_STORE_ADDRESSES),
+            store_tx_count: get_bool_flag(&config, DEFAULT_STORE_TX_COUNT),
         };
 
         // Initalize state

--- a/modules/historical_epochs_state/src/historical_epochs_state.rs
+++ b/modules/historical_epochs_state/src/historical_epochs_state.rs
@@ -4,7 +4,7 @@
 use crate::immutable_historical_epochs_state::ImmutableHistoricalEpochsState;
 use crate::state::{HistoricalEpochsStateConfig, State};
 use acropolis_common::caryatid::{PrimaryRead, RollbackWrapper};
-use acropolis_common::configuration::{StartupMode, get_bool_flag, get_string_flag};
+use acropolis_common::configuration::{get_bool_flag, get_string_flag, StartupMode};
 use acropolis_common::declare_cardano_reader;
 use acropolis_common::messages::{
     EpochActivityMessage, ProtocolParamsMessage, RawBlockMessage, StateQuery,

--- a/modules/historical_epochs_state/src/historical_epochs_state.rs
+++ b/modules/historical_epochs_state/src/historical_epochs_state.rs
@@ -4,7 +4,7 @@
 use crate::immutable_historical_epochs_state::ImmutableHistoricalEpochsState;
 use crate::state::{HistoricalEpochsStateConfig, State};
 use acropolis_common::caryatid::{PrimaryRead, RollbackWrapper};
-use acropolis_common::configuration::StartupMode;
+use acropolis_common::configuration::{StartupMode, get_bool_flag, get_string_flag};
 use acropolis_common::declare_cardano_reader;
 use acropolis_common::messages::{
     EpochActivityMessage, ProtocolParamsMessage, RawBlockMessage, StateQuery,
@@ -157,19 +157,14 @@ impl HistoricalEpochsState {
         let is_snapshot_mode = StartupMode::from_config(config.as_ref()).is_snapshot();
 
         // Query topic
-        let historical_epochs_query_topic = config
-            .get_string(DEFAULT_HISTORICAL_EPOCHS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_HISTORICAL_EPOCHS_QUERY_TOPIC.1.to_string());
+        let historical_epochs_query_topic =
+            get_string_flag(&config, DEFAULT_HISTORICAL_EPOCHS_QUERY_TOPIC);
         info!("Creating query handler on '{historical_epochs_query_topic}'");
 
         // Configuration
         let cfg = HistoricalEpochsStateConfig {
-            db_path: config
-                .get_string(DEFAULT_HISTORICAL_EPOCHS_STATE_DB_PATH.0)
-                .unwrap_or(DEFAULT_HISTORICAL_EPOCHS_STATE_DB_PATH.1.to_string()),
-            clear_on_start: config
-                .get_bool(DEFAULT_CLEAR_ON_START.0)
-                .unwrap_or(DEFAULT_CLEAR_ON_START.1),
+            db_path: get_string_flag(&config, DEFAULT_HISTORICAL_EPOCHS_STATE_DB_PATH),
+            clear_on_start: get_bool_flag(&config, DEFAULT_CLEAR_ON_START),
         };
 
         // Initalize state

--- a/modules/mcp_server/src/mcp_server.rs
+++ b/modules/mcp_server/src/mcp_server.rs
@@ -13,7 +13,10 @@ use caryatid_sdk::{module, Context};
 use config::Config;
 use tracing::info;
 
-use acropolis_common::messages::Message;
+use acropolis_common::{
+    configuration::{get_bool_flag, get_string_flag, get_u64_flag},
+    messages::Message,
+};
 
 mod resources;
 mod server;
@@ -22,9 +25,11 @@ mod tools;
 use server::AcropolisMCPServer;
 
 /// Default MCP server address
-const DEFAULT_MCP_ADDRESS: &str = "127.0.0.1";
+const DEFAULT_MCP_ADDRESS: (&str, &str) = ("address", "127.0.0.1");
 /// Default MCP server port
-const DEFAULT_MCP_PORT: u16 = 4341;
+const DEFAULT_MCP_PORT: (&str, u64) = ("port", 4341);
+/// Default enabled status
+const DEFAULT_ENABLED: (&str, bool) = ("enabled", false);
 
 #[module(
     message_type(Message),
@@ -37,7 +42,7 @@ impl MCPServer {
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         // Check if MCP server is enabled in config (under [module.mcp-server])
         // Note: `config` is already scoped to the module's config section
-        let enabled = config.get_bool("enabled").unwrap_or(false);
+        let enabled = get_bool_flag(&config, DEFAULT_ENABLED);
 
         if !enabled {
             info!("MCP server is disabled in configuration");
@@ -45,9 +50,8 @@ impl MCPServer {
         }
 
         // Get address and port from module config
-        let address =
-            config.get_string("address").unwrap_or_else(|_| DEFAULT_MCP_ADDRESS.to_string());
-        let port = config.get_int("port").map(|p| p as u16).unwrap_or(DEFAULT_MCP_PORT);
+        let address = get_string_flag(&config, DEFAULT_MCP_ADDRESS);
+        let port: u16 = get_u64_flag(&config, DEFAULT_MCP_PORT).try_into()?;
 
         info!("Initializing MCP server on {}:{}", address, port);
 

--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -4,7 +4,7 @@
 use acropolis_codec::map_to_block_era;
 use acropolis_common::{
     commands::chain_sync::ChainSyncCommand,
-    configuration::{StartupMode, SyncMode},
+    configuration::{get_string_flag, StartupMode, SyncMode},
     genesis_values::GenesisValues,
     messages::{CardanoMessage, Command, Message, RawBlockMessage},
     BlockHash, BlockInfo, BlockIntent, BlockStatus, Era, Point,
@@ -39,19 +39,25 @@ const DEFAULT_BLOCK_PUBLISH_TOPIC: (&str, &str) =
     ("block-publish-topic", "cardano.block.available");
 const DEFAULT_SYNC_COMMAND_TOPIC: (&str, &str) = ("completion-topic", "cardano.sync.command");
 
-const DEFAULT_AGGREGATOR_URL: &str =
-    "https://aggregator.release-mainnet.api.mithril.network/aggregator";
-const DEFAULT_GENESIS_KEY: &str = r#"
+const DEFAULT_AGGREGATOR_URL: (&str, &str) = (
+    "aggregator-url",
+    "https://aggregator.release-mainnet.api.mithril.network/aggregator",
+);
+const DEFAULT_GENESIS_KEY: (&str, &str) = (
+    "genesis-key",
+    r#"
 5b3139312c36362c3134302c3138352c3133382c31312c3233372c3230372c3235302c3134342c32
 372c322c3138382c33302c31322c38312c3135352c3230342c31302c3137392c37352c32332c3133
-382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"#;
+382c3139362c3231372c352c31342c32302c35372c37392c33392c3137365d"#,
+);
 const DEFAULT_PAUSE: (&str, PauseType) = ("pause", PauseType::NoPause);
 const DEFAULT_STOP: (&str, PauseType) = ("stop", PauseType::NoPause);
 #[cfg(not(target_env = "msvc"))]
 const DEFAULT_PROFILE: (&str, PauseType) = ("profile", PauseType::NoPause);
 const DEFAULT_DOWNLOAD_MAX_AGE: &str = "download-max-age";
 const DEFAULT_DIRECTORY: &str = "../../modules/mithril_snapshot_fetcher/downloads";
-const DEFAULT_NETWORK_NAME: &str = "mainnet";
+// TODO: Read network name from genesis message
+const DEFAULT_NETWORK_NAME: (&str, &str) = ("startup.network-name", "mainnet");
 const SNAPSHOT_METADATA_FILE: &str = "snapshot_metadata.json";
 
 /// Mithril feedback receiver
@@ -127,9 +133,7 @@ impl MithrilSnapshotFetcher {
     /// Can be overridden with the `directory` config key.
     fn resolve_directory(config: &Config) -> String {
         config.get_string("directory").unwrap_or_else(|_| {
-            let network = config
-                .get_string("startup.network-name")
-                .unwrap_or(DEFAULT_NETWORK_NAME.to_string());
+            let network = get_string_flag(config, DEFAULT_NETWORK_NAME);
             format!("{DEFAULT_DIRECTORY}/{network}")
         })
     }
@@ -193,10 +197,8 @@ impl MithrilSnapshotFetcher {
 
     /// Fetch and unpack a snapshot
     async fn download_snapshot(config: Arc<Config>) -> Result<()> {
-        let aggregator_url =
-            config.get_string("aggregator-url").unwrap_or(DEFAULT_AGGREGATOR_URL.to_string());
-        let genesis_key =
-            config.get_string("genesis-key").unwrap_or(DEFAULT_GENESIS_KEY.to_string());
+        let aggregator_url = get_string_flag(&config, DEFAULT_AGGREGATOR_URL);
+        let genesis_key = get_string_flag(&config, DEFAULT_GENESIS_KEY);
         let directory = Self::resolve_directory(&config);
         let snapshot_metadata_path = Path::new(&directory).join(SNAPSHOT_METADATA_FILE);
 
@@ -453,17 +455,14 @@ impl MithrilSnapshotFetcher {
             return Ok(());
         }
 
-        let bootstrapped_subscribe_topic = config
-            .get_string(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC.1.to_string());
+        let bootstrapped_subscribe_topic =
+            get_string_flag(&config, DEFAULT_BOOTSTRAPPED_SUBSCRIBE_TOPIC);
         info!("Creating subscriber for bootstrapped on '{bootstrapped_subscribe_topic}'");
 
         let mut bootstrapped_subscription =
             context.subscribe(&bootstrapped_subscribe_topic).await?;
         let mut sync_command_subscription = if StartupMode::from_config(&config).is_snapshot() {
-            let sync_command_topic = config
-                .get_string(DEFAULT_SYNC_COMMAND_TOPIC.0)
-                .unwrap_or(DEFAULT_SYNC_COMMAND_TOPIC.1.to_string());
+            let sync_command_topic = get_string_flag(&config, DEFAULT_SYNC_COMMAND_TOPIC);
 
             Some(context.subscribe(&sync_command_topic).await?)
         } else {

--- a/modules/parameters_state/src/parameters_state.rs
+++ b/modules/parameters_state/src/parameters_state.rs
@@ -2,7 +2,7 @@
 //! Accepts certificate events and derives the Governance State in memory
 
 use acropolis_common::caryatid::RollbackWrapper;
-use acropolis_common::configuration::StartupMode;
+use acropolis_common::configuration::{get_bool_flag, get_string_flag, StartupMode};
 use acropolis_common::declare_cardano_reader;
 use acropolis_common::messages::{
     GovernanceOutcomesMessage, SnapshotMessage, SnapshotStateMessage, StateTransitionMessage,
@@ -33,6 +33,7 @@ use state::State;
 const CONFIG_ENACT_STATE_TOPIC: (&str, &str) = ("enact-state-topic", "cardano.enact.state");
 const CONFIG_PROTOCOL_PARAMETERS_TOPIC: (&str, &str) =
     ("publish-parameters-topic", "cardano.protocol.parameters");
+// TODO: Read network name from genesis message
 const CONFIG_NETWORK_NAME: (&str, &str) = ("startup.network-name", "mainnet");
 const CONFIG_STORE_HISTORY: (&str, bool) = ("store-history", false);
 /// Topic for receiving bootstrap data when starting from a CBOR dump snapshot
@@ -64,25 +65,13 @@ struct ParametersStateConfig {
 }
 
 impl ParametersStateConfig {
-    fn conf(config: &Arc<Config>, keydef: (&str, &str)) -> String {
-        let actual = config.get_string(keydef.0).unwrap_or(keydef.1.to_string());
-        info!("Parameter value '{}' for {}", actual, keydef.0);
-        actual
-    }
-
-    fn conf_bool(config: &Arc<Config>, keydef: (&str, bool)) -> bool {
-        let actual = config.get_bool(keydef.0).unwrap_or(keydef.1);
-        info!("Parameter value '{}' for {}", actual, keydef.0);
-        actual
-    }
-
     pub fn new(context: Arc<Context<Message>>, config: &Arc<Config>) -> Arc<Self> {
         Arc::new(Self {
             context,
-            network_name: Self::conf(config, CONFIG_NETWORK_NAME),
-            protocol_parameters_topic: Self::conf(config, CONFIG_PROTOCOL_PARAMETERS_TOPIC),
-            parameters_query_topic: Self::conf(config, DEFAULT_PARAMETERS_QUERY_TOPIC),
-            store_history: Self::conf_bool(config, CONFIG_STORE_HISTORY),
+            network_name: get_string_flag(config, CONFIG_NETWORK_NAME),
+            protocol_parameters_topic: get_string_flag(config, CONFIG_PROTOCOL_PARAMETERS_TOPIC),
+            parameters_query_topic: get_string_flag(config, DEFAULT_PARAMETERS_QUERY_TOPIC),
+            store_history: get_bool_flag(config, CONFIG_STORE_HISTORY),
         })
     }
 }

--- a/modules/rest_blockfrost/src/rest_blockfrost.rs
+++ b/modules/rest_blockfrost/src/rest_blockfrost.rs
@@ -2,6 +2,7 @@
 
 use std::{collections::HashMap, future::Future, sync::Arc};
 
+use acropolis_common::configuration::get_string_flag;
 use acropolis_common::rest_error::RESTError;
 use acropolis_common::{
     messages::{Message, RESTResponse},
@@ -805,7 +806,7 @@ fn register_handler<F, Fut>(
         + 'static,
     Fut: Future<Output = Result<RESTResponse, RESTError>> + Send + 'static,
 {
-    let topic_name = context.config.get_string(topic.0).unwrap_or_else(|_| topic.1.to_string());
+    let topic_name = get_string_flag(&context.config, topic);
     info!("Creating request handler on '{}'", topic_name);
 
     handle_rest_with_path_parameter(context.clone(), &topic_name, move |params| {
@@ -831,7 +832,7 @@ fn register_handler_with_query<F, Fut>(
         + 'static,
     Fut: Future<Output = Result<RESTResponse, RESTError>> + Send + 'static,
 {
-    let topic_name = context.config.get_string(topic.0).unwrap_or_else(|_| topic.1.to_string());
+    let topic_name = get_string_flag(&context.config, topic);
     info!("Creating request handler on '{}'", topic_name);
 
     handle_rest_with_path_and_query_parameters(

--- a/modules/spdd_state/src/spdd_state.rs
+++ b/modules/spdd_state/src/spdd_state.rs
@@ -1,6 +1,7 @@
 //! Acropolis SPDD state module for Caryatid
 //! Stores historical stake pool delegation distributions
 use acropolis_common::caryatid::{PrimaryRead, RollbackWrapper};
+use acropolis_common::configuration::{get_bool_flag, get_string_flag};
 use acropolis_common::declare_cardano_reader;
 use acropolis_common::messages::SPOStakeDistributionMessage;
 use acropolis_common::queries::errors::QueryError;
@@ -73,18 +74,14 @@ impl SPDDState {
         // Get configuration
 
         // REST topic (not included in BF)
-        let handle_spdd_topic = config
-            .get_string(DEFAULT_HANDLE_SPDD_TOPIC.0)
-            .unwrap_or(DEFAULT_HANDLE_SPDD_TOPIC.1.to_string());
+        let handle_spdd_topic = get_string_flag(&config, DEFAULT_HANDLE_SPDD_TOPIC);
         info!("Creating request handler on '{}'", handle_spdd_topic);
 
         // Query topic
-        let spdd_query_topic = config
-            .get_string(DEFAULT_SPDD_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_SPDD_QUERY_TOPIC.1.to_string());
+        let spdd_query_topic = get_string_flag(&config, DEFAULT_SPDD_QUERY_TOPIC);
         info!("Creating query handler on '{}'", spdd_query_topic);
 
-        let store_spdd = config.get_bool(DEFAULT_STORE_SPDD.0).unwrap_or(DEFAULT_STORE_SPDD.1);
+        let store_spdd = get_bool_flag(&config, DEFAULT_STORE_SPDD);
 
         let history_opt = if store_spdd {
             let history = Arc::new(Mutex::new(StateHistory::<State>::new(

--- a/modules/spo_state/src/spo_state.rs
+++ b/modules/spo_state/src/spo_state.rs
@@ -2,7 +2,7 @@
 //! Accepts certificate events and derives the SPO state in memory
 
 use acropolis_common::caryatid::{PrimaryRead, RollbackWrapper, ValidationContext};
-use acropolis_common::configuration::StartupMode;
+use acropolis_common::configuration::{get_string_flag, StartupMode};
 use acropolis_common::declare_cardano_reader;
 use acropolis_common::messages::{
     EpochActivityMessage, GovernanceProceduresMessage, ProtocolParamsMessage, RawBlockMessage,
@@ -541,35 +541,25 @@ impl SPOState {
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
         // Get configuration
 
-        let clock_tick_subscribe_topic = config
-            .get_string(DEFAULT_CLOCK_TICK_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_CLOCK_TICK_SUBSCRIBE_TOPIC.1.to_string());
+        let clock_tick_subscribe_topic =
+            get_string_flag(&config, DEFAULT_CLOCK_TICK_SUBSCRIBE_TOPIC);
         info!("Creating subscriber on '{clock_tick_subscribe_topic}'");
 
-        let snapshot_topic = config
-            .get_string(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.1.to_string());
+        let snapshot_topic = get_string_flag(&config, DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC);
 
         // Publish Topics
-        let spo_state_publish_topic = config
-            .get_string(DEFAULT_SPO_STATE_PUBLISH_TOPIC.0)
-            .unwrap_or(DEFAULT_SPO_STATE_PUBLISH_TOPIC.1.to_string());
+        let spo_state_publish_topic = get_string_flag(&config, DEFAULT_SPO_STATE_PUBLISH_TOPIC);
         info!("Creating SPO state publisher on '{spo_state_publish_topic}'");
 
-        let pool_registration_updates_publish_topic = config
-            .get_string(DEFAULT_POOL_REGISTRATION_UPDATES_PUBLISH_TOPIC.0)
-            .unwrap_or(DEFAULT_POOL_REGISTRATION_UPDATES_PUBLISH_TOPIC.1.to_string());
+        let pool_registration_updates_publish_topic =
+            get_string_flag(&config, DEFAULT_POOL_REGISTRATION_UPDATES_PUBLISH_TOPIC);
         info!("Creating pool registration updates publisher on '{pool_registration_updates_publish_topic}'");
 
-        let validation_publish_topic = config
-            .get_string(DEFAULT_VALIDATION_PUBLISH_TOPIC.0)
-            .unwrap_or(DEFAULT_VALIDATION_PUBLISH_TOPIC.1.to_string());
+        let validation_publish_topic = get_string_flag(&config, DEFAULT_VALIDATION_PUBLISH_TOPIC);
         info!("Validation outcome topic publisher on '{validation_publish_topic}'");
 
         // query topic
-        let pools_query_topic = config
-            .get_string(DEFAULT_POOLS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_POOLS_QUERY_TOPIC.1.to_string());
+        let pools_query_topic = get_string_flag(&config, DEFAULT_POOLS_QUERY_TOPIC);
         info!("Creating query handler on '{}'", pools_query_topic);
 
         // store config

--- a/modules/stake_delta_filter/src/stake_delta_filter.rs
+++ b/modules/stake_delta_filter/src/stake_delta_filter.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::StartupMode,
+    configuration::{conf_enum, get_bool_flag, get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
         AddressDeltasMessage, CardanoMessage, Message, StateQuery, StateQueryResponse,
@@ -21,7 +21,6 @@ use acropolis_common::{
 use anyhow::{anyhow, bail, Result};
 use caryatid_sdk::{module, Context, Subscription};
 use config::Config;
-use serde::Deserialize;
 use std::{path::Path, sync::Arc};
 use tokio::sync::Mutex;
 use tracing::{error, info, info_span, Instrument};
@@ -64,6 +63,7 @@ const DEFAULT_CACHE_MODE: (&str, CacheMode) = ("cache-mode", CacheMode::Predefin
 const DEFAULT_WRITE_FULL_CACHE: (&str, bool) = ("write-full-cache", false);
 
 /// Network: currently only Main/Test. Parameter is necessary to distinguish caches.
+/// TODO: Read NetworkId from genesis message
 const DEFAULT_NETWORK: (&str, NetworkId) = ("network", NetworkId::Mainnet);
 
 /// Stake Delta Filter module
@@ -105,26 +105,14 @@ impl StakeDeltaFilterParams {
         format!("{:?}", self.network)
     }
 
-    fn conf(config: &Arc<Config>, keydef: (&str, &str)) -> String {
-        config.get_string(keydef.0).unwrap_or(keydef.1.to_string())
-    }
-
-    fn conf_enum<'a, T: Deserialize<'a>>(config: &Arc<Config>, keydef: (&str, T)) -> Result<T> {
-        if config.get_string(keydef.0).is_ok() {
-            config.get::<T>(keydef.0).map_err(|e| anyhow!("cannot parse {} value: {e}", keydef.0))
-        } else {
-            Ok(keydef.1)
-        }
-    }
-
     fn init(cfg: Arc<Config>) -> Result<Arc<Self>> {
         let params = Self {
-            stake_address_delta_topic: Self::conf(&cfg, DEFAULT_STAKE_ADDRESS_DELTA_TOPIC),
-            validation_topic: Self::conf(&cfg, DEFAULT_VALIDATION_TOPIC),
-            cache_dir: Self::conf(&cfg, DEFAULT_CACHE_DIR),
-            cache_mode: Self::conf_enum::<CacheMode>(&cfg, DEFAULT_CACHE_MODE)?,
-            write_full_cache: Self::conf_enum::<bool>(&cfg, DEFAULT_WRITE_FULL_CACHE)?,
-            network: Self::conf_enum::<NetworkId>(&cfg, DEFAULT_NETWORK)?,
+            stake_address_delta_topic: get_string_flag(&cfg, DEFAULT_STAKE_ADDRESS_DELTA_TOPIC),
+            validation_topic: get_string_flag(&cfg, DEFAULT_VALIDATION_TOPIC),
+            cache_dir: get_string_flag(&cfg, DEFAULT_CACHE_DIR),
+            cache_mode: conf_enum::<CacheMode>(&cfg, DEFAULT_CACHE_MODE)?,
+            write_full_cache: get_bool_flag(&cfg, DEFAULT_WRITE_FULL_CACHE),
+            network: conf_enum::<NetworkId>(&cfg, DEFAULT_NETWORK)?,
         };
 
         info!("Cache mode {:?}", params.cache_mode);

--- a/modules/stats/src/stats.rs
+++ b/modules/stats/src/stats.rs
@@ -1,4 +1,4 @@
-use acropolis_common::messages::Message;
+use acropolis_common::{configuration::get_string_flag, messages::Message};
 use anyhow::Result;
 use caryatid_sdk::{module, Context};
 use config::Config;
@@ -13,9 +13,8 @@ pub struct Stats;
 
 impl Stats {
     pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        let clock_tick_subscribe_topic = config
-            .get_string(DEFAULT_CLOCK_TICK_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_CLOCK_TICK_SUBSCRIBE_TOPIC.1.to_string());
+        let clock_tick_subscribe_topic =
+            get_string_flag(&config, DEFAULT_CLOCK_TICK_SUBSCRIBE_TOPIC);
         info!("Creating subscriber on '{clock_tick_subscribe_topic}'");
         let mut clock_tick_subscription = context.subscribe(&clock_tick_subscribe_topic).await?;
         context.run(async move {

--- a/modules/tx_submitter/src/tx_submitter.rs
+++ b/modules/tx_submitter/src/tx_submitter.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use acropolis_common::{
     commands::transactions::{TransactionsCommand, TransactionsCommandResponse},
+    configuration::{get_string_flag, get_u64_flag},
     messages::{Command, CommandResponse, Message},
 };
 use anyhow::{Context as _, Result, bail};
@@ -16,6 +17,10 @@ use tokio::sync::RwLock;
 use tracing::warn;
 
 use crate::{peer::PeerConnection, tx::Transaction};
+
+const DEFAULT_SUBSCRIBE_TOPIC: (&str, &str) = ("subscribe-topic", "cardano.txs.submit");
+// TODO: Read magic number from genesis message
+const DEFAULT_MAGIC_NUMBER: (&str, u64) = ("magic-number", 764824073);
 
 #[module(
     message_type(Message),
@@ -83,9 +88,8 @@ struct SubmitterConfig {
 }
 impl SubmitterConfig {
     pub fn parse(config: &Config) -> Result<Self> {
-        let subscribe_topic =
-            config.get_string("subscribe-topic").unwrap_or("cardano.txs.submit".to_string());
-        let magic = config.get("magic-number").unwrap_or(764824073);
+        let subscribe_topic = get_string_flag(config, DEFAULT_SUBSCRIBE_TOPIC);
+        let magic = get_u64_flag(config, DEFAULT_MAGIC_NUMBER);
         Ok(Self {
             subscribe_topic,
             magic,

--- a/modules/tx_unpacker/src/tx_unpacker.rs
+++ b/modules/tx_unpacker/src/tx_unpacker.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use crate::state::State;
 use acropolis_common::{
     caryatid::PrimaryRead,
+    configuration::get_string_flag,
     messages::{
         AssetDeltasMessage, CardanoMessage, GovernanceProceduresMessage, Message,
         StateTransitionMessage, TxCertificatesMessage, UTXODeltasMessage, WithdrawalsMessage,
@@ -33,7 +34,8 @@ const DEFAULT_TRANSACTIONS_SUBSCRIBE_TOPIC: (&str, &str) =
     ("transactions-subscribe-topic", "cardano.txs");
 
 const CIP25_METADATA_LABEL: u64 = 721;
-const DEFAULT_NETWORK_NAME: &str = "mainnet";
+// TODO: Read network name from genesis message
+const DEFAULT_NETWORK_NAME: (&str, &str) = ("startup.network-name", "mainnet");
 
 /// Tx unpacker module
 /// Parameterised by the outer message enum used on the bus
@@ -417,9 +419,8 @@ impl TxUnpacker {
         let publish_tx_validation_topic = config.get_string("publish-tx-validation-topic").ok();
 
         // Main transaction subscriber
-        let transactions_subscribe_topic = config
-            .get_string(DEFAULT_TRANSACTIONS_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_TRANSACTIONS_SUBSCRIBE_TOPIC.1.to_string());
+        let transactions_subscribe_topic =
+            get_string_flag(&config, DEFAULT_TRANSACTIONS_SUBSCRIBE_TOPIC);
         info!("Creating subscriber on '{transactions_subscribe_topic}'");
         let txs_sub = context.subscribe(&transactions_subscribe_topic).await?;
 
@@ -444,11 +445,7 @@ impl TxUnpacker {
             None => None,
         };
 
-        let network_id = match config
-            .get_string("startup.network-name")
-            .unwrap_or(DEFAULT_NETWORK_NAME.to_string())
-            .as_ref()
-        {
+        let network_id = match get_string_flag(&config, DEFAULT_NETWORK_NAME).as_ref() {
             "mainnet" => NetworkId::Mainnet,
             _ => NetworkId::Testnet,
         };

--- a/modules/utxo_state/src/utxo_state.rs
+++ b/modules/utxo_state/src/utxo_state.rs
@@ -3,7 +3,7 @@
 
 use acropolis_common::{
     caryatid::{RollbackAwarePublisher, RollbackWrapper, ValidationContext},
-    configuration::StartupMode,
+    configuration::{get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
         CardanoMessage, Message, PoolRegistrationUpdatesMessage, ProtocolParamsMessage,
@@ -79,12 +79,12 @@ declare_cardano_reader!(
     PoolRegistrationUpdatesMessage
 );
 
-const DEFAULT_STORE: &str = "memory";
+const DEFAULT_STORE: (&str, &str) = ("store", "memory");
 const DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC: (&str, &str) =
     ("snapshot-subscribe-topic", "cardano.snapshot");
 const DEFAULT_UTXO_VALIDATION_TOPIC: (&str, &str) =
     ("utxo-validation-publish-topic", "cardano.validation.utxo");
-const DEFAULT_ADDRESS_DELTA_PUBLISH_MODE: &str = "compact";
+const DEFAULT_ADDRESS_DELTA_PUBLISH_MODE: (&str, &str) = ("address-delta-publish-mode", "compact");
 
 pub(crate) async fn publish_observer_message(
     publisher: &Option<Mutex<RollbackAwarePublisher<Message>>>,
@@ -269,24 +269,17 @@ impl UTXOState {
         let utxo_deltas_reader = UTxODeltasReader::new(&context, &config).await?;
         let params_reader = ParamsReader::new(&context, &config).await?;
 
-        let snapshot_topic = config
-            .get_string(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.0)
-            .unwrap_or(DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC.1.to_string());
+        let snapshot_topic = get_string_flag(&config, DEFAULT_SNAPSHOT_SUBSCRIBE_TOPIC);
         info!("Creating snapshot subscriber on '{snapshot_topic}'");
 
-        let utxos_query_topic = config
-            .get_string(DEFAULT_UTXOS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_UTXOS_QUERY_TOPIC.1.to_string());
+        let utxos_query_topic = get_string_flag(&config, DEFAULT_UTXOS_QUERY_TOPIC);
 
-        let utxo_validation_publish_topic = config
-            .get_string(DEFAULT_UTXO_VALIDATION_TOPIC.0)
-            .unwrap_or(DEFAULT_UTXO_VALIDATION_TOPIC.1.to_string());
+        let utxo_validation_publish_topic = get_string_flag(&config, DEFAULT_UTXO_VALIDATION_TOPIC);
         info!("Creating UTxO validation publisher on '{utxo_validation_publish_topic}'");
 
-        let address_delta_publish_mode = config
-            .get_string("address-delta-publish-mode")
-            .unwrap_or_else(|_| DEFAULT_ADDRESS_DELTA_PUBLISH_MODE.to_string())
-            .parse::<AddressDeltaPublishMode>()?;
+        let address_delta_publish_mode =
+            get_string_flag(&config, DEFAULT_ADDRESS_DELTA_PUBLISH_MODE)
+                .parse::<AddressDeltaPublishMode>()?;
         info!(
             mode = ?address_delta_publish_mode,
             "Address delta publish mode"
@@ -295,7 +288,7 @@ impl UTXOState {
         let is_snapshot_mode = StartupMode::from_config(config.as_ref()).is_snapshot();
 
         // Create store
-        let store_type = config.get_string("store").unwrap_or(DEFAULT_STORE.to_string());
+        let store_type = get_string_flag(&config, DEFAULT_STORE);
         let store: Arc<dyn ImmutableUTXOStore> = match store_type.as_str() {
             "memory" => Arc::new(InMemoryImmutableUTXOStore::new(config.clone())),
             "dashmap" => Arc::new(DashMapImmutableUTXOStore::new(config.clone())),


### PR DESCRIPTION
## Description

This PR standardizes all modules on the common config helpers, making the modules initialization easier to follow and removes duplicated module specific helpers. 

## Related Issue(s)
Completes #92

## How was this tested?
* Verified that sync continues as expected

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
N/A

## Reviewer notes / Areas to focus
N/A
