### PR TITLE
chore: Adjust logging levels for peers management.

### DIFF
--- a/modules/peer_network_interface/src/connection.rs
+++ b/modules/peer_network_interface/src/connection.rs
@@ -14,7 +14,7 @@ use tokio::{
     select,
     sync::{mpsc, oneshot},
 };
-use tracing::error;
+use tracing::debug;
 
 use crate::network::PeerMessageSender;
 
@@ -113,7 +113,7 @@ impl PeerConnectionWorker {
         blockfetch: mpsc::UnboundedReceiver<BlockfetchCommand>,
     ) {
         if let Err(err) = self.do_run(chainsync, blockfetch).await {
-            error!(peer = self.address, "{err:#}");
+            debug!(peer = self.address, "{err:#}");
         }
         let _ = self.sender.write(PeerEvent::Disconnected).await;
     }

--- a/modules/peer_network_interface/src/network.rs
+++ b/modules/peer_network_interface/src/network.rs
@@ -568,7 +568,12 @@ impl NetworkManager {
             );
             return;
         };
-        warn!(address = %peer.conn.address, "disconnected from peer");
+
+        if self.configured_addrs.contains(&peer.conn.address) {
+            warn!(address = %peer.conn.address, "disconnected from pre-configured peer");
+        } else {
+            info!(address = %peer.conn.address, "peer disconnected");
+        }
 
         // Capture state before peer is partially consumed.
         let is_cold_origin = self.cold_origin.remove(&id);
@@ -592,7 +597,7 @@ impl NetworkManager {
         if is_cold_origin && !established && !is_configured {
             // Cold-promoted peer that never established a connection (TCP refused / timeout).
             // Blacklist so peer-sharing cannot re-add it this session.
-            warn!(
+            info!(
                 address = %address,
                 "cold-promoted peer never connected — blacklisting for session"
             );


### PR DESCRIPTION
## Description

Peers management logs should log as `info` rather then `error` if the situation (e.g. disconnecting of discovered peer) is expected.

## Related Issue(s)
N/A

## How was this tested?
E.g. `run mainnet` or `run testnet` as specified in `MS-5-8-tests-v1` tag.

## Checklist

- [x] My code builds and passes local tests
- [ ] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
N/A

## Reviewer notes / Areas to focus
N/A
