### PR TITLE
fix: credit donations and forfeited proposal deposits to treasury pot

### DIFF
--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -574,6 +574,9 @@ pub struct AccountsBootstrapMessage {
     /// to the DRep has their delegation cleared, even if they have switched delegations
     /// since.
     pub drep_delegations: Vec<(DRepCredential, Vec<StakeAddress>)>,
+
+    /// Total proposal deposits by stake address
+    pub proposal_deposits: HashMap<StakeAddress, Lovelace>,
 }
 
 /// Deltas to apply to pots at epoch boundary during snapshot bootstrap

--- a/common/src/messages.rs
+++ b/common/src/messages.rs
@@ -275,6 +275,9 @@ pub struct GovernanceProceduresMessage {
 
     /// Alonzo-compatible (from Shelley) and Babbage updates
     pub alonzo_babbage_updates: Vec<AlonzoBabbageUpdateProposal>,
+
+    /// Treasury donations
+    pub treasury_donations: Lovelace,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/modules/accounts_state/src/accounts_state.rs
+++ b/modules/accounts_state/src/accounts_state.rs
@@ -354,6 +354,18 @@ impl AccountsState {
                     RollbackWrapper::Rollback(_) => {}
                 }
 
+                // Read gov outcomes before epoch activity to apply forfeited proposal deposits to pots
+                let gov_outcomes = match ctx.consume(
+                    "readers.gov_outcomes",
+                    readers.gov_outcomes.read_with_rollbacks().await,
+                )? {
+                    RollbackWrapper::Normal((_, outcomes_msg)) => {
+                        state.handle_forfeited_deposits(&outcomes_msg);
+                        Some(outcomes_msg)
+                    }
+                    RollbackWrapper::Rollback(_) => None,
+                };
+
                 // Handle epoch activity
                 match ctx.consume(
                     "readers.epoch_activity",
@@ -396,28 +408,12 @@ impl AccountsState {
                 };
 
                 // Handle governance outcomes (enacted/expired proposals) at epoch boundary
-                match ctx.consume(
-                    "readers.gov_outcomes",
-                    readers.gov_outcomes.read_with_rollbacks().await,
-                )? {
-                    RollbackWrapper::Normal((block_info, outcomes_msg)) => {
-                        async {
-                            let refund_deltas = ctx.handle(
-                                "handle_governance_outcomes",
-                                state.handle_governance_outcomes(
-                                    &outcomes_msg,
-                                    &mut stake_address_undo,
-                                ),
-                            );
-                            stake_reward_deltas.extend(refund_deltas);
-                        }
-                        .instrument(info_span!(
-                            "account_state.handle_governance_outcomes",
-                            block = block_info.number
-                        ))
-                        .await;
-                    }
-                    RollbackWrapper::Rollback(_) => {}
+                if let Some(gov_outcomes) = gov_outcomes {
+                    let refund_deltas = ctx.handle(
+                        "handle_governance_outcomes",
+                        state.handle_governance_outcomes(&gov_outcomes, &mut stake_address_undo),
+                    );
+                    stake_reward_deltas.extend(refund_deltas);
                 }
 
                 // publish stake reward deltas if we're not in rollback

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -671,7 +671,6 @@ impl State {
 
         // Pay the refunds after snapshot, so they don't appear in active_stake
         reward_deltas.extend(self.pay_pool_refunds(undo));
-        reward_deltas.extend(self.pay_proposal_refunds(undo));
 
         // Verify pots state
         verifier.verify_pots(epoch, &self.pots);
@@ -879,29 +878,16 @@ impl State {
                 self.proposal_deposits.remove(&reward_account);
             }
 
-            let was_registered =
-                self.mutate_stake_address(undo, &reward_account, |stake_addresses| {
-                    if stake_addresses.is_registered(&reward_account) {
-                        stake_addresses.add_to_reward(&reward_account, deposit);
-                        true
-                    } else {
-                        false
-                    }
-                });
-            if was_registered {
-                reward_deltas.push(StakeRewardDelta {
-                    stake_address: reward_account.clone(),
-                    delta: deposit,
-                    reward_type: RewardType::ProposalRefund,
-                    pool: PoolId::default(),
-                });
-            } else {
-                warn!(
-                    "Reward account {} deregistered - paying refund to treasury",
-                    reward_account
-                );
-                self.pots.treasury += deposit;
-            }
+            self.mutate_stake_address(undo, &reward_account, |stake_addresses| {
+                stake_addresses.add_to_reward(&reward_account, deposit);
+            });
+
+            reward_deltas.push(StakeRewardDelta {
+                stake_address: reward_account.clone(),
+                delta: deposit,
+                reward_type: RewardType::ProposalRefund,
+                pool: PoolId::default(),
+            });
         }
 
         reward_deltas
@@ -1849,17 +1835,48 @@ impl State {
         self.pots.treasury = self.pots.treasury.saturating_add(procedures.treasury_donations);
     }
 
+    pub fn handle_forfeited_deposits(&mut self, outcomes_msg: &GovernanceOutcomesMessage) {
+        for outcome in &outcomes_msg.conway_outcomes {
+            let proposal = &outcome.voting.procedure;
+            let reward_account = &proposal.reward_account;
+            let deposit = proposal.deposit;
+
+            if let Some(entry) = self.get_stake_state(reward_account) {
+                if entry.registered {
+                    self.proposal_refunds.push((reward_account.clone(), deposit));
+                } else {
+                    // Pay deposit to treasury
+                    self.pots.treasury = self.pots.treasury.saturating_add(deposit);
+
+                    // Decrement account's proposal deposits
+                    let Some(balance) = self.proposal_deposits.get_mut(reward_account) else {
+                        warn!("No proposal deposit for {}", reward_account);
+                        continue;
+                    };
+
+                    if *balance < deposit {
+                        warn!(
+                            "Refund {} exceeds proposal deposit {} for {}",
+                            deposit, *balance, reward_account
+                        );
+                        continue;
+                    }
+
+                    *balance -= deposit;
+                    if *balance == 0 {
+                        self.proposal_deposits.remove(reward_account);
+                    }
+                }
+            }
+        }
+    }
+
     pub fn handle_governance_outcomes(
         &mut self,
         outcomes_msg: &GovernanceOutcomesMessage,
         undo: &mut BlockStakeAddressUndoRecorder,
     ) -> Result<Vec<StakeRewardDelta>> {
         for outcome in &outcomes_msg.conway_outcomes {
-            let proposal = &outcome.voting.procedure;
-            let deposit = proposal.deposit;
-
-            self.proposal_refunds.push((proposal.reward_account.clone(), deposit));
-
             // Handle treasury withdrawals for enacted TreasuryWithdrawal actions
             if let GovernanceOutcomeVariant::TreasuryWithdrawal(withdrawal_action) =
                 &outcome.action_to_perform
@@ -1875,7 +1892,7 @@ impl State {
                             self.mutate_stake_address(undo, &reward_account, |stake_addresses| {
                                 stake_addresses.add_to_reward(&reward_account, *amount);
                             });
-                            info!(
+                            debug!(
                                 "Treasury withdrawal: {} lovelace ({} ADA) to {}",
                                 amount,
                                 amount / 1_000_000,
@@ -1894,7 +1911,7 @@ impl State {
         }
 
         if !outcomes_msg.conway_outcomes.is_empty() {
-            info!(
+            debug!(
                 "Governance outcomes: {} proposals processed",
                 outcomes_msg.conway_outcomes.len(),
             );
@@ -1902,7 +1919,7 @@ impl State {
 
         let mut reward_deltas = Vec::new();
         reward_deltas.extend(self.pay_proposal_refunds(undo));
-        info!(
+        debug!(
             "Refunds: {}, rewards: {}",
             self.proposal_refunds.len(),
             reward_deltas.len()

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -218,6 +218,9 @@ impl State {
         // Apply DRep delegations (Used to reproduce PV9 deregistration bug)
         self.drep_delegators = bootstrap_msg.drep_delegations.into();
 
+        // Apply proposal deposits
+        self.proposal_deposits = bootstrap_msg.proposal_deposits;
+
         info!(
             "Accounts state bootstrap complete for epoch {}: {} accounts, {} pools, {} DReps, \
              pots(reserves={}, treasury={}, deposits={})",

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -1842,6 +1842,8 @@ impl State {
                 .and_modify(|amount| *amount += proposal.deposit)
                 .or_insert(proposal.deposit);
         }
+
+        self.pots.treasury = self.pots.treasury.saturating_add(procedures.treasury_donations);
     }
 
     pub fn handle_governance_outcomes(

--- a/modules/snapshot_bootstrapper/src/publisher.rs
+++ b/modules/snapshot_bootstrapper/src/publisher.rs
@@ -1,6 +1,7 @@
 use acropolis_common::configuration::SyncMode;
 use acropolis_common::messages::SPOBootstrapMessage;
 use acropolis_common::MagicNumber;
+use acropolis_common::ProposalProcedure;
 use acropolis_common::ProtocolParamUpdate;
 use acropolis_common::ReferenceScript;
 use acropolis_common::RewardParams;
@@ -115,6 +116,7 @@ pub struct SnapshotPublisher {
     dreps_len: usize,
     proposals: Vec<GovernanceProposal>,
     epoch_context: EpochContext,
+    procedures: Vec<ProposalProcedure>,
 }
 
 impl SnapshotPublisher {
@@ -139,6 +141,7 @@ impl SnapshotPublisher {
             dreps_len: 0,
             proposals: Vec::new(),
             epoch_context,
+            procedures: Vec::new(),
         }
     }
 
@@ -336,6 +339,12 @@ impl AccountsCallback for SnapshotPublisher {
             !data.snapshots.mark.spos.is_empty(),
         );
 
+        let mut proposal_deposits = HashMap::new();
+        for proposal in &self.procedures {
+            *proposal_deposits.entry(proposal.reward_account.clone()).or_insert(0) +=
+                proposal.deposit;
+        }
+
         // Convert the parsed data to the message type
         let message = AccountsBootstrapMessage {
             epoch: data.epoch,
@@ -348,6 +357,7 @@ impl AccountsCallback for SnapshotPublisher {
             bootstrap_snapshots: data.snapshots,
             pot_deltas: data.pot_deltas,
             drep_delegations: self.epoch_context.drep_delegations.clone(),
+            proposal_deposits,
         };
 
         let msg = Arc::new(Message::Snapshot(SnapshotMessage::Bootstrap(
@@ -569,6 +579,9 @@ impl GovernanceStateCallback for SnapshotPublisher {
         // Convert GovernanceState to ConwayVoting-compatible data
         let (proposals, votes) = state.to_conway_voting_data(epoch);
 
+        for (_, procedure) in &proposals {
+            self.procedures.push(procedure.clone());
+        }
         // Convert proposal roots
         let proposal_roots = GovernanceProposalRoots {
             pparam_update: state.proposal_roots.pparam_update,

--- a/modules/tx_unpacker/src/tx_unpacker.rs
+++ b/modules/tx_unpacker/src/tx_unpacker.rs
@@ -148,6 +148,7 @@ impl TxUnpacker {
                 let mut total_proposal_procedures = Vec::new();
                 let mut total_alonzo_babbage_update_proposals = Vec::new();
                 let mut total_output: u128 = 0;
+                let mut total_treasury_donations = 0;
                 let block_number = block.number as u32;
 
                 let span: tracing::Span =
@@ -221,6 +222,10 @@ impl TxUnpacker {
                                         if let Some(vps) = mapped_tx.voting_procedures.as_ref() {
                                             total_voting_procedures.push((tx_hash, vps.clone()));
                                         }
+
+                                        if let Some(donation) = mapped_tx.donation {
+                                            total_treasury_donations += donation;
+                                        }
                                     }
 
                                     if publish_utxo_deltas_topic.is_some() {
@@ -289,6 +294,7 @@ impl TxUnpacker {
                             voting_procedures: total_voting_procedures,
                             proposal_procedures: total_proposal_procedures,
                             alonzo_babbage_updates: total_alonzo_babbage_update_proposals,
+                            treasury_donations: total_treasury_donations,
                         }),
                     )));
 


### PR DESCRIPTION
## Description

This PR fixes a bug in `accounts_state` where we were undercounting the treasury pot due to not crediting donations. Other fixes included are crediting forfeited proposal deposits before calling `enter_epoch` and bootstrapping the `proposal_deposits` field. All pots will now match the values reported by the Haskell node from genesis to tip. 

## Related Issue(s)
N/A

## How was this tested?
* Ran to tip and ensured that pots verification was successful

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
Pots verification will now be successful to tip. 

## Reviewer notes / Areas to focus
N/A
