### PR TITLE
chore: remove log spam from omnibus process

### DIFF
--- a/common/src/epoch_snapshot.rs
+++ b/common/src/epoch_snapshot.rs
@@ -80,7 +80,7 @@ impl EpochSnapshot {
         registration_changes: Vec<RegistrationChange>,
         two_previous_snapshot: std::sync::Arc<EpochSnapshot>,
     ) -> Self {
-        use tracing::{debug, info};
+        use tracing::debug;
 
         let mut snapshot = EpochSnapshot {
             epoch,
@@ -205,7 +205,7 @@ impl EpochSnapshot {
         let total_rewards: u64 = stake_addresses.values().map(|sas| sas.rewards).sum();
 
         // Log to be comparable with the DBSync ada_pots table
-        info!(
+        debug!(
             epoch,
             treasury = pots.treasury,
             reserves = pots.reserves,

--- a/modules/accounts_state/src/monetary.rs
+++ b/modules/accounts_state/src/monetary.rs
@@ -5,7 +5,7 @@ use acropolis_common::{
 };
 use anyhow::{anyhow, Result};
 use bigdecimal::{BigDecimal, One, ToPrimitive};
-use tracing::info;
+use tracing::debug;
 
 /// Result of monetary calculation
 #[derive(Debug, Default, Clone)]
@@ -56,7 +56,7 @@ pub fn calculate_monetary_change(
         .to_u64()
         .ok_or(anyhow!("Can't calculate integral stake rewards"))?;
 
-    info!(total_rewards=%total_reward_pot, cut=%treasury_cut, increase=treasury_increase_u64,
+    debug!(total_rewards=%total_reward_pot, cut=%treasury_cut, increase=treasury_increase_u64,
           stake_rewards, "Treasury:");
 
     Ok(MonetaryResult {
@@ -99,7 +99,7 @@ fn calculate_monetary_expansion(
             / BigDecimal::from(monetary_expansion_factor.denom()))
         .with_scale(0);
 
-    info!(eta=%eta, rho=%monetary_expansion_factor, %monetary_expansion, "Monetary:");
+    debug!(eta=%eta, rho=%monetary_expansion_factor, %monetary_expansion, "Monetary:");
 
     monetary_expansion
 }

--- a/modules/accounts_state/src/rewards.rs
+++ b/modules/accounts_state/src/rewards.rs
@@ -94,7 +94,7 @@ pub fn calculate_rewards(
     let total_active_stake =
         BigDecimal::from(staking.spos.values().map(|s| s.total_stake).sum::<Lovelace>());
 
-    info!(epoch, go=staking.epoch, mark=performance.epoch,
+    debug!(epoch, go=staking.epoch, mark=performance.epoch,
           %total_supply, %total_active_stake, %stake_rewards, total_blocks,
           "Calculating rewards:");
 
@@ -149,7 +149,7 @@ pub fn calculate_rewards(
             pay_to_pool_reward_account = registrations.contains(&staking_spo.reward_account);
 
             if pay_to_pool_reward_account {
-                info!(
+                debug!(
                     "SPO {}'s reward account {} registered before stability window - will pay leader reward",
                     operator_id, staking_spo.reward_account
                 );
@@ -160,7 +160,7 @@ pub fn calculate_rewards(
         // In Cardano, addrsRew is captured at the stability window, so accounts that deregister
         // after the snapshot but before the stability window should NOT receive leader rewards.
         if pay_to_pool_reward_account && deregistrations.contains(&staking_spo.reward_account) {
-            info!(
+            debug!(
                 "SPO {}'s reward account {} deregistered before stability window - not paying",
                 operator_id, staking_spo.reward_account
             );
@@ -184,7 +184,7 @@ pub fn calculate_rewards(
                             > 0
                         {
                             pay_to_pool_reward_account = false;
-                            warn!("Shelley shared reward account bug: Dropping reward to {} in favour of {} on shared account {}",
+                            debug!("Shelley shared reward account bug: Dropping reward to {} in favour of {} on shared account {}",
                                   operator_id,
                                   other_id,
                                   staking_spo.reward_account);
@@ -193,7 +193,7 @@ pub fn calculate_rewards(
                     }
                 }
             } else {
-                info!("Reward account for SPO {} isn't registered", operator_id);
+                debug!("Reward account for SPO {} isn't registered", operator_id);
             }
         }
 
@@ -250,7 +250,7 @@ pub fn calculate_rewards(
         }
     }
 
-    info!(
+    debug!(
         num_delegators_paid,
         total_paid_to_delegators,
         num_pools_paid,

--- a/modules/accounts_state/src/runtime.rs
+++ b/modules/accounts_state/src/runtime.rs
@@ -12,7 +12,7 @@ use acropolis_common::{
 use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc;
 use tokio::task::{spawn_blocking, JoinHandle};
-use tracing::{error, info};
+use tracing::{debug, error};
 
 #[derive(Debug, Default)]
 pub(crate) struct AccountsRuntime {
@@ -96,7 +96,7 @@ impl RewardRuntime {
 
         if epoch_slot >= self.stability_window_slot {
             if let Some(tx) = self.start_rewards_tx.take() {
-                info!(
+                debug!(
                     "Starting rewards calculation at block {}, epoch slot {}",
                     block_number, epoch_slot
                 );

--- a/modules/accounts_state/src/state.rs
+++ b/modules/accounts_state/src/state.rs
@@ -424,7 +424,7 @@ impl State {
 
     /// Background stats logger
     pub fn log_stats(&self) {
-        info!(num_stake_addresses = self.stake_addresses.lock().unwrap().len());
+        debug!(num_stake_addresses = self.stake_addresses.lock().unwrap().len());
     }
 
     /// Query utxo_state for the total lovelace of AVVM UTxOs cancelled at the Allegra boundary.
@@ -510,7 +510,7 @@ impl State {
     ) -> Result<()> {
         let pointer_values = self.get_pointer_address_values(context.clone()).await?;
         if pointer_values.is_empty() {
-            info!("No pointer address UTxOs found at Conway boundary");
+            debug!("No pointer address UTxOs found at Conway boundary");
             return Ok(());
         }
 
@@ -529,7 +529,7 @@ impl State {
         let total_pointer_lovelace: u64 = pointer_values.values().sum();
         let unresolved_lovelace = total_pointer_lovelace - resolved_lovelace;
 
-        info!(
+        debug!(
             total_pointers = pointer_values.len(),
             resolved_accounts = stake_values.len(),
             total_pointer_lovelace,
@@ -611,7 +611,7 @@ impl State {
 
             let old_reserves = self.pots.reserves;
             self.pots.reserves += avvm_cancelled;
-            info!(
+            debug!(
                 old_reserves,
                 new_reserves = self.pots.reserves,
                 avvm_cancelled,
@@ -638,17 +638,17 @@ impl State {
         // We need to do this because tracking fees - which increase reserves - during Byron
         // is painful, requiring lookup of UTXO value for every input
         if is_new_era && era == Era::Shelley {
-            info!("Entering Shelley era - fixing up reserves");
+            debug!("Entering Shelley era - fixing up reserves");
 
             let total_utxos = self.get_total_utxos_at_shelley_start(context).await?;
-            info!("Total UTXO value: {total_utxos}");
+            debug!("Total UTXO value: {total_utxos}");
 
             let reserves = shelley_params.max_lovelace_supply - total_utxos;
-            info!("Reserves remaining: {reserves}");
+            debug!("Reserves remaining: {reserves}");
             self.pots.reserves = reserves;
         }
 
-        info!(
+        debug!(
             epoch,
             reserves = self.pots.reserves,
             treasury = self.pots.treasury,
@@ -692,7 +692,7 @@ impl State {
         )?;
         self.pots = monetary_change.pots.clone();
 
-        info!(
+        debug!(
             epoch,
             reserves = self.pots.reserves,
             treasury = self.pots.treasury,
@@ -801,7 +801,7 @@ impl State {
         };
         self.mutate_stake_addresses(undo, retiring_delegators.clone(), |stake_addresses| {
             for id in retiring.iter() {
-                info!(epoch, "SPO {id} has retired");
+                debug!(epoch, "SPO {id} has retired");
             }
 
             for stake_address in &retiring_delegators {
@@ -903,7 +903,7 @@ impl State {
                     pool: PoolId::default(),
                 });
             } else {
-                warn!(
+                debug!(
                     "Reward account {} deregistered - paying refund to treasury",
                     reward_account
                 );
@@ -929,7 +929,7 @@ impl State {
 
         let refunds = take(&mut self.pool_refunds);
         if !refunds.is_empty() {
-            info!(
+            debug!(
                 "{} retiring SPOs, total refunds {}",
                 refunds.len(),
                 (refunds.len() as u64) * deposit
@@ -956,7 +956,7 @@ impl State {
                     pool,
                 });
             } else {
-                warn!(
+                debug!(
                     "SPO reward account {} deregistered - paying refund to treasury",
                     stake_address
                 );
@@ -1011,7 +1011,7 @@ impl State {
                     total_value += value;
                 }
 
-                info!(
+                debug!(
                     "MIR accumulated: {total_value} stake addresses from {source_name} (epoch {}, {})",
                     deltas.len(),
                     if is_alonzo_plus { "sum" } else { "override" }
@@ -1042,7 +1042,7 @@ impl State {
                     error!("MIR to {other_name}: {e}");
                 }
 
-                info!("MIR of {value} from {source_name} to {other_name}");
+                debug!("MIR of {value} from {source_name} to {other_name}");
             }
         }
     }
@@ -1097,7 +1097,7 @@ impl State {
                 }
             }
 
-            info!(
+            debug!(
                 "Applied {} pending MIRs from reserves: {} applied, {} not applied (deregistered/unknown)",
                 count, total_applied, total_not_registered
             );
@@ -1145,7 +1145,7 @@ impl State {
                 }
             }
 
-            info!(
+            debug!(
                 "Applied {} pending MIRs from treasury: {} applied, {} not applied (deregistered/unknown)",
                 count, total_applied, total_not_registered
             );
@@ -1394,7 +1394,7 @@ impl State {
         self.pots.deposits += total_deposits;
 
         if new_count > 0 {
-            info!("{new_count} new SPOs, total new deposits {total_deposits}");
+            debug!("{new_count} new SPOs, total new deposits {total_deposits}");
         }
 
         // Check for any SPOs that have retired this epoch and need deposit refunds
@@ -1818,7 +1818,7 @@ impl State {
             update_value_with_delta(pot, delta)
                 .map_err(|e| anyhow::anyhow!("Applying {name} pot delta {delta}: {e}"))?;
 
-            info!("Pot delta for {name} {delta} => {pot}");
+            debug!("Pot delta for {name} {delta} => {pot}");
             Ok(())
         };
 
@@ -1876,7 +1876,7 @@ impl State {
                             self.mutate_stake_address(undo, &reward_account, |stake_addresses| {
                                 stake_addresses.add_to_reward(&reward_account, *amount);
                             });
-                            info!(
+                            debug!(
                                 "Treasury withdrawal: {} lovelace ({} ADA) to {}",
                                 amount,
                                 amount / 1_000_000,
@@ -1895,7 +1895,7 @@ impl State {
         }
 
         if !outcomes_msg.conway_outcomes.is_empty() {
-            info!(
+            debug!(
                 "Governance outcomes: {} proposals processed",
                 outcomes_msg.conway_outcomes.len(),
             );
@@ -1903,7 +1903,7 @@ impl State {
 
         let mut reward_deltas = Vec::new();
         reward_deltas.extend(self.pay_proposal_refunds(undo));
-        info!(
+        debug!(
             "Refunds: {}, rewards: {}",
             self.proposal_refunds.len(),
             reward_deltas.len()

--- a/modules/accounts_state/src/verifier.rs
+++ b/modules/accounts_state/src/verifier.rs
@@ -18,7 +18,7 @@ use std::{
     fs::{read_dir, File},
     path::PathBuf,
 };
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, warn};
 
 /// Verifier
 pub struct Verifier {
@@ -273,7 +273,7 @@ impl Verifier {
             }
 
             if pots == desired_pots {
-                info!(epoch = epoch, "Verification success for");
+                debug!(epoch = epoch, "Verification success for");
             }
         } else {
             warn!("Epoch {epoch} not represented in verify test data");
@@ -342,7 +342,7 @@ impl Verifier {
                 });
             }
 
-            info!(
+            debug!(
                 epoch,
                 "Read rewards verification data for {} SPOs",
                 expected_rewards.len()
@@ -427,7 +427,7 @@ impl Verifier {
             }
 
             if errors == 0 {
-                info!(epoch, "Rewards verification OK");
+                debug!(epoch, "Rewards verification OK");
             } else {
                 error!(errors, epoch, "Rewards verification:");
             }
@@ -520,7 +520,7 @@ impl Verifier {
 
         let (outcome, total, _, _, _) = Self::verify_spdd_impl(epoch, spdd, &reference);
         if outcome {
-            info!("Verification of SPDD, end of epoch {epoch}: OK, total active stake {total}");
+            debug!("Verification of SPDD, end of epoch {epoch}: OK, total active stake {total}");
         } else {
             error!("Verification of SPDD, end of epoch {epoch}: Failed");
         }

--- a/modules/accounts_state/src/verifier.rs
+++ b/modules/accounts_state/src/verifier.rs
@@ -18,7 +18,7 @@ use std::{
     fs::{read_dir, File},
     path::PathBuf,
 };
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info, warn};
 
 /// Verifier
 pub struct Verifier {
@@ -520,7 +520,7 @@ impl Verifier {
 
         let (outcome, total, _, _, _) = Self::verify_spdd_impl(epoch, spdd, &reference);
         if outcome {
-            debug!("Verification of SPDD, end of epoch {epoch}: OK, total active stake {total}");
+            info!("Verification of SPDD, end of epoch {epoch}: OK, total active stake {total}");
         } else {
             error!("Verification of SPDD, end of epoch {epoch}: Failed");
         }

--- a/modules/assets_state/src/state.rs
+++ b/modules/assets_state/src/state.rs
@@ -10,7 +10,7 @@ use acropolis_common::{
 };
 use anyhow::Result;
 use imbl::{HashMap, Vector};
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 const CIP67_LABEL_222: [u8; 4] = [0x00, 0x0d, 0xe1, 0x40];
 const CIP67_LABEL_333: [u8; 4] = [0x00, 0x14, 0xdf, 0x10];
@@ -253,7 +253,7 @@ impl State {
         } else if let Some(transactions) = &self.transactions {
             self.log_assets(transactions.len());
         } else {
-            info!("asset_state storage disabled in config");
+            debug!("asset_state storage disabled in config");
         }
 
         Ok(())

--- a/modules/drep_state/src/state.rs
+++ b/modules/drep_state/src/state.rs
@@ -15,7 +15,7 @@ use acropolis_common::{
 use anyhow::{anyhow, bail, Result};
 use caryatid_sdk::Context;
 use std::{collections::HashMap, sync::Arc};
-use tracing::info;
+use tracing::debug;
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct HistoricalDRepState {
@@ -225,7 +225,7 @@ impl State {
     }
 
     async fn log_stats(&self) {
-        info!(count = self.dreps.len());
+        debug!(count = self.dreps.len());
     }
 
     pub async fn tick(&self) -> Result<()> {

--- a/modules/governance_state/src/conway_voting.rs
+++ b/modules/governance_state/src/conway_voting.rs
@@ -488,7 +488,7 @@ impl ConwayVoting {
         };
         let committee_ok = Self::check_committee_validity(new_epoch, proposal, conway_params)?;
         let accepted = previous_ok && committee_ok && voted;
-        info!(
+        debug!(
             "Proposal {action_id}: enactment epoch {new_epoch}, votes {votes}, \
              thresholds {threshold}, prevous_ok {previous_ok}, bootstrap {bootstrap}, \
              voted {voted}, committee {committee_ok}, result {accepted}"

--- a/modules/governance_state/src/state.rs
+++ b/modules/governance_state/src/state.rs
@@ -19,7 +19,7 @@ use acropolis_common::{
 use anyhow::{anyhow, bail, Result};
 use hex::ToHex;
 use imbl::HashMap;
-use tracing::{debug, info};
+use tracing::debug;
 
 #[derive(Default, Clone)]
 pub struct State {
@@ -208,7 +208,7 @@ impl State {
             self.conway_voting.include_pending_votes()?;
             let acc = ratified.iter().filter(|oc| oc.voting.accepted).count();
 
-            info!(
+            debug!(
                 "Conway voting, epoch {} ({}): {voting_state}, total {} actions, {acc} accepted",
                 new_block.epoch,
                 new_block.era,
@@ -227,7 +227,7 @@ impl State {
     }
 
     pub fn log_stats(&self) {
-        info!(
+        debug!(
             "{}, {}, drep stake msgs (size): {} ({})",
             self.alonzo_babbage_voting.get_stats(),
             self.conway_voting.get_stats(),

--- a/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
+++ b/modules/mithril_snapshot_fetcher/src/mithril_snapshot_fetcher.rs
@@ -343,7 +343,7 @@ impl MithrilSnapshotFetcher {
                         last_epoch = Some(epoch);
 
                         if new_epoch {
-                            info!(epoch, number, slot, "New epoch");
+                            debug!(epoch, number, slot, "New epoch");
                         }
 
                         let timestamp = genesis.slot_to_timestamp(slot);

--- a/modules/parameters_state/src/parameters_state.rs
+++ b/modules/parameters_state/src/parameters_state.rs
@@ -21,7 +21,7 @@ use caryatid_sdk::{message_bus::Subscription, module, Context};
 use config::Config;
 use std::sync::Arc;
 use tokio::sync::Mutex;
-use tracing::{error, info, info_span, Instrument};
+use tracing::{debug, error, info, info_span, Instrument};
 
 mod alonzo_genesis;
 mod genesis_params;
@@ -131,7 +131,7 @@ impl ParametersState {
 
                             // Commit state on params change
                             if current_params != new_params.params {
-                                info!(
+                                debug!(
                                     "New parameter set enacted [from epoch, params]: [{},{}]",
                                     block.epoch,
                                     serde_json::to_string(&new_params.params)?

--- a/modules/parameters_state/src/parameters_updater.rs
+++ b/modules/parameters_state/src/parameters_updater.rs
@@ -7,7 +7,7 @@ use acropolis_common::{
     GovernanceOutcomeVariant, ProtocolParamUpdate,
 };
 use anyhow::{anyhow, bail, Result};
-use tracing::error;
+use tracing::{debug, error};
 
 #[derive(Default, Clone)]
 pub struct ParametersUpdater {
@@ -224,10 +224,9 @@ impl ParametersUpdater {
         }
         for (new_member, v) in cu.new_committee_members.iter() {
             if let Some(old) = c.members.insert(new_member.clone(), *v) {
-                error!(
-                    "New committee member {:?} replaces the old committee member {:?}",
-                    (new_member, v),
-                    old
+                debug!(
+                    "Updated committee member {:?}: {:?} -> {:?}",
+                    new_member, old, v
                 );
             }
         }

--- a/modules/parameters_state/src/state.rs
+++ b/modules/parameters_state/src/state.rs
@@ -9,7 +9,7 @@ use acropolis_common::{
 };
 use anyhow::Result;
 use std::ops::RangeInclusive;
-use tracing::info;
+use tracing::{debug, info};
 
 #[derive(Default, Clone)]
 pub struct State {
@@ -62,7 +62,7 @@ impl State {
         alonzo_gov: &[AlonzoBabbageVotingOutcome],
         conway_gov: &[GovernanceOutcomeVariant],
     ) -> Result<()> {
-        info!("Current Era: {:?}", self.current_era);
+        debug!("Current Era: {:?}", self.current_era);
         if self.current_era != Some(*new_era) {
             self.apply_genesis(new_era)?;
         }
@@ -74,7 +74,7 @@ impl State {
         new_era: &Era,
         msg: &GovernanceOutcomesMessage,
     ) -> Result<ProtocolParamsMessage> {
-        info!("Era: {:?}, applying enact state", new_era);
+        debug!("Era: {:?}, applying enact state", new_era);
         let conway_outcomes: Vec<_> =
             msg.conway_outcomes.iter().map(|o| o.action_to_perform.clone()).collect();
         self.apply_governance_outcomes(new_era, &msg.alonzo_babbage_outcomes, &conway_outcomes)?;

--- a/modules/peer_network_interface/src/block_flow.rs
+++ b/modules/peer_network_interface/src/block_flow.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use caryatid_sdk::{Context, Subscription};
 use pallas::network::miniprotocols::Point;
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 use crate::BlockSink;
 use crate::chain_state::{ChainEvent, ChainState, SpecificPoint};
@@ -256,7 +256,7 @@ impl BlockFlowHandler {
                             block_sink.announce_roll_forward(header, body, tip).await?;
                             *published_blocks += 1;
                             if published_blocks.is_multiple_of(100) {
-                                info!("Published block {}", header.number);
+                                debug!("Published block {}", header.number);
                             }
                         }
                         ChainEvent::RollBackward { header } => {

--- a/modules/spo_state/src/state.rs
+++ b/modules/spo_state/src/state.rs
@@ -22,7 +22,7 @@ use acropolis_common::{PoolRegistrationOutcome, PoolRegistrationUpdate};
 use anyhow::{anyhow, Result};
 use imbl::HashMap;
 use std::sync::{Arc, Mutex};
-use tracing::{debug, info};
+use tracing::debug;
 
 const DEFAULT_POOL_DEPOSIT: u64 = 500_000_000;
 
@@ -244,7 +244,7 @@ impl State {
     }
 
     fn log_stats(&self) {
-        info!(
+        debug!(
             num_spos = self.spos.keys().len(),
             num_pending_deregistrations =
                 self.pending_deregistrations.values().map(|d| d.len()).sum::<usize>(),

--- a/modules/utxo_state/src/state.rs
+++ b/modules/utxo_state/src/state.rs
@@ -483,7 +483,7 @@ impl State {
     async fn log_stats(&self) {
         let n_immutable = self.immutable_utxos.len().await.unwrap_or_default();
         let n_valid = self.count_valid_utxos().await;
-        info!(
+        debug!(
             slot = self.last_slot,
             number = self.last_number,
             immutable_utxos = n_immutable,

--- a/modules/utxo_state/src/state.rs
+++ b/modules/utxo_state/src/state.rs
@@ -449,7 +449,7 @@ impl State {
             // and remove from both maps
             let spent_utxos = self.volatile_spent.prune_before(boundary);
             if !spent_utxos.is_empty() {
-                info!("Removing {} immutably spent UTXOs", spent_utxos.len());
+                debug!("Removing {} immutably spent UTXOs", spent_utxos.len());
                 for key in spent_utxos {
                     // Remove from volatile, and only if not there, from immutable
                     if self.volatile_utxos.remove(&key).is_none() {
@@ -461,7 +461,7 @@ impl State {
             // Prune the created index too, and transfer the UTXOs to immutable
             let created_utxos = self.volatile_created.prune_before(boundary);
             if !created_utxos.is_empty() {
-                info!(
+                debug!(
                     "Moving {} volatile UTXOs into immutable",
                     created_utxos.len()
                 );

--- a/processes/omnibus/omnibus.toml
+++ b/processes/omnibus/omnibus.toml
@@ -151,9 +151,9 @@ store-drdd = false
 # Listen for DRep and SPO distributions
 stake-drep-distribution-topic = "cardano.drep.distribution"
 stake-spo-distribution-topic = "cardano.spo.distribution"
-verification-output-file = "../../modules/governance_state/data/verification.csv"
-verify-votes-files = "../../modules/governance_state/votes-mainnet/mainnet.{epoch}.{action_id}.csv"
-verify-aggregate-votes-file = "../../modules/governance_state/votes-mainnet/mainnet.votes.csv"
+#verification-output-file = "../../modules/governance_state/data/verification.csv"
+#verify-votes-files = "../../modules/governance_state/votes-mainnet/mainnet.{epoch}.{action_id}.csv"
+#verify-aggregate-votes-file = "../../modules/governance_state/votes-mainnet/mainnet.votes.csv"
 
 [module.parameters-state]
 # Listen for governance actions

--- a/processes/omnibus/src/main.rs
+++ b/processes/omnibus/src/main.rs
@@ -67,10 +67,10 @@ struct Args {
 pub async fn main() -> Result<()> {
     let args = <self::Args as clap::Parser>::parse();
 
-    // Standard logging using RUST_LOG for log levels default to INFO for events only
-    let fmt_layer = fmt::layer()
-        .with_filter(EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new("info")))
-        .with_filter(filter::filter_fn(|meta| meta.is_event()));
+    let mut filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    filter = filter.add_directive("fjall=error".parse().unwrap());
+    let fmt_layer =
+        fmt::layer().with_filter(filter).with_filter(filter::filter_fn(|meta| meta.is_event()));
 
     // Only turn on tracing if some OTEL environment variables exist
     if std::env::vars().any(|(name, _)| name.starts_with("OTEL_")) {


### PR DESCRIPTION
## Description

This PR replaces all info! logs with debug! in the omnibus process except `epoch_state`'s new epoch message. This makes it easier to inspect errors and follow the sync progress. I've also disabled governance verification by default as it creates significant log spam.

## Related Issue(s)
N/A

## How was this tested?
N/A

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
N/A

## Reviewer notes / Areas to focus
N/A
