### PR TITLE
bug: fixed erroneous committee check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,9 +2274,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -6196,9 +6196,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",

--- a/modules/parameters_state/src/parameters_updater.rs
+++ b/modules/parameters_state/src/parameters_updater.rs
@@ -223,13 +223,7 @@ impl ParametersUpdater {
             }
         }
         for (new_member, v) in cu.new_committee_members.iter() {
-            if let Some(old) = c.members.insert(new_member.clone(), *v) {
-                error!(
-                    "New committee member {:?} replaces the old committee member {:?}",
-                    (new_member, v),
-                    old
-                );
-            }
+            c.members.insert(new_member.clone(), *v);
         }
         c.threshold = cu.terms.clone();
     }


### PR DESCRIPTION
## Description

There was an error message for adding a committee member to a committee, where the member is already present.
It seems that there should not be such check.
The check was removed.

## Related Issue(s)

## How was this tested?
- integration tests (check from snapshot to tip)

## Checklist

- [ ] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [ ] branch has ≤ 5 commits (honor system)
- [ ] commit messages tell a coherent story
- [ ] branch is up to date with main (rebased on main; fast-forward possible)
- [ ] CI/CD passes on the merged-with-main result

## Impact / Side effects

## Reviewer notes / Areas to focus

