### PR TITLE
Prevent build failures by removing cache action from the omnibus bootstrap action

### DIFF
--- a/.github/workflows/run-omnibus-bootstap-test.yml
+++ b/.github/workflows/run-omnibus-bootstap-test.yml
@@ -26,16 +26,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: set up cache
-        uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            target/
-          key: ${{ runner.os }}-${{ github.workflow }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Build release version of omnibus process
         run: make build-release
 


### PR DESCRIPTION
## Description

The cache step has been removed from the omnibus bootstrap workflow.

Due to the way the `parameters_state` module is built - fetching genesis files from the internet - a successful cache hit from the github action caused a build failure for the omnibus process as the genesis files are not included in the cache.

## Related Issue(s)
Fixes #867 

## How was this tested?
Manually tested by reproducing the state of the system as it would be when running under github actions, also tested in CI/CD - https://github.com/input-output-hk/acropolis/actions/runs/24237526520.

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
The build stage of the omnibus bootstrap workflow should no longer fail due to missing genesis files.

## Reviewer notes / Areas to focus
Caching of `modules/parameters_state/downloads` was considered but discounted.  Doing a full, non-cached build of the software is a reasonable thing to do within this workflow.
