### PR TITLE
refactor: cache tx info before plutus script evaluation

### DIFF
--- a/modules/utxo_state/src/validations/phase_two/evaluate.rs
+++ b/modules/utxo_state/src/validations/phase_two/evaluate.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::collections::VecDeque;
 use std::mem::ManuallyDrop;
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
@@ -10,6 +11,7 @@ use acropolis_common::{
 };
 use rayon::prelude::*;
 use rayon::ThreadPool;
+use uplc_turbo::data::PlutusData;
 use uplc_turbo::{
     arena::Arena,
     binder::DeBruijn,
@@ -18,6 +20,9 @@ use uplc_turbo::{
     machine::{ExBudget, PlutusVersion},
     term::Term,
 };
+
+use crate::validations::phase_two::script_context::encode_tx_info;
+use crate::validations::phase_two::TxInfo;
 
 use super::script_context::ScriptContext;
 
@@ -223,6 +228,7 @@ pub fn build_scripts_table(
 ///
 /// If `is_valid` is false, scripts are expected to fail (per Alonzo spec).
 pub fn evaluate_scripts(
+    tx_info: &TxInfo,
     script_contexts: &[ScriptContext<'_>],
     scripts_table: &HashMap<ScriptHash, Arc<ReferenceScript>>,
     cost_models: &CostModels,
@@ -232,11 +238,29 @@ pub fn evaluate_scripts(
         return Ok(());
     }
 
+    let plutus_versions = script_contexts
+        .iter()
+        .filter_map(|sc| match sc.script_lang {
+            ScriptLang::Plutus(v) => Some(v),
+            ScriptLang::Native => None,
+        })
+        .collect::<HashSet<_>>();
+
+    // encode tx info first in parallel
+    let mut cached_tx_info_pd = HashMap::new();
+    let arena_for_tx_info = Arena::from_bump(Bump::with_capacity(ARENA_INITIAL_CAPACITY));
+    plutus_versions.iter().for_each(|common_version| {
+        let version = from_common_version(*common_version);
+        if let Ok(tx_info_pd) = encode_tx_info(tx_info, &arena_for_tx_info, version) {
+            cached_tx_info_pd.insert(*common_version, tx_info_pd);
+        }
+    });
+
     // Run all script evaluations in parallel on the evaluator thread pool
     let script_result: Result<(), Phase2ValidationError> = evaluator_pool().install(|| {
         script_contexts.par_iter().try_for_each(|sc| {
             let arena = arena_pool().acquire();
-            evaluate_single_script(&arena, sc, scripts_table, cost_models)
+            evaluate_single_script(&arena, sc, &cached_tx_info_pd, scripts_table, cost_models)
         })
     });
 
@@ -255,6 +279,7 @@ pub fn evaluate_scripts(
 fn evaluate_single_script(
     arena: &Arena,
     sc: &ScriptContext<'_>,
+    cached_tx_info_pd: &HashMap<acropolis_common::PlutusVersion, &PlutusData<'_>>,
     scripts_table: &HashMap<ScriptHash, Arc<ReferenceScript>>,
     cost_models: &CostModels,
 ) -> Result<(), Phase2ValidationError> {
@@ -264,9 +289,12 @@ fn evaluate_single_script(
     };
     let plutus_version = from_common_version(common_plutus_version);
 
+    // Get cached encoded tx info plutus data if exists
+    let tx_info_pd = cached_tx_info_pd.get(&common_plutus_version).copied();
+
     // 1. Build script arguments
     let args = sc
-        .to_script_args(arena, plutus_version)
+        .to_script_args(tx_info_pd, arena, plutus_version)
         .map_err(Phase2ValidationError::ScriptContextError)?;
 
     // 2. Look up script bytes
@@ -469,6 +497,7 @@ mod tests {
         let cost_models = ctx.protocol_params.cost_models();
 
         evaluate_scripts(
+            &tx_info,
             &script_contexts,
             &scripts_table,
             &cost_models,
@@ -505,6 +534,7 @@ mod tests {
         let cost_models = ctx.protocol_params.cost_models();
 
         let result = evaluate_scripts(
+            &tx_info,
             &script_contexts,
             &empty_table,
             &cost_models,

--- a/modules/utxo_state/src/validations/phase_two/mod.rs
+++ b/modules/utxo_state/src/validations/phase_two/mod.rs
@@ -44,6 +44,7 @@ pub fn validate_tx_phase_two(
     let script_contexts = build_script_contexts(&tx_info, scripts_needed, scripts_provided)?;
 
     evaluate_scripts(
+        &tx_info,
         &script_contexts,
         &scripts_table,
         cost_models,

--- a/modules/utxo_state/src/validations/phase_two/script_context.rs
+++ b/modules/utxo_state/src/validations/phase_two/script_context.rs
@@ -251,10 +251,14 @@ impl ScriptContext<'_> {
     /// V3: `[script_context]`
     pub fn to_script_args<'a>(
         &self,
+        tx_info_pd: Option<&'a PlutusData<'a>>,
         arena: &'a Arena,
         version: PlutusVersion,
     ) -> Result<Vec<&'a PlutusData<'a>>, ScriptContextError> {
-        let tx_info_pd = encode_tx_info(self.tx_info, arena, version)?;
+        let tx_info_pd = match tx_info_pd {
+            Some(pd) => pd,
+            None => encode_tx_info(self.tx_info, arena, version)?,
+        };
 
         match version {
             PlutusVersion::V1 | PlutusVersion::V2 => {
@@ -284,7 +288,7 @@ impl ScriptContext<'_> {
 // TxInfo encoding
 // ============================================================================
 
-fn encode_tx_info<'a>(
+pub fn encode_tx_info<'a>(
     tx_info: &TxInfo,
     arena: &'a Arena,
     version: PlutusVersion,
@@ -782,7 +786,7 @@ mod tests {
         let sc = &contexts[0];
 
         let arena = Arena::new();
-        let args = sc.to_script_args(&arena, PlutusVersion::V1).unwrap();
+        let args = sc.to_script_args(None, &arena, PlutusVersion::V1).unwrap();
 
         // V1 spending: [datum, redeemer, context]
         assert_eq!(args.len(), 3, "V1 spending should produce 3 args");


### PR DESCRIPTION
## Description

This PR caches `TxInfo` encoding before plutus script evaluation, 
so if transaction has several smart contracts, they can refer cached TxInfo.

## Related Issue(s)
None

## How was this tested?
Existing test cases passed

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
Improve plutus script evaluation a bit.

## Reviewer notes / Areas to focus
`evaluate_scripts` from ` modules/utxo_state/src/validations/phase_two/evaluate.rs`
