### PR TITLE
fix: tx certificate encoding

### DIFF
--- a/modules/utxo_state/src/validations/phase_two/cert.rs
+++ b/modules/utxo_state/src/validations/phase_two/cert.rs
@@ -5,16 +5,31 @@ use uplc_turbo::{arena::Arena, data::PlutusData, machine::PlutusVersion};
 
 use super::to_plutus_data::*;
 
-impl ToPlutusData for TxCertificate {
-    fn to_plutus_data<'a>(
-        &self,
-        arena: &'a Arena,
-        version: PlutusVersion,
-    ) -> Result<&'a PlutusData<'a>, ScriptContextError> {
-        match version {
-            PlutusVersion::V1 | PlutusVersion::V2 => encode_dcert(self, arena, version),
-            PlutusVersion::V3 => encode_tx_cert(self, arena, version),
-        }
+/// Conway bootstrap phase covers protocol major version 9.
+///
+/// Matches the Haskell ledger's `hardforkConwayBootstrapPhase` in
+/// `Cardano.Ledger.Conway.Era`. During this phase, the `Maybe Lovelace`
+/// deposit/refund fields on `TxCertRegStaking`/`TxCertUnRegStaking` are
+/// translated to `Nothing` regardless of the actual deposit on the cert.
+fn is_conway_bootstrap(protocol_major_version: u64) -> bool {
+    protocol_major_version == 9
+}
+
+/// Encode a certificate as PlutusData for the given Plutus version.
+///
+/// V1/V2 uses the legacy `DCert` encoding (deposit-independent).
+/// V3 uses the Conway `TxCert` encoding, which depends on protocol version
+/// for stake registration/deregistration certificates during the bootstrap
+/// phase.
+pub fn encode_cert<'a>(
+    cert: &TxCertificate,
+    arena: &'a Arena,
+    version: PlutusVersion,
+    protocol_major_version: u64,
+) -> Result<&'a PlutusData<'a>, ScriptContextError> {
+    match version {
+        PlutusVersion::V1 | PlutusVersion::V2 => encode_dcert(cert, arena, version),
+        PlutusVersion::V3 => encode_tx_cert(cert, arena, version, protocol_major_version),
     }
 }
 
@@ -81,7 +96,15 @@ fn encode_tx_cert<'a>(
     cert: &TxCertificate,
     arena: &'a Arena,
     version: PlutusVersion,
+    protocol_major_version: u64,
 ) -> Result<&'a PlutusData<'a>, ScriptContextError> {
+    // During Conway bootstrap (protocol v9), the Haskell ledger translates
+    // the `Maybe Lovelace` on RegStaking/UnRegStaking as `Nothing` even when
+    // the underlying cert carries a deposit/refund. See
+    // `cardano-ledger/eras/conway/impl/src/Cardano/Ledger/Conway/TxInfo.hs`
+    // (`transTxCert`).
+    let bootstrap = is_conway_bootstrap(protocol_major_version);
+
     match cert {
         TxCertificate::StakeRegistration(addr) => {
             let cred = addr.credential.to_plutus_data(arena, version)?;
@@ -91,9 +114,13 @@ fn encode_tx_cert<'a>(
         }
         TxCertificate::Registration(reg) => {
             let cred = reg.stake_address.credential.to_plutus_data(arena, version)?;
-            let deposit = reg.deposit.to_plutus_data(arena, version)?;
-            let just = constr(arena, 0, vec![deposit]);
-            Ok(constr(arena, 0, vec![cred, just]))
+            let maybe_deposit = if bootstrap {
+                constr(arena, 1, vec![])
+            } else {
+                let deposit = reg.deposit.to_plutus_data(arena, version)?;
+                constr(arena, 0, vec![deposit])
+            };
+            Ok(constr(arena, 0, vec![cred, maybe_deposit]))
         }
         TxCertificate::StakeDeregistration(addr) => {
             let cred = addr.credential.to_plutus_data(arena, version)?;
@@ -103,9 +130,13 @@ fn encode_tx_cert<'a>(
         }
         TxCertificate::Deregistration(dereg) => {
             let cred = dereg.stake_address.credential.to_plutus_data(arena, version)?;
-            let refund = dereg.refund.to_plutus_data(arena, version)?;
-            let just = constr(arena, 0, vec![refund]);
-            Ok(constr(arena, 1, vec![cred, just]))
+            let maybe_refund = if bootstrap {
+                constr(arena, 1, vec![])
+            } else {
+                let refund = dereg.refund.to_plutus_data(arena, version)?;
+                constr(arena, 0, vec![refund])
+            };
+            Ok(constr(arena, 1, vec![cred, maybe_refund]))
         }
         TxCertificate::StakeDelegation(deleg) => {
             let cred = deleg.stake_address.credential.to_plutus_data(arena, version)?;

--- a/modules/utxo_state/src/validations/phase_two/evaluate.rs
+++ b/modules/utxo_state/src/validations/phase_two/evaluate.rs
@@ -260,7 +260,9 @@ pub fn evaluate_scripts(
     let arena_for_tx_info = Arena::from_bump(Bump::with_capacity(ARENA_INITIAL_CAPACITY));
     plutus_versions.iter().for_each(|common_version| {
         let version = from_common_version(*common_version);
-        if let Ok(tx_info_pd) = encode_tx_info(tx_info, &arena_for_tx_info, version) {
+        if let Ok(tx_info_pd) =
+            encode_tx_info(tx_info, &arena_for_tx_info, version, protocol_major_version)
+        {
             cached_tx_info_pd.insert(*common_version, tx_info_pd);
         }
     });
@@ -311,7 +313,7 @@ fn evaluate_single_script(
 
     // 1. Build script arguments
     let args = sc
-        .to_script_args(tx_info_pd, arena, plutus_version)
+        .to_script_args(tx_info_pd, arena, plutus_version, protocol_major_version)
         .map_err(Phase2ValidationError::ScriptContextError)?;
 
     // 2. Look up script bytes
@@ -488,15 +490,13 @@ mod tests {
         matches Ok(());
         "conway - valid transaction 8 - with 1 Plutus V2 Mint script with duplicate redeemer pointers"
     )]
-    // TODO:
-    // Make this test pass
-    // #[test_case(validation_fixture!(
-    //     "conway",
-    //     "6f5ef8b9aaeb7bf6242b34c1191622448960901e704ff92968498c2f426cbef0"
-    // ) =>
-    //     matches Ok(());
-    //     "conway - valid transaction 9 - with 1 Plutus V3 Cert script"
-    // )]
+    #[test_case(validation_fixture!(
+        "conway",
+        "6f5ef8b9aaeb7bf6242b34c1191622448960901e704ff92968498c2f426cbef0"
+    ) =>
+        matches Ok(());
+        "conway - valid transaction 9 - with 1 Plutus V3 Cert script"
+    )]
     #[test_case(validation_fixture!(
         "conway",
         "332aac636f8476b1a91c0071a445103d8f55309c23bfddaf242732630efcf0ec",

--- a/modules/utxo_state/src/validations/phase_two/script_context.rs
+++ b/modules/utxo_state/src/validations/phase_two/script_context.rs
@@ -8,6 +8,7 @@ use acropolis_common::{
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use uplc_turbo::{arena::Arena, data::PlutusData, machine::PlutusVersion};
 
+use super::cert::encode_cert;
 use super::governance::*;
 use super::input::*;
 use super::time_range::*;
@@ -258,15 +259,17 @@ impl ScriptContext<'_> {
         tx_info_pd: Option<&'a PlutusData<'a>>,
         arena: &'a Arena,
         version: PlutusVersion,
+        protocol_major_version: u64,
     ) -> Result<Vec<&'a PlutusData<'a>>, ScriptContextError> {
         let tx_info_pd = match tx_info_pd {
             Some(pd) => pd,
-            None => encode_tx_info(self.tx_info, arena, version)?,
+            None => encode_tx_info(self.tx_info, arena, version, protocol_major_version)?,
         };
 
         match version {
             PlutusVersion::V1 | PlutusVersion::V2 => {
-                let purpose_pd = encode_script_purpose(&self.purpose, arena, version)?;
+                let purpose_pd =
+                    encode_script_purpose(&self.purpose, arena, version, protocol_major_version)?;
                 let context_pd = constr(arena, 0, vec![tx_info_pd, purpose_pd]);
 
                 let mut args = Vec::new();
@@ -279,8 +282,13 @@ impl ScriptContext<'_> {
             }
             PlutusVersion::V3 => {
                 let redeemer_pd = from_cbor(arena, &self.redeemer.data)?;
-                let script_info_pd =
-                    encode_script_info(&self.purpose, &self.datum, arena, version)?;
+                let script_info_pd = encode_script_info(
+                    &self.purpose,
+                    &self.datum,
+                    arena,
+                    version,
+                    protocol_major_version,
+                )?;
                 let context_pd = constr(arena, 0, vec![tx_info_pd, redeemer_pd, script_info_pd]);
                 Ok(vec![context_pd])
             }
@@ -296,6 +304,7 @@ pub fn encode_tx_info<'a>(
     tx_info: &TxInfo,
     arena: &'a Arena,
     version: PlutusVersion,
+    protocol_major_version: u64,
 ) -> Result<&'a PlutusData<'a>, ScriptContextError> {
     let inputs = {
         let items: Vec<_> = tx_info
@@ -331,7 +340,7 @@ pub fn encode_tx_info<'a>(
         let items: Vec<_> = tx_info
             .certificates
             .iter()
-            .map(|c| c.cert.to_plutus_data(arena, version))
+            .map(|c| encode_cert(&c.cert, arena, version, protocol_major_version))
             .collect::<Result<_, _>>()?;
         list(arena, items)
     };
@@ -379,7 +388,8 @@ pub fn encode_tx_info<'a>(
                     .collect::<Result<_, _>>()?;
                 list(arena, items)
             };
-            let redeemers_pd = encode_redeemers_map(tx_info, arena, version)?;
+            let redeemers_pd =
+                encode_redeemers_map(tx_info, arena, version, protocol_major_version)?;
             Ok(constr(
                 arena,
                 0,
@@ -408,7 +418,8 @@ pub fn encode_tx_info<'a>(
                     .collect::<Result<_, _>>()?;
                 list(arena, items)
             };
-            let redeemers_pd = encode_redeemers_map(tx_info, arena, version)?;
+            let redeemers_pd =
+                encode_redeemers_map(tx_info, arena, version, protocol_major_version)?;
             let votes = match &tx_info.voting_procedures {
                 Some(vp) => vp.to_plutus_data(arena, version)?,
                 None => map(arena, vec![]),
@@ -469,6 +480,7 @@ fn encode_script_purpose<'a>(
     purpose: &ScriptPurpose,
     arena: &'a Arena,
     version: PlutusVersion,
+    protocol_major_version: u64,
 ) -> Result<&'a PlutusData<'a>, ScriptContextError> {
     match purpose {
         ScriptPurpose::Mint(policy_id) => {
@@ -485,7 +497,7 @@ fn encode_script_purpose<'a>(
             Ok(constr(arena, 2, vec![staking]))
         }
         ScriptPurpose::Certify(cert_with_pos) => {
-            let c = cert_with_pos.cert.to_plutus_data(arena, version)?;
+            let c = encode_cert(&cert_with_pos.cert, arena, version, protocol_major_version)?;
             Ok(constr(arena, 3, vec![c]))
         }
         _ => Err(ScriptContextError::UnsupportedScriptPurpose),
@@ -501,6 +513,7 @@ fn encode_script_info<'a>(
     datum: &Option<Vec<u8>>,
     arena: &'a Arena,
     version: PlutusVersion,
+    protocol_major_version: u64,
 ) -> Result<&'a PlutusData<'a>, ScriptContextError> {
     match purpose {
         ScriptPurpose::Mint(policy_id) => {
@@ -524,7 +537,7 @@ fn encode_script_info<'a>(
         }
         ScriptPurpose::Certify(cert_with_pos) => {
             let idx = cert_with_pos.cert_index.to_plutus_data(arena, version)?;
-            let c = cert_with_pos.cert.to_plutus_data(arena, version)?;
+            let c = encode_cert(&cert_with_pos.cert, arena, version, protocol_major_version)?;
             Ok(constr(arena, 3, vec![idx, c]))
         }
         ScriptPurpose::Vote(voter) => {
@@ -547,6 +560,7 @@ fn encode_redeemers_map<'a>(
     tx_info: &TxInfo,
     arena: &'a Arena,
     version: PlutusVersion,
+    protocol_major_version: u64,
 ) -> Result<&'a PlutusData<'a>, ScriptContextError> {
     let sorted_inputs: Vec<UTxOIdentifier> = tx_info.inputs.iter().map(|ri| ri.utxo_id).collect();
 
@@ -568,7 +582,7 @@ fn encode_redeemers_map<'a>(
                     Some(tx_info.proposal_procedures.as_slice())
                 },
             )?;
-            let key = encode_redeemer_key(&purpose, arena, version)?;
+            let key = encode_redeemer_key(&purpose, arena, version, protocol_major_version)?;
             let value = from_cbor(arena, &redeemer.data)?;
             Ok((key, value))
         })
@@ -584,6 +598,7 @@ fn encode_redeemer_key<'a>(
     purpose: &ScriptPurpose,
     arena: &'a Arena,
     version: PlutusVersion,
+    protocol_major_version: u64,
 ) -> Result<&'a PlutusData<'a>, ScriptContextError> {
     match purpose {
         // This is because Plutus Data Constructor Order
@@ -611,13 +626,13 @@ fn encode_redeemer_key<'a>(
         },
         ScriptPurpose::Certify(cert_with_pos) => match version {
             PlutusVersion::V1 | PlutusVersion::V2 => {
-                let c = cert_with_pos.cert.to_plutus_data(arena, version)?;
+                let c = encode_cert(&cert_with_pos.cert, arena, version, protocol_major_version)?;
                 Ok(constr(arena, 3, vec![c]))
             }
             PlutusVersion::V3 => {
                 // V3: includes the certificate index
                 let idx = cert_with_pos.cert_index.to_plutus_data(arena, version)?;
-                let c = cert_with_pos.cert.to_plutus_data(arena, version)?;
+                let c = encode_cert(&cert_with_pos.cert, arena, version, protocol_major_version)?;
                 Ok(constr(arena, 3, vec![idx, c]))
             }
         },
@@ -791,7 +806,7 @@ mod tests {
         let sc = &contexts[0];
 
         let arena = Arena::new();
-        let args = sc.to_script_args(None, &arena, PlutusVersion::V1).unwrap();
+        let args = sc.to_script_args(None, &arena, PlutusVersion::V1, 5).unwrap();
 
         // V1 spending: [datum, redeemer, context]
         assert_eq!(args.len(), 3, "V1 spending should produce 3 args");

--- a/processes/omnibus/omnibus.bootstrap-utxo-validation.toml
+++ b/processes/omnibus/omnibus.bootstrap-utxo-validation.toml
@@ -1,3 +1,22 @@
+# Bootstrap configuration for Acropolis omnibus process
+# Use with: --config omnibus.toml --config omnibus.bootstrap.toml
+# Later configs override earlier ones
+
+# ============================================================================
+# Startup Configuration
+# ============================================================================
+[global.startup]
+network-name = "mainnet"
+startup-mode = "snapshot"   # Options: "genesis" | "snapshot"
+sync-mode = "mithril" # Options: "mithril" | "upstream"
+
+# ============================================================================
+# Bootstrap Module Configurations
+# ============================================================================
+[module.snapshot-bootstrapper]
+epoch = 507
+data-dir = "../../modules/snapshot_bootstrapper/data"
+
 [module.consensus]
 # List of validation result topics to listen on
 validators = [


### PR DESCRIPTION
## Description

This PR fixes Tx Certificate Encoding for Conway Bootstrap phase 
and this fixes the Plutus Script Evaluation failure on certain [transaction](https://cexplorer.io/tx/6f5ef8b9aaeb7bf6242b34c1191622448960901e704ff92968498c2f426cbef0).

## Related Issue(s)
N/A

## How was this tested?
Added test case of conway transaction which has Cert Script Purpose. (Need to consider Conway Bootstrap phase)

## Checklist

- [x] My code builds and passes local tests
- [x] I added/updated tests for my changes, where applicable
- [x] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
N/A

## Reviewer notes / Areas to focus
modules/utxo_state/src/validations/phase_two/cert.rs
