### PR TITLE
refactor: cleanup stake_delta_filter and read network from genesis message

### DIFF
--- a/common/src/genesis_values.rs
+++ b/common/src/genesis_values.rs
@@ -6,7 +6,7 @@ use crate::{
         slot_to_timestamp_with_params,
     },
     hash::Hash,
-    GenesisDelegates, MagicNumber, Pots,
+    GenesisDelegates, MagicNumber, NetworkId, Pots,
 };
 const MAINNET_SHELLEY_GENESIS_HASH: &str =
     "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81";
@@ -25,6 +25,13 @@ pub struct GenesisValues {
 }
 
 impl GenesisValues {
+    pub fn network_id(&self) -> NetworkId {
+        match self.magic_number {
+            MagicNumber(764824073) => NetworkId::Mainnet,
+            _ => NetworkId::Testnet,
+        }
+    }
+
     pub fn mainnet() -> Self {
         Self {
             byron_timestamp: 1506203091,

--- a/common/src/types.rs
+++ b/common/src/types.rs
@@ -1629,7 +1629,7 @@ pub struct ProtocolConsts {
 }
 
 #[derive(Debug, Default, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-pub struct MagicNumber(u32);
+pub struct MagicNumber(pub u32);
 
 impl MagicNumber {
     pub fn new(value: u32) -> Self {

--- a/modules/chain_store/src/chain_store.rs
+++ b/modules/chain_store/src/chain_store.rs
@@ -5,7 +5,9 @@ use crate::state::State;
 use crate::stores::{fjall::FjallStore, Store};
 
 use acropolis_common::configuration::get_string_flag;
+use acropolis_common::messages::GenesisCompleteMessage;
 use acropolis_common::queries::errors::QueryError;
+use acropolis_common::NetworkId;
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
     declare_cardano_reader,
@@ -16,14 +18,13 @@ use acropolis_common::{
     queries::blocks::{BlocksStateQueryResponse, DEFAULT_BLOCKS_QUERY_TOPIC},
     queries::transactions::{TransactionsStateQueryResponse, DEFAULT_TRANSACTIONS_QUERY_TOPIC},
     state_history::{StateHistory, StateHistoryStore},
-    NetworkId,
 };
 use anyhow::{bail, Result};
 use caryatid_sdk::message_bus::Subscription;
 use caryatid_sdk::{module, Context};
 use config::Config;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tracing::info;
 
 mod helpers;
@@ -49,6 +50,13 @@ declare_cardano_reader!(
     ProtocolParams,
     ProtocolParamsMessage
 );
+declare_cardano_reader!(
+    GenesisReader,
+    "genesis-subscribe-topic",
+    "cardano.sequence.bootstrapped",
+    GenesisComplete,
+    GenesisCompleteMessage
+);
 
 #[module(
     message_type(Message),
@@ -64,8 +72,8 @@ impl ChainStore {
         let validation_topic = get_string_flag(&config, DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC);
         info!("Publishing validation outcomes on '{validation_topic}'");
 
-        let network_id: NetworkId =
-            config.get_string("network-id").unwrap_or("mainnet".to_string()).into();
+        // Network ID is set from the GenesisValues (Wrapped in Arc<RwLock<>> to share with txs query handler)
+        let network_id: Arc<RwLock<Option<NetworkId>>> = Arc::new(RwLock::new(None));
 
         let store_type = get_string_flag(&config, DEFAULT_STORE);
         let store: Arc<dyn Store> = match store_type.as_str() {
@@ -107,9 +115,10 @@ impl ChainStore {
         });
 
         let query_store = store.clone();
+        let network_id_for_txs = network_id.clone();
         context.handle(&txs_queries_topic, move |req| {
             let query_store = query_store.clone();
-            let network_id = network_id.clone();
+            let network_id = network_id_for_txs.clone();
             async move {
                 let Message::StateQuery(StateQuery::Transactions(query)) = req.as_ref() else {
                     return Arc::new(Message::StateQueryResponse(
@@ -118,7 +127,24 @@ impl ChainStore {
                         )),
                     ));
                 };
-                let res = handle_txs_query(&query_store, query, network_id).unwrap_or_else(|err| {
+
+                let network = {
+                    let guard = network_id.read().await;
+                    match &*guard {
+                        Some(n) => n.clone(),
+                        None => {
+                            return Arc::new(Message::StateQueryResponse(
+                                StateQueryResponse::Transactions(
+                                    TransactionsStateQueryResponse::Error(
+                                        QueryError::internal_error("network not initialized"),
+                                    ),
+                                ),
+                            ));
+                        }
+                    }
+                };
+
+                let res = handle_txs_query(&query_store, query, network).unwrap_or_else(|err| {
                     TransactionsStateQueryResponse::Error(QueryError::internal_error(
                         err.to_string(),
                     ))
@@ -131,9 +157,26 @@ impl ChainStore {
 
         let mut params_reader = ParamsReader::new(&context, &config).await?;
         let mut blocks_reader = BlocksReader::new(&context, &config).await?;
+        let mut genesis_reader = GenesisReader::new(&context, &config).await?;
         let run_ctx = context.clone();
 
         context.run::<Result<(), anyhow::Error>, _>(async move {
+            match genesis_reader.read_with_rollbacks().await? {
+                RollbackWrapper::Normal((_, genesis)) => {
+                    let mut guard = network_id.write().await;
+
+                    if let Some(existing) = guard.as_ref() {
+                        if *existing != genesis.values.network_id() {
+                            panic!("NetworkId mismatch");
+                        }
+                    } else {
+                        *guard = Some(genesis.values.network_id());
+                    }
+                }
+                RollbackWrapper::Rollback(_) => {
+                    bail!("Unexpected rollback while reading genesis values");
+                }
+            }
             match blocks_reader.read_with_rollbacks().await? {
                 RollbackWrapper::Normal((block_info, block)) => {
                     if let Err(err) =

--- a/modules/stake_delta_filter/src/configuration.rs
+++ b/modules/stake_delta_filter/src/configuration.rs
@@ -1,0 +1,79 @@
+use anyhow::{anyhow, Result};
+use config::Config;
+use std::{path::Path, sync::Arc};
+use tracing::info;
+
+use acropolis_common::{
+    configuration::{conf_enum, get_bool_flag, get_string_flag, StartupMode},
+    NetworkId,
+};
+
+use crate::utils::CacheMode;
+
+const DEFAULT_STAKE_ADDRESS_DELTA_TOPIC: (&str, &str) =
+    ("publishing-stake-delta-topic", "cardano.stake.deltas");
+const DEFAULT_VALIDATION_TOPIC: (&str, &str) = (
+    "publishing-validation-topic",
+    "cardano.validation.stake.filter",
+);
+/// Directory to put cached shelley address pointers into. Depending on the address
+/// cache mode, these cached pointers can be used instead of tracking current pointer
+/// values in blockchain (which can be quite resource-consuming).
+const DEFAULT_CACHE_DIR: (&str, &str) = ("cache-dir", "cache");
+
+/// Cache mode: use built-in; always build cache; always read cache (error if missing);
+/// build if missing, read otherwise.
+const DEFAULT_CACHE_MODE: (&str, CacheMode) = ("cache-mode", CacheMode::Predefined);
+
+/// Cache remembers all stake addresses that could potentially be referenced by pointers. However
+/// only a few addressed are actually referenced by pointers in real blockchain.
+/// `true` means that all possible addresses should be written to disk (as potential pointers).
+/// `false` means that only addresses used in actual pointers should be written to disk.
+const DEFAULT_WRITE_FULL_CACHE: (&str, bool) = ("write-full-cache", false);
+
+#[derive(Clone, Debug, Default)]
+pub struct StakeDeltaFilterParams {
+    pub stake_address_delta_topic: String,
+    pub validation_topic: String,
+
+    pub cache_dir: String,
+    pub cache_mode: CacheMode,
+    pub write_full_cache: bool,
+    pub is_snapshot_mode: bool,
+}
+
+impl StakeDeltaFilterParams {
+    pub fn get_cache_file_name(&self, modifier: &str, network: &NetworkId) -> Result<String> {
+        let path = Path::new(&self.cache_dir);
+        let full = path.join(format!("{:?}{}", network, modifier).to_lowercase());
+        let str =
+            full.to_str().ok_or_else(|| anyhow!("Cannot produce cache file name".to_string()))?;
+        Ok(str.to_string())
+    }
+
+    pub fn init(cfg: Arc<Config>) -> Result<Arc<Self>> {
+        let params = Self {
+            stake_address_delta_topic: get_string_flag(&cfg, DEFAULT_STAKE_ADDRESS_DELTA_TOPIC),
+            validation_topic: get_string_flag(&cfg, DEFAULT_VALIDATION_TOPIC),
+            cache_dir: get_string_flag(&cfg, DEFAULT_CACHE_DIR),
+            cache_mode: conf_enum::<CacheMode>(&cfg, DEFAULT_CACHE_MODE)?,
+            write_full_cache: get_bool_flag(&cfg, DEFAULT_WRITE_FULL_CACHE),
+            is_snapshot_mode: StartupMode::from_config(cfg.as_ref()).is_snapshot(),
+        };
+
+        info!("Cache mode {:?}", params.cache_mode);
+        if params.cache_mode == CacheMode::Read {
+            if !Path::new(&params.cache_dir).try_exists()? {
+                return Err(anyhow!(
+                    "Pointer cache directory '{}' does not exist.",
+                    params.cache_dir
+                ));
+            }
+            info!("Reading (writing) caches from (to) {}", params.cache_dir);
+        } else if params.cache_mode != CacheMode::Predefined {
+            std::fs::create_dir_all(&params.cache_dir)?;
+        }
+
+        Ok(Arc::new(params))
+    }
+}

--- a/modules/stake_delta_filter/src/queries.rs
+++ b/modules/stake_delta_filter/src/queries.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+
+use acropolis_common::{
+    configuration::get_string_flag,
+    messages::{Message, StateQuery, StateQueryResponse},
+    queries::{
+        errors::QueryError,
+        stake_deltas::{
+            StakeDeltaQuery, StakeDeltaQueryResponse, DEFAULT_STAKE_DELTAS_QUERY_TOPIC,
+        },
+    },
+    state_history::StateHistory,
+};
+use caryatid_sdk::Context;
+use config::Config;
+use tokio::sync::Mutex;
+use tracing::info;
+
+use crate::{state::State, utils::PointerCache};
+
+/// Register a query handler that resolves pointer addresses using the given cache.
+pub fn register_query_handler(
+    context: &Arc<Context<Message>>,
+    config: &Arc<Config>,
+    cache: Arc<PointerCache>,
+) {
+    let query_topic = config
+        .get_string(DEFAULT_STAKE_DELTAS_QUERY_TOPIC.0)
+        .unwrap_or(DEFAULT_STAKE_DELTAS_QUERY_TOPIC.1.to_string());
+    info!("Registering query handler on '{query_topic}'");
+
+    context.handle(&query_topic, move |message| {
+        let cache = cache.clone();
+        async move {
+            let Message::StateQuery(StateQuery::StakeDeltas(query)) = message.as_ref() else {
+                return Arc::new(Message::StateQueryResponse(
+                    StateQueryResponse::StakeDeltas(StakeDeltaQueryResponse::Error(
+                        QueryError::internal_error("Invalid message for stake-delta-filter"),
+                    )),
+                ));
+            };
+
+            let response = match query {
+                StakeDeltaQuery::ResolvePointers { pointers } => {
+                    let mut resolved = std::collections::HashMap::new();
+                    for ptr in pointers {
+                        if let Some(Some(stake_addr)) = cache.decode_pointer(ptr) {
+                            resolved.insert(ptr.clone(), stake_addr.clone());
+                        }
+                    }
+                    StakeDeltaQueryResponse::ResolvedPointers(resolved)
+                }
+            };
+
+            Arc::new(Message::StateQueryResponse(
+                StateQueryResponse::StakeDeltas(response),
+            ))
+        }
+    });
+}
+
+/// Register a query handler for stateful mode, where the cache is behind a Mutex.
+pub fn register_query_handler_stateful(
+    context: &Arc<Context<Message>>,
+    config: &Arc<Config>,
+    history: Arc<Mutex<StateHistory<State>>>,
+) {
+    let query_topic = get_string_flag(config, DEFAULT_STAKE_DELTAS_QUERY_TOPIC);
+    info!("Registering stateful query handler on '{query_topic}'");
+
+    context.handle(&query_topic, move |message| {
+        let history = history.clone();
+        async move {
+            let Message::StateQuery(StateQuery::StakeDeltas(query)) = message.as_ref() else {
+                return Arc::new(Message::StateQueryResponse(
+                    StateQueryResponse::StakeDeltas(StakeDeltaQueryResponse::Error(
+                        QueryError::internal_error("Invalid message for stake-delta-filter"),
+                    )),
+                ));
+            };
+
+            let locked = history.lock().await;
+            let state = match locked.current() {
+                Some(state) => state,
+                None => {
+                    return Arc::new(Message::StateQueryResponse(
+                        StateQueryResponse::StakeDeltas(StakeDeltaQueryResponse::Error(
+                            QueryError::internal_error("Invalid message for stake-delta-filter"),
+                        )),
+                    ))
+                }
+            };
+
+            let response = match query {
+                StakeDeltaQuery::ResolvePointers { pointers } => {
+                    let mut resolved = std::collections::HashMap::new();
+                    for ptr in pointers {
+                        if let Some(Some(stake_addr)) = state.pointer_cache.decode_pointer(ptr) {
+                            resolved.insert(ptr.clone(), stake_addr.clone());
+                        }
+                    }
+                    StakeDeltaQueryResponse::ResolvedPointers(resolved)
+                }
+            };
+
+            Arc::new(Message::StateQueryResponse(
+                StateQueryResponse::StakeDeltas(response),
+            ))
+        }
+    });
+}

--- a/modules/stake_delta_filter/src/stake_delta_filter.rs
+++ b/modules/stake_delta_filter/src/stake_delta_filter.rs
@@ -3,27 +3,20 @@
 
 use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
-    configuration::{conf_enum, get_bool_flag, get_string_flag, StartupMode},
     declare_cardano_reader,
     messages::{
-        AddressDeltasMessage, CardanoMessage, Message, StateQuery, StateQueryResponse,
+        AddressDeltasMessage, CardanoMessage, GenesisCompleteMessage, Message,
         StateTransitionMessage, TxCertificatesMessage,
-    },
-    queries::{
-        errors::QueryError,
-        stake_deltas::{
-            StakeDeltaQuery, StakeDeltaQueryResponse, DEFAULT_STAKE_DELTAS_QUERY_TOPIC,
-        },
     },
     state_history::{StateHistory, StateHistoryStore},
     NetworkId,
 };
-use anyhow::{anyhow, bail, Result};
+use anyhow::{bail, Result};
 use caryatid_sdk::{module, Context, Subscription};
 use config::Config;
-use std::{path::Path, sync::Arc};
+use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, info_span, Instrument};
+use tracing::{error, info};
 
 declare_cardano_reader!(
     AddressDeltasReader,
@@ -39,32 +32,13 @@ declare_cardano_reader!(
     TxCertificates,
     TxCertificatesMessage
 );
-
-const DEFAULT_STAKE_ADDRESS_DELTA_TOPIC: (&str, &str) =
-    ("publishing-stake-delta-topic", "cardano.stake.deltas");
-const DEFAULT_VALIDATION_TOPIC: (&str, &str) = (
-    "publishing-validation-topic",
-    "cardano.validation.stake.filter",
+declare_cardano_reader!(
+    GenesisReader,
+    "genesis-subscribe-topic",
+    "cardano.sequence.bootstrapped",
+    GenesisComplete,
+    GenesisCompleteMessage
 );
-
-/// Directory to put cached shelley address pointers into. Depending on the address
-/// cache mode, these cached pointers can be used instead of tracking current pointer
-/// values in blockchain (which can be quite resource-consuming).
-const DEFAULT_CACHE_DIR: (&str, &str) = ("cache-dir", "cache");
-
-/// Cache mode: use built-in; always build cache; always read cache (error if missing);
-/// build if missing, read otherwise.
-const DEFAULT_CACHE_MODE: (&str, CacheMode) = ("cache-mode", CacheMode::Predefined);
-
-/// Cache remembers all stake addresses that could potentially be referenced by pointers. However
-/// only a few addressed are actually referenced by pointers in real blockchain.
-/// `true` means that all possible addresses should be written to disk (as potential pointers).
-/// `false` means that only addresses used in actual pointers should be written to disk.
-const DEFAULT_WRITE_FULL_CACHE: (&str, bool) = ("write-full-cache", false);
-
-/// Network: currently only Main/Test. Parameter is necessary to distinguish caches.
-/// TODO: Read NetworkId from genesis message
-const DEFAULT_NETWORK: (&str, NetworkId) = ("network", NetworkId::Mainnet);
 
 /// Stake Delta Filter module
 #[module(
@@ -74,195 +48,147 @@ const DEFAULT_NETWORK: (&str, NetworkId) = ("network", NetworkId::Mainnet);
 )]
 pub struct StakeDeltaFilter;
 
+mod configuration;
 mod predefined;
+mod queries;
 mod state;
 mod utils;
 
 use state::{DeltaPublisher, State};
 use utils::{process_message, CacheMode, PointerCache, Tracker};
 
-#[derive(Clone, Debug, Default)]
-struct StakeDeltaFilterParams {
-    stake_address_delta_topic: String,
-    validation_topic: String,
-    network: NetworkId,
-
-    cache_dir: String,
-    cache_mode: CacheMode,
-    write_full_cache: bool,
-}
-
-impl StakeDeltaFilterParams {
-    fn get_cache_file_name(&self, modifier: &str) -> Result<String> {
-        let path = Path::new(&self.cache_dir);
-        let full = path.join(format!("{}{}", self.get_network_name(), modifier).to_lowercase());
-        let str =
-            full.to_str().ok_or_else(|| anyhow!("Cannot produce cache file name".to_string()))?;
-        Ok(str.to_string())
-    }
-
-    fn get_network_name(&self) -> String {
-        format!("{:?}", self.network)
-    }
-
-    fn init(cfg: Arc<Config>) -> Result<Arc<Self>> {
-        let params = Self {
-            stake_address_delta_topic: get_string_flag(&cfg, DEFAULT_STAKE_ADDRESS_DELTA_TOPIC),
-            validation_topic: get_string_flag(&cfg, DEFAULT_VALIDATION_TOPIC),
-            cache_dir: get_string_flag(&cfg, DEFAULT_CACHE_DIR),
-            cache_mode: conf_enum::<CacheMode>(&cfg, DEFAULT_CACHE_MODE)?,
-            write_full_cache: get_bool_flag(&cfg, DEFAULT_WRITE_FULL_CACHE),
-            network: conf_enum::<NetworkId>(&cfg, DEFAULT_NETWORK)?,
-        };
-
-        info!("Cache mode {:?}", params.cache_mode);
-        if params.cache_mode == CacheMode::Read {
-            if !Path::new(&params.cache_dir).try_exists()? {
-                return Err(anyhow!(
-                    "Pointer cache directory '{}' does not exist.",
-                    params.cache_dir
-                ));
-            }
-            info!("Reading (writing) caches from (to) {}", params.cache_dir);
-        } else if params.cache_mode != CacheMode::Predefined {
-            std::fs::create_dir_all(&params.cache_dir)?;
-        }
-
-        Ok(Arc::new(params))
-    }
-}
+use crate::{
+    configuration::StakeDeltaFilterParams,
+    queries::{register_query_handler, register_query_handler_stateful},
+    utils::get_network_name,
+};
 
 impl StakeDeltaFilter {
-    pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
-        let address_delta_reader = AddressDeltasReader::new(&context, &config).await?;
-        let params = StakeDeltaFilterParams::init(config.clone())?;
-        let is_snapshot_mode = StartupMode::from_config(config.as_ref()).is_snapshot();
-        let cache_path = params.get_cache_file_name(".json")?;
-        let publisher = DeltaPublisher::new(context.clone(), params.clone());
+    async fn run(
+        context: Arc<Context<Message>>,
+        mut genesis_reader: GenesisReader,
+        address_delta_reader: AddressDeltasReader,
+        certs_reader: CertsReader,
+        publisher: DeltaPublisher,
+        params: Arc<StakeDeltaFilterParams>,
+    ) -> Result<()> {
+        let network_id = match genesis_reader.read_with_rollbacks().await? {
+            RollbackWrapper::Normal((_, genesis_values)) => genesis_values.values.network_id(),
+            RollbackWrapper::Rollback(_) => {
+                bail!("Unexpected rollback while reading genesis values")
+            }
+        };
 
-        match params.cache_mode {
+        match params.as_ref().cache_mode {
             CacheMode::Predefined => {
-                Self::stateless_init(
-                    PointerCache::try_load_predefined(&params.get_network_name())?,
-                    context,
+                let cache = PointerCache::try_load_predefined(&get_network_name(network_id))?;
+                register_query_handler(&context, &context.config, cache.clone());
+
+                Self::stateless_run(
+                    cache,
                     publisher,
                     address_delta_reader,
-                    is_snapshot_mode,
+                    certs_reader,
+                    params.is_snapshot_mode,
                 )
-                .await
+                .await?;
             }
-
             CacheMode::Read => {
-                Self::stateless_init(
-                    PointerCache::try_load(&cache_path)?,
-                    context,
+                let cache =
+                    PointerCache::try_load(&params.get_cache_file_name(".json", &network_id)?)?;
+                register_query_handler(&context, &context.config, cache.clone());
+
+                Self::stateless_run(
+                    cache,
                     publisher,
                     address_delta_reader,
-                    is_snapshot_mode,
+                    certs_reader,
+                    params.is_snapshot_mode,
                 )
-                .await
+                .await?;
             }
 
-            CacheMode::WriteIfAbsent => match PointerCache::try_load(&cache_path) {
-                Ok(cache) => {
-                    Self::stateless_init(
-                        cache,
-                        context,
-                        publisher,
-                        address_delta_reader,
-                        is_snapshot_mode,
-                    )
-                    .await
-                }
-                Err(e) => {
-                    info!("Cannot load cache: {}, building from scratch", e);
-                    let certs_reader = CertsReader::new(&context, &config).await?;
-                    Self::stateful_init(
-                        params,
-                        context,
-                        certs_reader,
-                        address_delta_reader,
-                        publisher,
-                        is_snapshot_mode,
-                    )
-                    .await
-                }
-            },
+            CacheMode::WriteIfAbsent => {
+                match PointerCache::try_load(&params.get_cache_file_name(".json", &network_id)?) {
+                    Ok(cache) => {
+                        register_query_handler(&context, &context.config, cache.clone());
+
+                        Self::stateless_run(
+                            cache,
+                            publisher,
+                            address_delta_reader,
+                            certs_reader,
+                            params.is_snapshot_mode,
+                        )
+                        .await?;
+                    }
+                    Err(e) => {
+                        info!("Cannot load cache: {}, building from scratch", e);
+                        let history = Arc::new(Mutex::new(StateHistory::<State>::new(
+                            "stake_delta_filter",
+                            StateHistoryStore::default_block_store(),
+                        )));
+                        register_query_handler_stateful(&context, &context.config, history.clone());
+
+                        Self::stateful_run(
+                            history,
+                            certs_reader,
+                            address_delta_reader,
+                            publisher,
+                            network_id,
+                            params,
+                            context,
+                        )
+                        .await?;
+                    }
+                };
+            }
 
             CacheMode::Write => {
-                let certs_reader = CertsReader::new(&context, &config).await?;
-                Self::stateful_init(
-                    params,
-                    context,
+                let history = Arc::new(Mutex::new(StateHistory::<State>::new(
+                    "stake_delta_filter",
+                    StateHistoryStore::default_block_store(),
+                )));
+                register_query_handler_stateful(&context, &context.config, history.clone());
+
+                Self::stateful_run(
+                    history,
                     certs_reader,
                     address_delta_reader,
                     publisher,
-                    is_snapshot_mode,
+                    network_id,
+                    params,
+                    context,
                 )
-                .await
+                .await?;
             }
         }
+
+        Ok(())
     }
 
-    /// Register a query handler that resolves pointer addresses using the given cache.
-    fn register_query_handler(
-        context: &Arc<Context<Message>>,
-        config: &Arc<Config>,
-        cache: Arc<PointerCache>,
-    ) {
-        let query_topic = config
-            .get_string(DEFAULT_STAKE_DELTAS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_STAKE_DELTAS_QUERY_TOPIC.1.to_string());
-        info!("Registering query handler on '{query_topic}'");
+    pub async fn init(&self, context: Arc<Context<Message>>, config: Arc<Config>) -> Result<()> {
+        let genesis_reader = GenesisReader::new(&context, &config).await?;
+        let address_delta_reader = AddressDeltasReader::new(&context, &config).await?;
+        let certs_reader = CertsReader::new(&context, &config).await?;
 
-        context.handle(&query_topic, move |message| {
-            let cache = cache.clone();
-            async move {
-                let Message::StateQuery(StateQuery::StakeDeltas(query)) = message.as_ref() else {
-                    return Arc::new(Message::StateQueryResponse(
-                        StateQueryResponse::StakeDeltas(StakeDeltaQueryResponse::Error(
-                            QueryError::internal_error("Invalid message for stake-delta-filter"),
-                        )),
-                    ));
-                };
+        let params = StakeDeltaFilterParams::init(config.clone())?;
+        let publisher = DeltaPublisher::new(context.clone(), params.clone());
 
-                let response = match query {
-                    StakeDeltaQuery::ResolvePointers { pointers } => {
-                        let mut resolved = std::collections::HashMap::new();
-                        for ptr in pointers {
-                            if let Some(Some(stake_addr)) = cache.decode_pointer(ptr) {
-                                resolved.insert(ptr.clone(), stake_addr.clone());
-                            }
-                        }
-                        StakeDeltaQueryResponse::ResolvedPointers(resolved)
-                    }
-                };
-
-                Arc::new(Message::StateQueryResponse(
-                    StateQueryResponse::StakeDeltas(response),
-                ))
-            }
+        // Start run task
+        let run_ctx = context.clone();
+        context.run(async move {
+            Self::run(
+                run_ctx,
+                genesis_reader,
+                address_delta_reader,
+                certs_reader,
+                publisher,
+                params,
+            )
+            .await
+            .unwrap_or_else(|e| error!("Failed: {e}"));
         });
-    }
-
-    async fn stateless_init(
-        cache: Arc<PointerCache>,
-        context: Arc<Context<Message>>,
-        publisher: DeltaPublisher,
-        address_delta_reader: AddressDeltasReader,
-        is_snapshot_mode: bool,
-    ) -> Result<()> {
-        info!("Stateless init: using stake pointer cache");
-
-        // Register query handler for pointer resolution
-        Self::register_query_handler(&context, &context.config, cache.clone());
-
-        context.clone().run(Self::stateless_run(
-            cache,
-            publisher,
-            address_delta_reader,
-            is_snapshot_mode,
-        ));
 
         Ok(())
     }
@@ -271,6 +197,7 @@ impl StakeDeltaFilter {
         cache: Arc<PointerCache>,
         mut publisher: DeltaPublisher,
         mut address_delta_reader: AddressDeltasReader,
+        mut certs_reader: CertsReader,
         is_snapshot_mode: bool,
     ) -> Result<()> {
         if !is_snapshot_mode {
@@ -283,6 +210,9 @@ impl StakeDeltaFilter {
         }
         loop {
             let primary = PrimaryRead::from_read(address_delta_reader.read_with_rollbacks().await?);
+
+            // Read certs to keep messages aligned
+            certs_reader.read_with_rollbacks().await?;
 
             if let Some(address_deltas) = primary.message() {
                 let msg = process_message(&cache, address_deltas, primary.block_info(), None);
@@ -300,129 +230,16 @@ impl StakeDeltaFilter {
         }
     }
 
-    /// Register a query handler for stateful mode, where the cache is behind a Mutex.
-    fn register_query_handler_stateful(
-        context: &Arc<Context<Message>>,
-        config: &Arc<Config>,
-        history: Arc<Mutex<StateHistory<State>>>,
-    ) {
-        let query_topic = config
-            .get_string(DEFAULT_STAKE_DELTAS_QUERY_TOPIC.0)
-            .unwrap_or(DEFAULT_STAKE_DELTAS_QUERY_TOPIC.1.to_string());
-        info!("Registering stateful query handler on '{query_topic}'");
-
-        context.handle(&query_topic, move |message| {
-            let history = history.clone();
-            async move {
-                let Message::StateQuery(StateQuery::StakeDeltas(query)) = message.as_ref() else {
-                    return Arc::new(Message::StateQueryResponse(
-                        StateQueryResponse::StakeDeltas(StakeDeltaQueryResponse::Error(
-                            QueryError::internal_error("Invalid message for stake-delta-filter"),
-                        )),
-                    ));
-                };
-
-                let locked = history.lock().await;
-                let state = match locked.current() {
-                    Some(state) => state,
-                    None => {
-                        return Arc::new(Message::StateQueryResponse(
-                            StateQueryResponse::StakeDeltas(StakeDeltaQueryResponse::Error(
-                                QueryError::internal_error(
-                                    "Invalid message for stake-delta-filter",
-                                ),
-                            )),
-                        ))
-                    }
-                };
-
-                let response = match query {
-                    StakeDeltaQuery::ResolvePointers { pointers } => {
-                        let mut resolved = std::collections::HashMap::new();
-                        for ptr in pointers {
-                            if let Some(Some(stake_addr)) = state.pointer_cache.decode_pointer(ptr)
-                            {
-                                resolved.insert(ptr.clone(), stake_addr.clone());
-                            }
-                        }
-                        StakeDeltaQueryResponse::ResolvedPointers(resolved)
-                    }
-                };
-
-                Arc::new(Message::StateQueryResponse(
-                    StateQueryResponse::StakeDeltas(response),
-                ))
-            }
-        });
-    }
-
-    async fn stateful_init(
-        params: Arc<StakeDeltaFilterParams>,
-        context: Arc<Context<Message>>,
-        certs_reader: CertsReader,
-        address_deltas_reader: AddressDeltasReader,
-        publisher: DeltaPublisher,
-        is_snapshot_mode: bool,
-    ) -> Result<()> {
-        info!("Stateful init: creating stake pointer cache");
-
-        // State
-        let history = Arc::new(Mutex::new(StateHistory::<State>::new(
-            "stake_delta_filter",
-            StateHistoryStore::default_block_store(),
-        )));
-        let history_tick = history.clone();
-
-        // Register query handler for pointer resolution (stateful)
-        Self::register_query_handler_stateful(&context, &context.config, history.clone());
-
-        let context_run = context.clone();
-        context.run(Self::stateful_run(
-            history,
-            certs_reader,
-            address_deltas_reader,
-            publisher,
-            params,
-            context_run,
-            is_snapshot_mode,
-        ));
-
-        // Ticker to log stats
-        let mut subscription = context.subscribe("clock.tick").await?;
-        context.run(async move {
-            loop {
-                let Ok((_, message)) = subscription.read().await else {
-                    return;
-                };
-                if let Message::Clock(message) = message.as_ref() {
-                    if (message.number % 60) == 0 {
-                        let span = info_span!("stake_delta_filter.tick", number = message.number);
-                        async {
-                            let history = history_tick.lock().await;
-                            if let Some(state) = history.current() {
-                                state.tick().await.inspect_err(|e| error!("Tick error: {e}")).ok();
-                            }
-                        }
-                        .instrument(span)
-                        .await;
-                    }
-                }
-            }
-        });
-
-        Ok(())
-    }
-
     async fn stateful_run(
         history: Arc<Mutex<StateHistory<State>>>,
         mut certs_reader: CertsReader,
         mut address_deltas_reader: AddressDeltasReader,
         mut publisher: DeltaPublisher,
+        network: NetworkId,
         params: Arc<StakeDeltaFilterParams>,
         context: Arc<Context<Message>>,
-        is_snapshot_mode: bool,
     ) -> Result<()> {
-        if !is_snapshot_mode {
+        if !params.is_snapshot_mode {
             match address_deltas_reader.read_with_rollbacks().await? {
                 RollbackWrapper::Normal(_) => {}
                 RollbackWrapper::Rollback(_) => {
@@ -469,7 +286,7 @@ impl StakeDeltaFilter {
 
             if primary.message().is_some() {
                 let block_info = primary.block_info();
-                state.save()?;
+                state.save(&network)?;
                 history.lock().await.commit(block_info.number, state);
 
                 if primary.do_validation() {

--- a/modules/stake_delta_filter/src/state.rs
+++ b/modules/stake_delta_filter/src/state.rs
@@ -3,6 +3,7 @@
 use crate::StakeDeltaFilterParams;
 use crate::{process_message, PointerCache, Tracker};
 use acropolis_common::caryatid::RollbackAwarePublisher;
+use acropolis_common::NetworkId;
 use acropolis_common::{
     messages::{
         AddressDeltasMessage, CardanoMessage, Message, StakeAddressDeltasMessage,
@@ -15,7 +16,6 @@ use caryatid_sdk::Context;
 use serde_with::serde_as;
 use std::collections::HashMap;
 use std::{fs, io::Write, sync::Arc};
-use tracing::info;
 
 #[allow(dead_code)]
 #[serde_as]
@@ -103,33 +103,21 @@ impl State {
         }
     }
 
-    pub fn info(&self) {
-        info!(
-            "pointer cache size: {}, max slot: {}",
-            self.pointer_cache.pointer_map.len(),
-            self.pointer_cache.max_slot
-        );
-        self.tracker.info();
-    }
-
-    pub fn save(&mut self) -> Result<()> {
+    pub fn save(&mut self, network: &NetworkId) -> Result<()> {
         let used_pointers = self.tracker.get_used_pointers();
 
         if self.params.write_full_cache {
-            self.pointer_cache.try_save(&self.params.get_cache_file_name(".json")?)?;
+            self.pointer_cache.try_save(&self.params.get_cache_file_name(".json", network)?)?;
         } else {
-            self.pointer_cache
-                .try_save_filtered(&self.params.get_cache_file_name("")?, &used_pointers)?;
+            self.pointer_cache.try_save_filtered(
+                &self.params.get_cache_file_name("", network)?,
+                &used_pointers,
+            )?;
         }
 
-        let mut file = fs::File::create(self.params.get_cache_file_name(".track.log")?)?;
+        let mut file = fs::File::create(self.params.get_cache_file_name(".track.log", network)?)?;
         file.write_all(self.tracker.report().as_bytes())?;
 
-        Ok(())
-    }
-
-    pub async fn tick(&self) -> Result<()> {
-        self.info();
         Ok(())
     }
 }

--- a/modules/stake_delta_filter/src/utils.rs
+++ b/modules/stake_delta_filter/src/utils.rs
@@ -1,6 +1,6 @@
 use acropolis_common::{
     messages::{AddressDeltasMessage, StakeAddressDeltasMessage},
-    Address, AddressDelta, BlockInfo, Era, ShelleyAddress, ShelleyAddressDelegationPart,
+    Address, AddressDelta, BlockInfo, Era, NetworkId, ShelleyAddress, ShelleyAddressDelegationPart,
     ShelleyAddressPointer, StakeAddress, StakeAddressDelta, StakeCredential, TxIdentifier,
 };
 use anyhow::{anyhow, Result};
@@ -14,6 +14,10 @@ use std::{
     sync::Arc,
 };
 use tracing::error;
+
+pub fn get_network_name(network: NetworkId) -> String {
+    format!("{:?}", network)
+}
 
 #[serde_as]
 #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
@@ -218,27 +222,6 @@ impl Tracker {
             (true, true) => Some(OccurrenceInfoKind::Mixed),
             _ => None,
         }
-    }
-
-    pub fn info(&self) {
-        let mut valid_ptrs = 0;
-        let mut invalid_ptrs = 0;
-        let mut mixed_ptrs = 0;
-        for (_k, v) in self.occurrence.iter() {
-            if let Some(kind) = Self::get_kind(v) {
-                match kind {
-                    OccurrenceInfoKind::Valid => valid_ptrs += 1,
-                    OccurrenceInfoKind::Invalid => invalid_ptrs += 1,
-                    OccurrenceInfoKind::Mixed => mixed_ptrs += 1,
-                }
-            }
-        }
-        tracing::info!(
-            "Pointers dereferencing stats: valid {}, invalid {}, mixed {}",
-            valid_ptrs,
-            invalid_ptrs,
-            mixed_ptrs
-        )
     }
 
     fn join_hash_set(hs: HashSet<String>, mid: &str) -> String {
@@ -467,7 +450,7 @@ mod test {
         match network {
             Network::Mainnet => Ok(NetworkId::Mainnet),
             Network::Testnet => Ok(NetworkId::Testnet),
-            _ => Err(anyhow!("Unknown network in address")),
+            _ => Err(anyhow::anyhow!("Unknown network in address")),
         }
     }
 

--- a/modules/tx_unpacker/src/tx_unpacker.rs
+++ b/modules/tx_unpacker/src/tx_unpacker.rs
@@ -8,9 +8,9 @@ use acropolis_common::{
     caryatid::{PrimaryRead, RollbackWrapper, ValidationContext},
     configuration::get_string_flag,
     messages::{
-        AssetDeltasMessage, CardanoMessage, GovernanceProceduresMessage, Message,
-        ProtocolParamsMessage, RawTxsMessage, StateTransitionMessage, TxCertificatesMessage,
-        UTXODeltasMessage, WithdrawalsMessage,
+        AssetDeltasMessage, CardanoMessage, GenesisCompleteMessage, GovernanceProceduresMessage,
+        Message, ProtocolParamsMessage, RawTxsMessage, StateTransitionMessage,
+        TxCertificatesMessage, UTXODeltasMessage, WithdrawalsMessage,
     },
     state_history::{StateHistory, StateHistoryStore},
     *,
@@ -44,13 +44,18 @@ declare_cardano_reader!(
     ProtocolParams,
     ProtocolParamsMessage
 );
+declare_cardano_reader!(
+    GenesisReader,
+    "genesis-subscribe-topic",
+    "cardano.sequence.bootstrapped",
+    GenesisComplete,
+    GenesisCompleteMessage
+);
 
 const DEFAULT_VALIDATION_OUTCOME_PUBLISH_TOPIC: (&str, &str) =
     ("publish-tx-validation-topic", "cardano.validation.tx");
 
 const CIP25_METADATA_LABEL: u64 = 721;
-// TODO: Read network name from genesis message
-const DEFAULT_NETWORK_NAME: (&str, &str) = ("startup.network-name", "mainnet");
 
 /// Tx unpacker module
 /// Parameterised by the outer message enum used on the bus
@@ -65,7 +70,6 @@ impl TxUnpacker {
     #[allow(clippy::too_many_arguments)]
     async fn run(
         context: Arc<Context<Message>>,
-        network_id: NetworkId,
         history: Arc<Mutex<StateHistory<State>>>,
         // publishers
         publish_utxo_deltas_topic: Option<String>,
@@ -76,24 +80,14 @@ impl TxUnpacker {
         publish_tx_validation_topic: String,
         // subscribers
         mut txs_reader: TxsReader,
-        bootstrapped_sub: Option<Box<dyn Subscription<Message>>>,
         mut params_reader: Option<ParamsReader>,
+        mut genesis_reader: GenesisReader,
     ) -> Result<()> {
-        let genesis = match bootstrapped_sub {
-            Some(mut sub) => {
-                let (_, bootstrapped_message) = sub.read().await?;
-                let genesis = match bootstrapped_message.as_ref() {
-                    Message::Cardano((_, CardanoMessage::GenesisComplete(complete))) => {
-                        complete.values.clone()
-                    }
-                    _ => panic!(
-                        "Unexpected message in genesis completion topic: {bootstrapped_message:?}"
-                    ),
-                };
-
-                Some(genesis)
+        let genesis = match genesis_reader.read_with_rollbacks().await? {
+            RollbackWrapper::Normal((_, genesis)) => genesis.values.clone(),
+            RollbackWrapper::Rollback(_) => {
+                bail!("Unexpected rollback while reading genesis values")
             }
-            None => None,
         };
 
         loop {
@@ -169,7 +163,7 @@ impl TxUnpacker {
                                         tx.hash().to_vec().try_into().expect("invalid tx hash length");
                                     let tx_identifier = TxIdentifier::new(block_number, tx_index);
 
-                                    let mapped_tx = acropolis_codec::map_transaction(&tx, raw_tx, tx_identifier, network_id.clone(), block.era);
+                                    let mapped_tx = acropolis_codec::map_transaction(&tx, raw_tx, tx_identifier, genesis.network_id(), block.era);
                                     let tx_output = mapped_tx.calculate_tx_output();
 
                                     // sum up total output lovelace for a block
@@ -327,23 +321,21 @@ impl TxUnpacker {
 
             if let Some(txs_msg) = primary.message() {
                 if primary.do_validation() {
-                    if let Some(ref genesis) = genesis {
-                        let block = primary.block_info();
+                    let block = primary.block_info();
 
-                        let span = info_span!("tx_unpacker.validate", block = block.number);
-                        async {
-                            ctx.handle(
-                                "validate",
-                                state
-                                    .validate(block, txs_msg, &genesis.genesis_delegs)
-                                    .map_err(|e| e.into()),
-                            );
+                    let span = info_span!("tx_unpacker.validate", block = block.number);
+                    async {
+                        ctx.handle(
+                            "validate",
+                            state
+                                .validate(block, txs_msg, &genesis.genesis_delegs)
+                                .map_err(|e| e.into()),
+                        );
 
-                            ctx.publish().await;
-                        }
-                        .instrument(span)
-                        .await;
+                        ctx.publish().await;
                     }
+                    .instrument(span)
+                    .await;
                 }
             }
 
@@ -400,20 +392,7 @@ impl TxUnpacker {
             None => None,
         };
 
-        // Optional subscription for bootstrap (only needed if we are validating)
-        let bootstrapped_subscribe_topic = config.get_string("bootstrapped-subscribe-topic").ok();
-        let bootstrapped_sub = match bootstrapped_subscribe_topic {
-            Some(topic) => {
-                info!("Creating subscriber on '{topic}'");
-                Some(context.subscribe(&topic).await?)
-            }
-            None => None,
-        };
-
-        let network_id = match get_string_flag(&config, DEFAULT_NETWORK_NAME).as_ref() {
-            "mainnet" => NetworkId::Mainnet,
-            _ => NetworkId::Testnet,
-        };
+        let genesis_reader = GenesisReader::new(&context, &config).await?;
 
         // Initialize State
         let history = Arc::new(Mutex::new(StateHistory::<State>::new(
@@ -425,7 +404,6 @@ impl TxUnpacker {
         context.run(async move {
             Self::run(
                 context_run,
-                network_id,
                 history,
                 publish_utxo_deltas_topic,
                 publish_asset_deltas_topic,
@@ -434,8 +412,8 @@ impl TxUnpacker {
                 publish_governance_procedures_topic,
                 publish_tx_validation_topic,
                 txs_reader,
-                bootstrapped_sub,
                 params_reader,
+                genesis_reader,
             )
             .await
             .unwrap_or_else(|e| error!("Failed to run Tx Unpacker: {e}"));


### PR DESCRIPTION

## Description

This PR cleans up the `stake_delta_filter` initialization flow and removes the need to specify the network id a second time in the toml by reading from the genesis values message. I've also included the needed changes for `tx_unpacker` and `chain_store` to read from the genesis message for setting the network id. 
 
## Related Issue(s)
N/A

## How was this tested?
* Verified that predefined and write modes continue to work as expected (snapshot and genesis)

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
No long need to specify the network specifically for `stake_delta_filter`. 

## Reviewer notes / Areas to focus
* Flow cleanup in `modules/stake_delta_filter/src/stake_delta_filter.rs` (Was required as reading the genesis message must be done in the run method and not init)
