### PR TITLE
GenesisValues mainnet() is unsed only in tests should be moved out prod code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,7 @@ name = "acropolis_module_block_kes_validator"
 version = "0.1.0"
 dependencies = [
  "acropolis_common",
+ "acropolis_test_utils",
  "anyhow",
  "caryatid_sdk",
  "config",
@@ -150,6 +151,7 @@ name = "acropolis_module_block_vrf_validator"
 version = "0.1.0"
 dependencies = [
  "acropolis_common",
+ "acropolis_test_utils",
  "anyhow",
  "blake2 0.10.6",
  "caryatid_sdk",
@@ -254,6 +256,7 @@ name = "acropolis_module_epochs_state"
 version = "0.1.0"
 dependencies = [
  "acropolis_common",
+ "acropolis_test_utils",
  "anyhow",
  "caryatid_sdk",
  "config",
@@ -425,6 +428,7 @@ version = "0.2.0"
 dependencies = [
  "acropolis_common",
  "acropolis_module_consensus",
+ "acropolis_test_utils",
  "anyhow",
  "caryatid_sdk",
  "config",
@@ -465,6 +469,7 @@ version = "0.1.0"
 dependencies = [
  "acropolis_codec",
  "acropolis_common",
+ "acropolis_test_utils",
  "anyhow",
  "async-compression",
  "caryatid_sdk",
@@ -588,6 +593,7 @@ version = "0.1.0"
 dependencies = [
  "acropolis_codec",
  "acropolis_common",
+ "acropolis_test_utils",
  "anyhow",
  "async-trait",
  "caryatid_sdk",
@@ -799,6 +805,13 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "acropolis_test_utils"
+version = "0.1.0"
+dependencies = [
+ "acropolis_common",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "cardano",
     "codec",
     "common",
+    "test_utils",
 
     # Modules
     "modules/genesis_bootstrapper",         # Genesis bootstrap UTXOs

--- a/common/src/genesis_values.rs
+++ b/common/src/genesis_values.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use crate::{
     calculations::{
         epoch_to_first_slot_with_shelley_params, slot_to_epoch_with_shelley_params,
@@ -8,9 +6,6 @@ use crate::{
     hash::Hash,
     GenesisDelegates, MagicNumber, NetworkId, Pots,
 };
-const MAINNET_SHELLEY_GENESIS_HASH: &str =
-    "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81";
-
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub struct GenesisValues {
@@ -29,74 +24,6 @@ impl GenesisValues {
         match self.magic_number {
             MagicNumber(764824073) => NetworkId::Mainnet,
             _ => NetworkId::Testnet,
-        }
-    }
-
-    pub fn mainnet() -> Self {
-        Self {
-            byron_timestamp: 1506203091,
-            shelley_epoch: 208,
-            shelley_epoch_len: 432000,
-            shelley_genesis_hash: Hash::<32>::from_str(MAINNET_SHELLEY_GENESIS_HASH).unwrap(),
-            genesis_delegs: GenesisDelegates::try_from(vec![
-                (
-                    "ad5463153dc3d24b9ff133e46136028bdc1edbb897f5a7cf1b37950c",
-                    (
-                        "d9e5c76ad5ee778960804094a389f0b546b5c2b140a62f8ec43ea54d",
-                        "64fa87e8b29a5b7bfbd6795677e3e878c505bc4a3649485d366b50abadec92d7",
-                    ),
-                ),
-                (
-                    "b9547b8a57656539a8d9bc42c008e38d9c8bd9c8adbb1e73ad529497",
-                    (
-                        "855d6fc1e54274e331e34478eeac8d060b0b90c1f9e8a2b01167c048",
-                        "66d5167a1f426bd1adcc8bbf4b88c280d38c148d135cb41e3f5a39f948ad7fcc",
-                    ),
-                ),
-                (
-                    "60baee25cbc90047e83fd01e1e57dc0b06d3d0cb150d0ab40bbfead1",
-                    (
-                        "7f72a1826ae3b279782ab2bc582d0d2958de65bd86b2c4f82d8ba956",
-                        "c0546d9aa5740afd569d3c2d9c412595cd60822bb6d9a4e8ce6c43d12bd0f674",
-                    ),
-                ),
-                (
-                    "f7b341c14cd58fca4195a9b278cce1ef402dc0e06deb77e543cd1757",
-                    (
-                        "69ae12f9e45c0c9122356c8e624b1fbbed6c22a2e3b4358cf0cb5011",
-                        "6394a632af51a32768a6f12dac3485d9c0712d0b54e3f389f355385762a478f2",
-                    ),
-                ),
-                (
-                    "162f94554ac8c225383a2248c245659eda870eaa82d0ef25fc7dcd82",
-                    (
-                        "4485708022839a7b9b8b639a939c85ec0ed6999b5b6dc651b03c43f6",
-                        "aba81e764b71006c515986bf7b37a72fbb5554f78e6775f08e384dbd572a4b32",
-                    ),
-                ),
-                (
-                    "2075a095b3c844a29c24317a94a643ab8e22d54a3a3a72a420260af6",
-                    (
-                        "6535db26347283990a252313a7903a45e3526ec25ddba381c071b25b",
-                        "fcaca997b8105bd860876348fc2c6e68b13607f9bbd23515cd2193b555d267af",
-                    ),
-                ),
-                (
-                    "268cfc0b89e910ead22e0ade91493d8212f53f3e2164b2e4bef0819b",
-                    (
-                        "1d4f2e1fda43070d71bb22a5522f86943c7c18aeb4fa47a362c27e23",
-                        "63ef48bc5355f3e7973100c371d6a095251c80ceb40559f4750aa7014a6fb6db",
-                    ),
-                ),
-            ])
-            .unwrap(),
-            magic_number: MagicNumber::new(764824073),
-            security_param: 2160,
-            initial_pots: Pots {
-                reserves: 13887515255000000,
-                treasury: 0,
-                deposits: 0,
-            },
         }
     }
 

--- a/modules/block_kes_validator/Cargo.toml
+++ b/modules/block_kes_validator/Cargo.toml
@@ -24,5 +24,8 @@ pallas = { workspace = true }
 
 kes-summed-ed25519 = { git = "https://github.com/txpipe/kes", rev = "f69fb357d46f6a18925543d785850059569d7e78" }
 
+[dev-dependencies]
+acropolis_test_utils = { path = "../../test_utils" }
+
 [lib]
 path = "src/block_kes_validator.rs"

--- a/modules/block_kes_validator/src/ouroboros/kes_validation.rs
+++ b/modules/block_kes_validator/src/ouroboros/kes_validation.rs
@@ -256,7 +256,8 @@ fn body_signature<'a>(header: &'a MultiEraHeader) -> Option<&'a [u8]> {
 
 #[cfg(test)]
 mod tests {
-    use acropolis_common::{genesis_values::GenesisValues, serialization::Bech32Conversion, Era};
+    use acropolis_common::{serialization::Bech32Conversion, Era};
+    use acropolis_test_utils::mainnet_genesis_values;
     use pallas::ledger::traverse::MultiEraHeader;
 
     use super::*;
@@ -265,7 +266,7 @@ mod tests {
     fn test_4490511_block_produced_by_genesis_key() {
         let slots_per_kes_period = 129600;
         let max_kes_evolutions = 62;
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let block_header_4490511: Vec<u8> =
             hex::decode(include_str!("./data/4490511.cbor")).unwrap();
@@ -295,7 +296,7 @@ mod tests {
     fn test_4556956_block() {
         let slots_per_kes_period = 129600;
         let max_kes_evolutions = 62;
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let block_header_4556956: Vec<u8> =
             hex::decode(include_str!("./data/4556956.cbor")).unwrap();
@@ -332,7 +333,7 @@ mod tests {
     fn test_4556956_block_with_wrong_ocert_counter() {
         let slots_per_kes_period = 129600;
         let max_kes_evolutions = 62;
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let block_header_4556956: Vec<u8> =
             hex::decode(include_str!("./data/4556956.cbor")).unwrap();
@@ -377,7 +378,7 @@ mod tests {
     fn test_4556956_block_with_missing_ocert_counter_and_active_spos() {
         let slots_per_kes_period = 129600;
         let max_kes_evolutions = 62;
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let block_header_4556956: Vec<u8> =
             hex::decode(include_str!("./data/4556956.cbor")).unwrap();
@@ -416,7 +417,7 @@ mod tests {
     fn test_7854823_praos_block() {
         let slots_per_kes_period = 129600;
         let max_kes_evolutions = 62;
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let block_header_7854823: Vec<u8> =
             hex::decode(include_str!("./data/7854823.cbor")).unwrap();
@@ -452,7 +453,7 @@ mod tests {
     fn test_7854823_praos_block_with_overincremented_ocert_counter() {
         let slots_per_kes_period = 129600;
         let max_kes_evolutions = 62;
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let block_header_7854823: Vec<u8> =
             hex::decode(include_str!("./data/7854823.cbor")).unwrap();

--- a/modules/block_vrf_validator/Cargo.toml
+++ b/modules/block_vrf_validator/Cargo.toml
@@ -29,5 +29,8 @@ dashu-int = "0.4.1"
 # The vrf crate has not been fully tested in production environments and still has several upstream issues that are open PRs but not merged yet.
 vrf_dalek = { package = "pallas_vrf", git = "https://github.com/txpipe/vrf", rev = "62ef4c7252ed05df98611da191e20c0dd144f025" }
 
+[dev-dependencies]
+acropolis_test_utils = { path = "../../test_utils" }
+
 [lib]
 path = "src/block_vrf_validator.rs"

--- a/modules/block_vrf_validator/src/ouroboros/overlay_schedule.rs
+++ b/modules/block_vrf_validator/src/ouroboros/overlay_schedule.rs
@@ -134,13 +134,13 @@ pub fn lookup_in_overlay_schedule(
 
 #[cfg(test)]
 mod tests {
-    use acropolis_common::genesis_values::GenesisValues;
+    use acropolis_test_utils::mainnet_genesis_values;
 
     use super::*;
 
     #[test]
     fn test_lookup_in_overlay_schedule_1() {
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
         let genesis_delegs = genesis_values.genesis_delegs;
         let decentralisation_param = RationalNumber::ONE;
         let active_slots_coeff = RationalNumber::new(1, 20);
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn test_lookup_in_overlay_schedule_2() {
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
         let genesis_delegs = genesis_values.genesis_delegs;
         let decentralisation_param = RationalNumber::new(1, 2);
         let active_slots_coeff = RationalNumber::new(1, 20);

--- a/modules/block_vrf_validator/src/ouroboros/tpraos.rs
+++ b/modules/block_vrf_validator/src/ouroboros/tpraos.rs
@@ -181,18 +181,18 @@ fn leader_vrf_cert<'a>(header: &'a MultiEraHeader) -> Option<&'a VrfCert> {
 mod tests {
     use acropolis_common::{
         crypto::keyhash_256,
-        genesis_values::GenesisValues,
         protocol_params::NonceHash,
         serialization::Bech32Conversion,
         validation::{VrfLeaderValueTooBigError, WrongLeaderVrfKeyError},
         BlockHash, BlockIntent, BlockStatus, Era,
     };
+    use acropolis_test_utils::mainnet_genesis_values;
 
     use super::*;
 
     #[test]
     fn test_4490511_block_produced_by_genesis_key() {
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let epoch_nonce = Nonce::from(
             NonceHash::try_from(
                 hex::decode("1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81")
@@ -247,7 +247,7 @@ mod tests {
 
     #[test]
     fn test_4556956_block() {
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let epoch_nonce = Nonce::from(
             NonceHash::try_from(
                 hex::decode("3fac34ac3d7d1ac6c976ba68b1509b1ee3aafdbf6de96e10789e488e13e16bd7")
@@ -308,7 +308,7 @@ mod tests {
 
     #[test]
     fn test_4576496_block() {
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let epoch_nonce = Nonce::from(
             NonceHash::try_from(
                 hex::decode("3fac34ac3d7d1ac6c976ba68b1509b1ee3aafdbf6de96e10789e488e13e16bd7")
@@ -369,7 +369,7 @@ mod tests {
 
     #[test]
     fn test_4576496_block_as_unknown_pool() {
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let epoch_nonce = Nonce::from(
             NonceHash::try_from(
                 hex::decode("3fac34ac3d7d1ac6c976ba68b1509b1ee3aafdbf6de96e10789e488e13e16bd7")
@@ -431,7 +431,7 @@ mod tests {
 
     #[test]
     fn test_4576496_block_as_wrong_leader_vrf_key() {
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let epoch_nonce = Nonce::from(
             NonceHash::try_from(
                 hex::decode("3fac34ac3d7d1ac6c976ba68b1509b1ee3aafdbf6de96e10789e488e13e16bd7")
@@ -502,7 +502,7 @@ mod tests {
 
     #[test]
     fn test_4576496_block_with_small_active_stake() {
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let epoch_nonce = Nonce::from(
             NonceHash::try_from(
                 hex::decode("3fac34ac3d7d1ac6c976ba68b1509b1ee3aafdbf6de96e10789e488e13e16bd7")

--- a/modules/epochs_state/Cargo.toml
+++ b/modules/epochs_state/Cargo.toml
@@ -21,5 +21,8 @@ pallas = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 
+[dev-dependencies]
+acropolis_test_utils = { path = "../../test_utils" }
+
 [lib]
 path = "src/epochs_state.rs"

--- a/modules/epochs_state/src/state.rs
+++ b/modules/epochs_state/src/state.rs
@@ -328,6 +328,7 @@ mod tests {
         state_history::{StateHistory, StateHistoryStore},
         BlockHash, BlockInfo, BlockIntent, BlockStatus, Era,
     };
+    use acropolis_test_utils::mainnet_genesis_values;
     use tokio::sync::Mutex;
 
     fn make_block(epoch: u64) -> BlockInfo {
@@ -383,7 +384,7 @@ mod tests {
 
     #[test]
     fn initial_state_is_zeroed() {
-        let state = State::new(&GenesisValues::mainnet());
+        let state = State::new(&mainnet_genesis_values());
         assert_eq!(state.epoch_blocks, 0);
         assert_eq!(state.epoch_txs, 0);
         assert_eq!(state.epoch_outputs, 0);
@@ -393,7 +394,7 @@ mod tests {
 
     #[test]
     fn handle_mint_single_issuer_records_counts() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         let issuer = b"issuer_key";
         let mut block = make_block(100);
         state.handle_mint(&block, Some(issuer), false);
@@ -410,7 +411,7 @@ mod tests {
 
     #[test]
     fn handle_mint_without_issuer() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         let mut block = make_block(100);
         state.handle_mint(&block, None, false);
         block.number += 1;
@@ -426,7 +427,7 @@ mod tests {
 
     #[test]
     fn handle_mint_multiple_issuer_records_counts() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         let mut block = make_block(100);
         state.handle_mint(&block, Some(b"issuer_1"), false);
         block.number += 1;
@@ -460,7 +461,7 @@ mod tests {
 
     #[test]
     fn handle_block_txs_correctly() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         let mut block = make_block(100);
 
         state.handle_block_txs(
@@ -488,7 +489,7 @@ mod tests {
 
     #[test]
     fn end_epoch_resets_and_returns_message() {
-        let genesis = GenesisValues::mainnet();
+        let genesis = mainnet_genesis_values();
         let mut state = State::new(&genesis);
         let block = make_block(1);
         state.handle_mint(&block, Some(b"issuer_1"), false);
@@ -599,9 +600,9 @@ mod tests {
 
     #[test]
     fn test_epoch_208_nonce() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         state.praos_params = Some(PraosParams::mainnet());
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
 
         let e_208_first_block_header_cbor =
             hex::decode(include_str!("../data/4490511.cbor")).unwrap();
@@ -627,9 +628,9 @@ mod tests {
 
     #[test]
     fn test_nonce_evolving() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         state.praos_params = Some(PraosParams::mainnet());
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
 
         let e_208_first_block_header_cbor =
             hex::decode(include_str!("../data/4490511.cbor")).unwrap();
@@ -662,9 +663,9 @@ mod tests {
 
     #[test]
     fn test_epoch_209_nonce() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         state.praos_params = Some(PraosParams::mainnet());
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let e_208_candidate = Nonce::from(
             NonceHash::try_from(
                 hex::decode("ea98cb2dac7208296ac89030f24cdc0dc6fbfebc4bf1f5b7a8331ec47e3bb311")
@@ -721,9 +722,9 @@ mod tests {
 
     #[test]
     fn test_epoch_210_nonce() {
-        let mut state = State::new(&GenesisValues::mainnet());
+        let mut state = State::new(&mainnet_genesis_values());
         state.praos_params = Some(PraosParams::mainnet());
-        let genesis_value = GenesisValues::mainnet();
+        let genesis_value = mainnet_genesis_values();
         let e_209_lab = Nonce::from(
             NonceHash::try_from(
                 hex::decode("e5e914ba8c727baf3c3465ae6a62508186772eb20649aa7a99a637328f62803e")

--- a/modules/peer_network_interface/Cargo.toml
+++ b/modules/peer_network_interface/Cargo.toml
@@ -27,4 +27,5 @@ tracing = { workspace = true }
 path = "src/peer_network_interface.rs"
 
 [dev-dependencies]
+acropolis_test_utils = { path = "../../test_utils" }
 acropolis_module_consensus = { path = "../consensus" }

--- a/modules/peer_network_interface/src/block_flow_consensus_scenarios_tests.rs
+++ b/modules/peer_network_interface/src/block_flow_consensus_scenarios_tests.rs
@@ -12,9 +12,9 @@ use acropolis_common::messages::{
 };
 use acropolis_common::{
     BlockHash, BlockInfo, BlockIntent, BlockStatus, Era, configuration::BlockFlowMode,
-    genesis_values::GenesisValues,
 };
 use acropolis_module_consensus::Consensus;
+use acropolis_test_utils::mainnet_genesis_values;
 use caryatid_sdk::{Context, Subscription, mock_bus::MockBus};
 use config::{Config, FileFormat};
 use pallas::network::miniprotocols::Point;
@@ -114,7 +114,7 @@ async fn make_harness() -> TestHarness {
             Arc::new(Message::Cardano((
                 genesis_block_info,
                 CardanoMessage::GenesisComplete(GenesisCompleteMessage {
-                    values: GenesisValues::mainnet(),
+                    values: mainnet_genesis_values(),
                 }),
             ))),
         )
@@ -166,7 +166,7 @@ async fn make_harness() -> TestHarness {
     let sink = BlockSink {
         context: context.clone(),
         topic: "cardano.block.available".to_string(),
-        genesis_values: GenesisValues::mainnet(),
+        genesis_values: mainnet_genesis_values(),
         upstream_cache: None,
         last_epoch: None,
         era: None,

--- a/modules/peer_network_interface/src/network.rs
+++ b/modules/peer_network_interface/src/network.rs
@@ -722,9 +722,9 @@ mod tests {
     use crate::configuration::{InterfaceConfig, SyncPoint};
     use crate::connection::{Header, PeerChainSyncEvent, PeerEvent};
     use acropolis_common::configuration::BlockFlowMode;
-    use acropolis_common::genesis_values::GenesisValues;
     use acropolis_common::messages::Message;
     use acropolis_common::{BlockHash, Era};
+    use acropolis_test_utils::mainnet_genesis_values;
     use caryatid_sdk::Context;
     use caryatid_sdk::mock_bus::MockBus;
     use config::Config;
@@ -743,7 +743,7 @@ mod tests {
         BlockSink {
             context,
             topic: "test.block.available".to_string(),
-            genesis_values: GenesisValues::mainnet(),
+            genesis_values: mainnet_genesis_values(),
             upstream_cache: None,
             last_epoch: None,
             era: None,

--- a/modules/snapshot_bootstrapper/Cargo.toml
+++ b/modules/snapshot_bootstrapper/Cargo.toml
@@ -29,6 +29,7 @@ futures-util = "0.3.31"
 tokio-util = "0.7.17"
 
 [dev-dependencies]
+acropolis_test_utils = { path = "../../test_utils" }
 wiremock = "0.6.5"
 flate2 = "1.1.5"
 tempfile = "3.23.0"

--- a/modules/snapshot_bootstrapper/src/publisher.rs
+++ b/modules/snapshot_bootstrapper/src/publisher.rs
@@ -663,6 +663,7 @@ impl SnapshotCallbacks for SnapshotPublisher {
 mod tests {
     use super::*;
     use acropolis_common::protocol_params::Nonce;
+    use acropolis_test_utils::mainnet_genesis_values;
 
     fn make_test_nonces() -> Nonces {
         Nonces {
@@ -678,7 +679,7 @@ mod tests {
     #[test]
     fn test_bootstrap_context_new() {
         let nonces = make_test_nonces();
-        let genesis = GenesisValues::mainnet();
+        let genesis = mainnet_genesis_values();
 
         let ctx = EpochContext::new(
             nonces.clone(),
@@ -700,7 +701,7 @@ mod tests {
     fn test_epoch_context_stores_nonces() {
         // This would require mocking Context, so just test the data flow concept
         let nonces = make_test_nonces();
-        let genesis = GenesisValues::mainnet();
+        let genesis = mainnet_genesis_values();
 
         let ctx = EpochContext::new(
             nonces.clone(),

--- a/modules/utxo_state/Cargo.toml
+++ b/modules/utxo_state/Cargo.toml
@@ -33,6 +33,7 @@ serde = { workspace = true }
 path = "src/utxo_state.rs"
 
 [dev-dependencies]
+acropolis_test_utils = { path = "../../test_utils" }
 hex.workspace = true
 pallas.workspace = true
 serde.workspace = true

--- a/modules/utxo_state/src/validations/phase_two/evaluate.rs
+++ b/modules/utxo_state/src/validations/phase_two/evaluate.rs
@@ -420,7 +420,8 @@ mod tests {
     use super::*;
     use crate::test_utils::{to_era, to_pallas_era, TestContext};
     use crate::validation_fixture;
-    use acropolis_common::{genesis_values::GenesisValues, NetworkId, TxIdentifier};
+    use acropolis_common::{NetworkId, TxIdentifier};
+    use acropolis_test_utils::mainnet_genesis_values;
     use pallas::ledger::traverse::MultiEraTx;
     use test_case::test_case;
 
@@ -516,7 +517,7 @@ mod tests {
         };
         let scripts_table = build_scripts_table(&tx_deltas, &ctx.utxos, lookup_ref_script);
 
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
         let tx_info = TxInfo::new(&tx_deltas, &ctx.utxos, &genesis_values).unwrap();
         let scripts_needed = crate::utils::get_scripts_needed(&tx_deltas, &ctx.utxos);
         let scripts_provided = crate::utils::get_scripts_provided(&tx_deltas, &ctx.utxos);
@@ -552,7 +553,7 @@ mod tests {
         );
         let tx_deltas = mapped_tx.convert_to_utxo_deltas(true);
 
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
         let tx_info = TxInfo::new(&tx_deltas, &ctx.utxos, &genesis_values).unwrap();
         let scripts_needed = crate::utils::get_scripts_needed(&tx_deltas, &ctx.utxos);
         let scripts_provided = crate::utils::get_scripts_provided(&tx_deltas, &ctx.utxos);

--- a/modules/utxo_state/src/validations/phase_two/script_context.rs
+++ b/modules/utxo_state/src/validations/phase_two/script_context.rs
@@ -713,6 +713,7 @@ mod tests {
     use crate::test_utils::{to_era, to_pallas_era, TestContext};
     use crate::validation_fixture;
     use acropolis_common::{NetworkId, TxIdentifier};
+    use acropolis_test_utils::mainnet_genesis_values;
     use pallas::ledger::traverse::MultiEraTx;
 
     fn build_test_deltas(_ctx: &TestContext, raw_tx: &[u8], era: &str) -> TxUTxODeltas {
@@ -736,7 +737,7 @@ mod tests {
             "a95d16e891e51f98a3b1d3fe862ed355ebc8abffb7a7269d86f775553d9e653f"
         );
         let tx_deltas = build_test_deltas(&ctx, &raw_tx, era);
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let tx_info = TxInfo::new(&tx_deltas, &ctx.utxos, &genesis_values).unwrap();
 
@@ -757,7 +758,7 @@ mod tests {
             "a95d16e891e51f98a3b1d3fe862ed355ebc8abffb7a7269d86f775553d9e653f"
         );
         let tx_deltas = build_test_deltas(&ctx, &raw_tx, era);
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let tx_info = TxInfo::new(&tx_deltas, &ctx.utxos, &genesis_values).unwrap();
         let scripts_needed = crate::utils::get_scripts_needed(&tx_deltas, &ctx.utxos);
@@ -777,7 +778,7 @@ mod tests {
             "a95d16e891e51f98a3b1d3fe862ed355ebc8abffb7a7269d86f775553d9e653f"
         );
         let tx_deltas = build_test_deltas(&ctx, &raw_tx, era);
-        let genesis_values = GenesisValues::mainnet();
+        let genesis_values = mainnet_genesis_values();
 
         let tx_info = TxInfo::new(&tx_deltas, &ctx.utxos, &genesis_values).unwrap();
         let scripts_needed = crate::utils::get_scripts_needed(&tx_deltas, &ctx.utxos);

--- a/modules/utxo_state/src/validations/phase_two/time_range.rs
+++ b/modules/utxo_state/src/validations/phase_two/time_range.rs
@@ -87,10 +87,11 @@ impl ToPlutusData for TimeRange {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use acropolis_test_utils::mainnet_genesis_values;
 
     #[test]
     fn time_range_shelley_slot() {
-        let gv = GenesisValues::mainnet();
+        let gv = mainnet_genesis_values();
         // Mainnet: byron_timestamp=1506203091, shelley_epoch=208
         // Shelley start slot = 208 * 21600 = 4492800
         // Shelley start timestamp = 1506203091 + 4492800 * 20 = 1596059091
@@ -107,7 +108,7 @@ mod tests {
 
     #[test]
     fn time_range_none_bounds() {
-        let gv = GenesisValues::mainnet();
+        let gv = mainnet_genesis_values();
         let tr = TimeRange::new(None, None, &gv);
         assert!(tr.lower_bound.is_none());
         assert!(tr.upper_bound.is_none());
@@ -115,7 +116,7 @@ mod tests {
 
     #[test]
     fn time_range_mixed_bounds() {
-        let gv = GenesisValues::mainnet();
+        let gv = mainnet_genesis_values();
         let tr = TimeRange::new(Some(44_000_000), None, &gv);
         assert!(tr.lower_bound.is_some());
         assert!(tr.upper_bound.is_none());

--- a/test_utils/Cargo.toml
+++ b/test_utils/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "acropolis_test_utils"
+version = "0.1.0"
+edition = "2021"
+description = "Test helpers for Acropolis modules"
+license = "Apache-2.0"
+
+[dependencies]
+acropolis_common = { path = "../common" }

--- a/test_utils/src/lib.rs
+++ b/test_utils/src/lib.rs
@@ -1,0 +1,76 @@
+use std::str::FromStr;
+
+use acropolis_common::{
+    genesis_values::GenesisValues, hash::Hash, GenesisDelegates, MagicNumber, Pots,
+};
+
+const MAINNET_SHELLEY_GENESIS_HASH: &str =
+    "1a3be38bcbb7911969283716ad7aa550250226b76a61fc51cc9a9a35d9276d81";
+
+pub fn mainnet_genesis_values() -> GenesisValues {
+    GenesisValues {
+        byron_timestamp: 1506203091,
+        shelley_epoch: 208,
+        shelley_epoch_len: 432000,
+        shelley_genesis_hash: Hash::<32>::from_str(MAINNET_SHELLEY_GENESIS_HASH).unwrap(),
+        genesis_delegs: GenesisDelegates::try_from(vec![
+            (
+                "ad5463153dc3d24b9ff133e46136028bdc1edbb897f5a7cf1b37950c",
+                (
+                    "d9e5c76ad5ee778960804094a389f0b546b5c2b140a62f8ec43ea54d",
+                    "64fa87e8b29a5b7bfbd6795677e3e878c505bc4a3649485d366b50abadec92d7",
+                ),
+            ),
+            (
+                "b9547b8a57656539a8d9bc42c008e38d9c8bd9c8adbb1e73ad529497",
+                (
+                    "855d6fc1e54274e331e34478eeac8d060b0b90c1f9e8a2b01167c048",
+                    "66d5167a1f426bd1adcc8bbf4b88c280d38c148d135cb41e3f5a39f948ad7fcc",
+                ),
+            ),
+            (
+                "60baee25cbc90047e83fd01e1e57dc0b06d3d0cb150d0ab40bbfead1",
+                (
+                    "7f72a1826ae3b279782ab2bc582d0d2958de65bd86b2c4f82d8ba956",
+                    "c0546d9aa5740afd569d3c2d9c412595cd60822bb6d9a4e8ce6c43d12bd0f674",
+                ),
+            ),
+            (
+                "f7b341c14cd58fca4195a9b278cce1ef402dc0e06deb77e543cd1757",
+                (
+                    "69ae12f9e45c0c9122356c8e624b1fbbed6c22a2e3b4358cf0cb5011",
+                    "6394a632af51a32768a6f12dac3485d9c0712d0b54e3f389f355385762a478f2",
+                ),
+            ),
+            (
+                "162f94554ac8c225383a2248c245659eda870eaa82d0ef25fc7dcd82",
+                (
+                    "4485708022839a7b9b8b639a939c85ec0ed6999b5b6dc651b03c43f6",
+                    "aba81e764b71006c515986bf7b37a72fbb5554f78e6775f08e384dbd572a4b32",
+                ),
+            ),
+            (
+                "2075a095b3c844a29c24317a94a643ab8e22d54a3a3a72a420260af6",
+                (
+                    "6535db26347283990a252313a7903a45e3526ec25ddba381c071b25b",
+                    "fcaca997b8105bd860876348fc2c6e68b13607f9bbd23515cd2193b555d267af",
+                ),
+            ),
+            (
+                "268cfc0b89e910ead22e0ade91493d8212f53f3e2164b2e4bef0819b",
+                (
+                    "1d4f2e1fda43070d71bb22a5522f86943c7c18aeb4fa47a362c27e23",
+                    "63ef48bc5355f3e7973100c371d6a095251c80ceb40559f4750aa7014a6fb6db",
+                ),
+            ),
+        ])
+        .unwrap(),
+        magic_number: MagicNumber::new(764824073),
+        security_param: 2160,
+        initial_pots: Pots {
+            reserves: 13887515255000000,
+            treasury: 0,
+            deposits: 0,
+        },
+    }
+}


### PR DESCRIPTION
## Description

GenesisValues::mainnet() is used only in tests and needs to be moved to test utils.

## Related Issue(s)
#868 

## How was this tested?
All tests still work.

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
N/A

## Reviewer notes / Areas to focus
N/A
