### PR TITLE
fix: rename slot_issuer to slot_leader for BlockInfo serialization

### DIFF
--- a/common/src/queries/blocks.rs
+++ b/common/src/queries/blocks.rs
@@ -165,7 +165,7 @@ impl Serialize for BlockInfo {
         state.serialize_field("epoch", &self.epoch)?;
         state.serialize_field("epoch_slot", &self.epoch_slot)?;
         state.serialize_field(
-            "slot_issuer",
+            "slot_leader",
             &self.issuer.clone().map(|vkey| -> String {
                 match vkey {
                     BlockIssuer::HeavyDelegate(_) => "Byron genesis slot issuer".to_string(),


### PR DESCRIPTION
## Description

Renames the `slot_issuer` field to `slot_leader` when serializing `BlockInfo`

## Related Issue(s)
N/A

## How was this tested?
N/A

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
N/A

## Reviewer notes / Areas to focus
N/A
