### PR TITLE
fix: script malformedness check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1001,7 +1001,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1012,7 +1012,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2845,7 +2845,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3393,9 +3393,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3417,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -3670,7 +3670,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -3941,7 +3941,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4506,7 +4506,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5562,7 +5562,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5599,7 +5599,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6139,7 +6139,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6222,7 +6222,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6757,7 +6757,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6808,7 +6808,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6992,7 +6992,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7011,7 +7011,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8009,7 +8009,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/modules/utxo_state/Cargo.toml
+++ b/modules/utxo_state/Cargo.toml
@@ -28,13 +28,13 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 amaru-uplc = { workspace = true }
 serde = { workspace = true }
-hex = { workspace = true }
 
 [lib]
 path = "src/utxo_state.rs"
 
 [dev-dependencies]
 acropolis_test_utils = { path = "../../test_utils" }
+hex.workspace = true
 pallas.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/modules/utxo_state/Cargo.toml
+++ b/modules/utxo_state/Cargo.toml
@@ -28,13 +28,13 @@ rayon = { workspace = true }
 thiserror = { workspace = true }
 amaru-uplc = { workspace = true }
 serde = { workspace = true }
+hex = { workspace = true }
 
 [lib]
 path = "src/utxo_state.rs"
 
 [dev-dependencies]
 acropolis_test_utils = { path = "../../test_utils" }
-hex.workspace = true
 pallas.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/modules/utxo_state/src/validations/babbage/utxow.rs
+++ b/modules/utxo_state/src/validations/babbage/utxow.rs
@@ -44,12 +44,19 @@ fn validate_script_wellformedness(
     reference_script: &ReferenceScript,
     protocol_major_version: u64,
 ) -> Result<(), Box<UTxOWValidationError>> {
-    let (plutus_version, script_bytes) = match reference_script {
+    let (plutus_version, cbor_bytes) = match reference_script {
         ReferenceScript::PlutusV1(bytes) => (PlutusVersion::V1, bytes),
         ReferenceScript::PlutusV2(bytes) => (PlutusVersion::V2, bytes),
         ReferenceScript::PlutusV3(bytes) => (PlutusVersion::V3, bytes),
         _ => return Ok(()),
     };
+    let script_bytes = serde_cbor::from_slice(cbor_bytes).map_err(|e| {
+        Box::new(UTxOWValidationError::MalformedReferenceScripts {
+            script_hash: *script_hash,
+            protocol_major_version,
+            reason: format!("Invalid CBOR Wrapped Bytes: {}", e),
+        })
+    })?;
 
     let arena = Arena::new();
     let _: &Program<DeBruijn> = flat::decode(
@@ -70,6 +77,8 @@ fn validate_script_wellformedness(
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
     use crate::test_utils::TestContext;
     use crate::test_utils::{to_era, to_pallas_era};
@@ -112,5 +121,15 @@ mod tests {
             .collect::<HashMap<ScriptHash, &ReferenceScript>>();
 
         validate(created_reference_scripts, &ctx.protocol_params).map_err(|e| *e)
+    }
+
+    #[test]
+    fn test_script_malformedness() {
+        let script_hash =
+            ScriptHash::from_str("f0aab964eb5df4800b9100f12945ed8e0832c04fe366f8919a7c3a46")
+                .unwrap();
+        let reference_script = ReferenceScript::PlutusV2(hex::decode("455910490101").unwrap());
+        let result = validate_script_wellformedness(&script_hash, &reference_script, 10);
+        assert!(result.is_ok());
     }
 }


### PR DESCRIPTION
## Description

This PR fixes script malformedness check which is caused because we don't decode cbor wrapped script bytes from reference script.

## Related Issue(s)
None

## How was this tested?
Added a test case

## Checklist

- [x] My code builds and passes local tests
- [x] I added/updated tests for my changes, where applicable
- [ ] I updated documentation (if applicable)
- [x] branch has ≤ 5 commits (honor system)
- [x] commit messages tell a coherent story
- [x] branch is up to date with main (rebased on main; fast-forward possible)
- [x] CI/CD passes on the merged-with-main result

## Impact / Side effects
None

## Reviewer notes / Areas to focus
`modules/utxo_state/src/validations/babbage/utxow.rs`: Script Malformedness check
