### PR TITLE
fix: use kv separation for blocks keyspace in chain_store

### DIFF
--- a/modules/chain_store/src/stores/fjall.rs
+++ b/modules/chain_store/src/stores/fjall.rs
@@ -188,7 +188,10 @@ struct FjallBlockStore {
 
 impl FjallBlockStore {
     fn new(database: &Database) -> Result<Self> {
-        let blocks = database.keyspace(BLOCKS_KEYSPACE, fjall::KeyspaceCreateOptions::default)?;
+        let blocks = database.keyspace(BLOCKS_KEYSPACE, || {
+            fjall::KeyspaceCreateOptions::default()
+                .with_kv_separation(Some(fjall::KvSeparationOptions::default()))
+        })?;
         let block_hashes_by_slot = database.keyspace(
             BLOCK_HASHES_BY_SLOT_KEYSPACE,
             fjall::KeyspaceCreateOptions::default,


### PR DESCRIPTION
## Description

This PR enables KV separation for the `blocks` keyspace in `chain_store`. Block data is large, and storing it in the LSM tree caused heavy compaction and stalls during sync. KV separation stores values separately, reducing write pressure and improving ingestion.

## Related Issue(s)
N/A

## How was this tested?
* Synced from genesis to tip without deadlocks

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
* Faster writes and less compaction
* Slightly higher read cost

## Reviewer notes / Areas to focus
N/A
