### PR TITLE
Add MCP server specs and update lessons learned

### DIFF
--- a/.specify/memory/lessons.md
+++ b/.specify/memory/lessons.md
@@ -1,8 +1,8 @@
 ---
 title: Lessons Learned Database
 description: Accumulated lessons from PR reviews and manual entries
-last_updated: 2026-01-22
-total_lessons: 11
+last_updated: 2026-02-12
+total_lessons: 19
 ---
 
 # Lessons Learned
@@ -185,3 +185,123 @@ frequency: 1
 ```
 
 Use `'\''` rather than `'` in regular expressions within shell scripts. This escape sequence (close quote, escaped quote, open quote) allows embedding literal single quotes in single-quoted strings.
+
+
+### L012
+
+```yaml
+lesson_id: L012
+category: architecture
+tags: [dependencies, cargo, reproducibility]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Pin git dependencies to a specific commit or tag. Unpinned git dependencies make builds non-reproducible and can change underneath you. Also avoid adding implementation dependencies in a spec-only PR.
+
+
+### L013
+
+```yaml
+lesson_id: L013
+category: documentation
+tags: [templates, spec, completeness]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Don't ship unfilled template files. If a document (e.g. plan.md) isn't ready, omit it from the PR rather than including placeholder content that could confuse reviewers.
+
+
+### L014
+
+```yaml
+lesson_id: L014
+category: documentation
+tags: [checklists, consistency, spec]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Keep checklists consistent with actual document content. If a spec references specific implementation details (crate names, etc.), don't mark "no implementation details" as passing on the checklist.
+
+
+### L015
+
+```yaml
+lesson_id: L015
+category: testing
+tags: [success-criteria, benchmarks, measurability]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Success criteria must be fully measurable. Define the benchmark environment (hardware/profile), a concrete test corpus (e.g. golden vectors), and precise definitions for subjective terms like "typical scripts" or "equivalent error semantics".
+
+
+### L016
+
+```yaml
+lesson_id: L016
+category: documentation
+tags: [accuracy, codebase, research]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Verify codebase state before documenting existing patterns. Don't claim a pattern exists (e.g. "follows existing error wrapping") without checking the actual code — it may not exist yet.
+
+
+### L017
+
+```yaml
+lesson_id: L017
+category: code-quality
+tags: [types, reuse, duplication]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Reuse existing types from common crates instead of defining new ones. Check `acropolis_common` for existing types (e.g. `ExUnits`, `Transaction`) before creating duplicates in feature modules.
+
+
+### L018
+
+```yaml
+lesson_id: L018
+category: architecture
+tags: [validation, ordering, cardano, phase2]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Phase 2 validation must run sequentially after Phase 1 per transaction, not in a separate async module, because Phase 2 results determine what gets applied (inputs vs collateral). Within a single transaction, scripts can be parallelized.
+
+
+### L019
+
+```yaml
+lesson_id: L019
+category: architecture
+tags: [parallelism, validation, cardano]
+source: pr
+source_ref: "PR #669"
+date: 2026-02-12
+frequency: 1
+```
+
+Parallelism scope for script validation: scripts within the same transaction can run in parallel, and scripts from transactions with independent script contexts can also be parallelized. But cross-transaction parallelism requires care since earlier tx results affect later tx inputs.

--- a/specs/586-mcp-server/contracts/mcp-protocol.md
+++ b/specs/586-mcp-server/contracts/mcp-protocol.md
@@ -1,0 +1,84 @@
+# Contract: MCP Protocol Coverage
+
+This document is the wire-level contract the MCP server promises to its clients. It lists the MCP methods the server implements, what it returns, and how each one ties back to the shared routes registry.
+
+## Server identity
+
+`get_info` returns:
+
+| Field | Value |
+|---|---|
+| `protocol_version` | rmcp default (MCP 1.0) |
+| `server_info.name` | `"acropolis-mcp"` |
+| `server_info.title` | `"Acropolis MCP Server"` |
+| `server_info.version` | crate version of `acropolis_module_mcp_server` |
+| `capabilities` | `resources` and `tools` enabled |
+| `instructions` | One-sentence prompt describing the server's purpose and naming a few tools |
+
+## Methods implemented
+
+### `resources/list`
+
+- **Input**: optional pagination cursor (ignored — single page).
+- **Output**: one entry per `RouteDefinition` in `rest_blockfrost::ROUTES`:
+  - `uri`: the route's `mcp_uri_template` (e.g. `blockfrost://epochs/{number}`)
+  - `name`: the route's `name`
+  - `description`: the route's `description`
+  - `mime_type`: `"application/json"`
+- **Pagination**: `next_cursor = None`. All resources are returned in one response.
+
+### `resources/read`
+
+- **Input**: `{ uri: string }`.
+- **Behavior**:
+  1. Walk `ROUTES`, find the first entry whose `mcp_uri_template` matches the requested URI, extracting `param_names`.
+  2. Call the corresponding handler in `rest_blockfrost` via the existing message bus / handler-table path.
+  3. Return the handler's JSON response as `TextResourceContents` with `mime_type = "application/json"` and `text = serde_json::to_string_pretty(value)`.
+- **Errors**:
+  - No matching template → `INTERNAL_ERROR` with `"Failed to handle resource: <reason>"`.
+  - Handler failure → `INTERNAL_ERROR` with the underlying error message.
+  - JSON serialization failure → `INTERNAL_ERROR` with the serde error.
+
+### `tools/list`
+
+- **Input**: optional pagination cursor (ignored).
+- **Output**: one tool per `RouteDefinition` with:
+  - `name`: snake_cased, `get_`-prefixed transformation of `route.name` (e.g. `"Epoch Information"` → `"get_epoch_information"`).
+  - `description`: the route's `description`.
+  - `inputSchema`: a JSON Schema object whose required `properties` are the entries in `route.param_names`, each typed `string`. If `route.handler_type == WithQuery`, an additional optional `query: string` property is added.
+
+### `tools/call`
+
+- **Input**: `{ name: string, arguments: object }`.
+- **Behavior**:
+  1. Match `name` against the tool list derived from `ROUTES`.
+  2. Read each `param_names[i]` from `arguments` (required, must be a string).
+  3. If `WithQuery`, optionally read `query` from `arguments`.
+  4. Dispatch to the same handler the equivalent REST request would have hit.
+  5. Return the handler's JSON result as the tool's textual content.
+- **Errors**:
+  - Unknown tool name → `INTERNAL_ERROR` with `"Tool call failed: <reason>"`.
+  - Missing or wrongly-typed argument → `INTERNAL_ERROR` with the parameter name in the message.
+  - Handler failure → `INTERNAL_ERROR` with the underlying error message.
+
+## Transport contract
+
+- HTTP server on `<address>:<port>` (default `127.0.0.1:4341`).
+- MCP endpoint mounted at `/mcp` (e.g. `http://127.0.0.1:4341/mcp`).
+- Underlying rmcp `StreamableHttpService` with `LocalSessionManager` — each HTTP client gets an isolated MCP session.
+- No authentication, no rate limiting. See [[research]] R-009 for the rationale and the production-hardening notes.
+
+## Logging contract
+
+At info level, the server logs:
+
+- Startup: `Initializing MCP server on <addr>:<port>`, `Starting Acropolis MCP server on http://<addr>:<port>/mcp`, `MCP server listening on http://<addr>:<port>/mcp`, `MCP server started`.
+- Capability negotiation: `MCP get_info called - advertising <N> tools and <M> resources`.
+- Per-request: `MCP client requested resource list`, `MCP client reading resource: <uri>`, `MCP client requested tools list - returning <N> tools`, `MCP client calling tool: <name>`.
+
+## Out of scope
+
+- Streaming/cursor pagination.
+- Subscriptions / `resources/subscribe`.
+- Prompts and sampling capabilities.
+- TLS termination, auth, rate limiting (operator responsibility — see quickstart and research).

--- a/specs/586-mcp-server/data-model.md
+++ b/specs/586-mcp-server/data-model.md
@@ -1,0 +1,94 @@
+# Data Model: MCP Server for Acropolis
+
+**Phase 1 output for spec `586-mcp-server`.**
+
+This document captures the durable data types introduced by this feature and how the MCP-protocol-level concepts (tools, resources, server info) are derived from them. There is no database, no on-disk format, and no message-bus type added: the entire data model is a shared registry consumed by both the REST and MCP modules.
+
+## RouteDefinition (source of truth)
+
+Defined in `modules/rest_blockfrost/src/routes.rs`. One static, hand-maintained `RouteDefinition` per endpoint.
+
+| Field | Type | Purpose |
+|---|---|---|
+| `topic_pattern` | `&'static str` | Caryatid topic this route binds to, e.g. `"rest.get.epochs.*"`. Used by the REST router. |
+| `rest_path` | `&'static str` | REST path template, e.g. `"/epochs/{number}"`. Used by the REST router and by humans reading the file. |
+| `mcp_uri_template` | `&'static str` | MCP resource URI template, e.g. `"blockfrost://epochs/{number}"`. The MCP module advertises this verbatim. |
+| `name` | `&'static str` | Human-readable name, e.g. `"Epoch Information"`. Used as both the MCP resource name and the seed for the MCP tool's display title. |
+| `description` | `&'static str` | One-sentence description of what the endpoint returns. Used as the MCP description on both tools and resources. |
+| `handler_type` | `HandlerType` | Discriminator: `PathOnly` or `WithQuery`. Drives JSON-schema generation for the tool. |
+| `handler_name` | `&'static str` | Name of the handler function for traceability — not used at runtime. |
+| `param_names` | `&'static [&'static str]` | Ordered list of path parameter names. Defines required tool arguments and is used by the URI matcher when resolving a resource read. |
+
+### Invariants
+
+- For any `RouteDefinition`, every `{name}` placeholder in `rest_path` and `mcp_uri_template` MUST appear in `param_names`, in order.
+- `mcp_uri_template` MUST start with `blockfrost://` so the URI scheme uniquely identifies an Acropolis MCP resource.
+- `name` MUST be unique across `ROUTES` — it is the basis for the tool's name and must not collide.
+
+## HandlerType
+
+```rust
+enum HandlerType {
+    PathOnly,   // handler accepts only path parameters
+    WithQuery,  // handler accepts path parameters plus a query string
+}
+```
+
+Drives one branch in MCP tool schema generation:
+- `PathOnly`: schema has exactly the required path parameters.
+- `WithQuery`: schema additionally has an optional `query` string parameter.
+
+## ROUTES (the registry instance)
+
+`pub const ROUTES: &[RouteDefinition]` is the registry. As of merge it contains 63 entries grouped by section (Accounts, Blocks, Governance – DReps, Governance – Proposals, Pools, Epochs, Assets, Addresses, Transactions). New endpoints are added by appending to this slice; both surfaces pick them up on the next rebuild.
+
+## Derivations
+
+### Registry → MCP resource list (`resources/list`)
+
+For each `RouteDefinition r`, emit one `RawResource`:
+- `uri = r.mcp_uri_template`
+- `name = r.name`
+- `description = r.description`
+- `mime_type = "application/json"`
+- everything else nil/default
+
+### Registry → MCP tool list (`tools/list`)
+
+For each `RouteDefinition r`, emit one `Tool`:
+- `name`: derived from `r.name` via snake_case normalization with a `get_` prefix (e.g. `"Epoch Information"` → `"get_epoch_information"`).
+- `description = r.description`
+- `inputSchema`: a JSON Schema `object` whose properties are each entry in `r.param_names` typed as `string` and listed in `required`. If `r.handler_type == WithQuery`, add an optional `query: string` property.
+
+### Resource read → handler dispatch
+
+Given an incoming `resources/read` URI:
+1. Match it against each `r.mcp_uri_template` in `ROUTES`, extracting the values of `r.param_names`.
+2. The first match wins. Reconstruct the equivalent REST request from the matched `RouteDefinition.rest_path` and call the corresponding handler from `rest_blockfrost`.
+3. Wrap the handler's JSON return value in an MCP `TextResourceContents` with `mime_type = "application/json"`.
+
+### Tool call → handler dispatch
+
+Given an incoming `tools/call` with `name = T` and `arguments = A`:
+1. Find the `RouteDefinition` whose derived tool name equals `T`.
+2. Read each `param_names[i]` out of `A` (required, string).
+3. If `WithQuery`, also read the optional `query` field.
+4. Dispatch to the same handler the REST module would have invoked.
+5. Wrap the JSON result as the tool's textual content.
+
+## Server identity (advertised in `get_info`)
+
+| Field | Value |
+|---|---|
+| `server_info.name` | `"acropolis-mcp"` |
+| `server_info.title` | `"Acropolis MCP Server"` |
+| `server_info.version` | `env!("CARGO_PKG_VERSION")` of the `mcp_server` crate |
+| `capabilities` | `resources` + `tools` enabled |
+| `instructions` | A short sentence telling the model that this server exposes Blockfrost-compatible endpoints and naming a few representative tools. |
+
+## Things explicitly *not* in the data model
+
+- No persistent storage. The server is a thin protocol translator.
+- No session-scoped state. Each MCP session is independent.
+- No new message bus types. The MCP module reuses what `rest_blockfrost` already publishes/subscribes to.
+- No per-route auth or rate-limit metadata. (Deferred — see [[research]] R-009.)

--- a/specs/586-mcp-server/plan.md
+++ b/specs/586-mcp-server/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: MCP Server for AI Queries
+
+**Branch**: `586-mcp-server` | **Date**: 2026-05-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/586-mcp-server/spec.md`
+
+> **Note**: This plan is retroactive — the feature shipped as PR #595. The plan reflects the decisions actually made during implementation, not a pre-coding design exercise.
+
+## Summary
+
+Expose Acropolis's Blockfrost-compatible API surface to MCP-capable AI clients (Claude Code, VS Code Copilot, MCP Inspector) by adding an opt-in `mcp_server` Caryatid module to the omnibus process. The module hosts an HTTP/SSE server speaking MCP 1.0 via the `rmcp` crate and turns a shared `RouteDefinition` registry — owned by `rest_blockfrost` — into MCP tools and resources. The MCP module performs no query logic of its own; it dispatches each request to the same handler the REST module would have used.
+
+## Technical Context
+
+**Language/Version**: Rust 1.75+ (workspace pinned via root `Cargo.toml`)
+**Primary Dependencies**:
+- `rmcp = "0.8"` with features `["server", "transport-streamable-http-server"]` — MCP protocol implementation
+- `axum` — HTTP server (workspace version, already used elsewhere)
+- `tokio` — async runtime (workspace version)
+- `caryatid_sdk` — module framework
+- `acropolis_common` — shared types and config helpers
+- `acropolis_module_rest_blockfrost` — handler reuse and the routes registry
+- `serde_json`, `tracing`, `anyhow`, `config` — standard workspace dependencies
+
+**Storage**: None. The module is stateless; all state lives in modules queried via the existing Caryatid message bus.
+**Testing**: `cargo test` for unit coverage; a Python script (`scripts/test_mcp_standalone.py` / `scripts/test_mcp_server.py`) for integration-level verification driving the live HTTP endpoint. MCP Inspector (`npx @anthropics/mcp-inspector`) for ad-hoc exploration.
+**Target Platform**: Linux/macOS server, same as the omnibus process. The HTTP transport is OS-agnostic.
+**Project Type**: Single-project Rust workspace member (`modules/mcp_server/`) plus a thin `processes/mcp_standalone/` binary for clients that prefer a standalone process.
+**Performance Goals**: Match the underlying REST handlers — MCP adds protocol framing only. No new scaling target.
+**Constraints**:
+- Cannot use stdio transport: the omnibus process owns stdio for logging.
+- Must not block other modules during init — the listener spawns in a background task.
+- Must default to disabled and localhost-only.
+**Scale/Scope**: 63 endpoints exposed at the point of merge, growing as `routes.rs` grows. Concurrent MCP sessions limited only by tokio task budget.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+This project does not have a constitution file under `.specify/memory/constitution.md` enforcing programmatic gates for this feature beyond the general principles already encoded in `CLAUDE.md`:
+
+- **Module isolation**: Satisfied — the MCP module touches no other module's state; it consumes the `rest_blockfrost` routes registry as a public symbol and dispatches through the message bus.
+- **Publish-subscribe architecture**: Satisfied — the MCP module is a consumer of existing topics; it adds no new message types.
+- **Opt-in feature flags**: Satisfied — disabled by default, surfaced through `[module.mcp-server]` config.
+- **No production claim**: Satisfied — the host is the omnibus process, which `CLAUDE.md` already labels as testing-only.
+
+Re-check after Phase 1: no constitution violations introduced.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/586-mcp-server/
+├── plan.md              # This file
+├── spec.md              # User-visible spec
+├── research.md          # Phase 0: transport, handler-reuse, and registry decisions
+├── data-model.md        # Phase 1: RouteDefinition shape and tool/resource derivation rules
+├── quickstart.md        # Phase 1: how to enable, configure, and verify the server
+├── contracts/
+│   └── mcp-protocol.md  # MCP method coverage and JSON-schema conventions
+└── tasks.md             # Phase 2: dependency-ordered implementation tasks
+```
+
+### Source Code (repository root)
+
+```text
+modules/
+├── mcp_server/                       # New module
+│   ├── Cargo.toml                    # Depends on rest_blockfrost for handlers + ROUTES
+│   ├── README.md                     # Operator-facing docs
+│   └── src/
+│       ├── mcp_server.rs             # Module entry point + Caryatid lifecycle
+│       ├── server.rs                 # ServerHandler impl, HTTP listener
+│       ├── resources.rs              # URI parsing, resource dispatch, ROUTES → resource list
+│       └── tools.rs                  # Tool-name + JSON-schema generation, tool dispatch
+└── rest_blockfrost/
+    └── src/
+        └── routes.rs                 # NEW — single source of truth: RouteDefinition + ROUTES
+
+processes/
+├── omnibus/
+│   ├── src/main.rs                   # Register MCPServer alongside existing modules
+│   ├── omnibus.toml                  # New [module.mcp-server] section
+│   └── omnibus-local.toml            # Matching local override
+└── mcp_standalone/
+    └── Cargo.toml                    # Thin standalone binary (currently a stub)
+
+scripts/
+├── test_mcp_server.py                # Drive the live MCP endpoint
+└── test_mcp_standalone.py            # Variant for the standalone binary
+
+.vscode/
+└── mcp.json                          # Claude Code / VS Code Copilot integration target
+```
+
+**Structure Decision**: Standard Acropolis module under `modules/`, plus a passive change to `rest_blockfrost` to publish `RouteDefinition` and `ROUTES` as a public API. The MCP module depends on `rest_blockfrost` rather than the other way round so the existing REST module's surface area is untouched semantically and the new module is the only one carrying MCP-specific code.
+
+## Complexity Tracking
+
+> Filled because the implementation introduces a cross-module coupling (`mcp_server` → `rest_blockfrost`) that deserves explicit justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| MCP module depends directly on `rest_blockfrost` (not just on the common message bus) | Needs the `ROUTES` registry and the existing handler functions; routing requests purely via the message bus would require defining a parallel set of query topics and replaying handler logic | Pure message-bus routing would force a second handler registry and re-introduce the very duplication this feature is designed to eliminate (see US3/FR-002) |
+| HTTP/SSE transport rather than stdio | The omnibus owns stdio for logging; HTTP also enables multiple concurrent AI clients out of the box | Stdio is the MCP "happy path" for single-process integrations, but it cannot coexist with the omnibus's existing stdio usage |
+| Two binaries (`mcp_server` module hosted in omnibus + `mcp_standalone` process) | Some clients prefer a dedicated process; the standalone variant exists as a placeholder for that path without forcing the omnibus to give up the in-process route | Maintaining only the in-process module would leave stdio-only MCP clients (Claude Desktop today) unsupported in the long run |

--- a/specs/586-mcp-server/quickstart.md
+++ b/specs/586-mcp-server/quickstart.md
@@ -1,0 +1,98 @@
+# Quickstart: MCP Server for Acropolis
+
+This walks an operator from a clean checkout to a working MCP session against the running omnibus.
+
+## Prerequisites
+
+- An Acropolis checkout that builds cleanly (`make build`).
+- One of the following MCP clients:
+  - Claude Code (uses `.vscode/mcp.json` automatically when present).
+  - VS Code with the MCP extension.
+  - `npx @anthropics/mcp-inspector` for ad-hoc testing.
+
+## 1. Enable the module
+
+Open `processes/omnibus/omnibus.toml` and confirm the `[module.mcp-server]` section is present and enabled:
+
+```toml
+[module.mcp-server]
+enabled = true
+address = "127.0.0.1"   # use 0.0.0.0 only if you understand the risk
+port = 4341
+```
+
+The default is `enabled = false` on a fresh deploy. The module logs `MCP server is disabled in configuration` and binds no port when disabled.
+
+## 2. Run the omnibus
+
+```bash
+make run
+```
+
+You should see, in order:
+
+```
+Initializing MCP server on 127.0.0.1:4341
+Starting Acropolis MCP server on http://127.0.0.1:4341/mcp
+MCP server listening on http://127.0.0.1:4341/mcp
+MCP server started
+```
+
+If the port is busy you will see a `tracing::error!` line; the rest of the node still runs.
+
+## 3. Confirm the server with MCP Inspector
+
+```bash
+npx @anthropics/mcp-inspector
+```
+
+Configure the Inspector with:
+
+- Transport: **HTTP (Streamable HTTP)**
+- URL: `http://127.0.0.1:4341/mcp`
+
+Verify:
+
+- `resources/list` returns ~63 entries, every URI starting with `blockfrost://`.
+- `tools/list` returns the same count, each tool name in `get_*` form.
+- `resources/read` on `blockfrost://epochs/latest` returns a JSON object describing the current epoch.
+- `tools/call` on `get_epoch_information` with `{ "number": "latest" }` returns the same payload.
+
+## 4. Connect Claude Code
+
+Make sure `.vscode/mcp.json` exists at the repo root with:
+
+```json
+{
+  "servers": {
+    "acropolis": {
+      "type": "http",
+      "url": "http://localhost:4341/mcp"
+    }
+  }
+}
+```
+
+Open Claude Code in this workspace and confirm the `acropolis` MCP server appears as connected. Ask:
+
+> "What's the current epoch on this node, and which stake pool produced the most blocks in it?"
+
+Claude should call `get_epoch_information` and one of the pool tools, then synthesize an answer.
+
+## 5. Run the smoke-test script
+
+```bash
+python3 scripts/test_mcp_server.py
+```
+
+The script drives the protocol directly and prints PASS/FAIL for each step. Use this to confirm the server is up before debugging client-side problems.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `Address already in use` in the omnibus logs | Another process owns port 4341. Change `port` or stop the other process. |
+| Client connects but `tools/list` is empty | The `mcp_server` crate did not link against the `rest_blockfrost` routes — check `Cargo.toml` shows the path dependency. |
+| `resources/read` returns "no matching route" | The URI in the request does not match any `mcp_uri_template`. Compare against `tools/list`. |
+| Server logs every call as info and is noisy | Lower `RUST_LOG` to `warn` or filter on `acropolis_module_mcp_server=warn`. |
+| Need to expose to another machine | Set `address = "0.0.0.0"` *and* add a firewall rule. The server has no authentication; do not put it on a public interface. |

--- a/specs/586-mcp-server/research.md
+++ b/specs/586-mcp-server/research.md
@@ -1,0 +1,94 @@
+# Research: MCP Server for Acropolis
+
+**Phase 0 output for spec `586-mcp-server`.**
+
+This document captures the design questions weighed during implementation of the MCP server and the rationale for each choice. It is written retroactively to explain why the code looks the way it does.
+
+## R-001: Which MCP SDK?
+
+**Decision**: Use the `rmcp` Rust crate at version `0.8` with the `transport-streamable-http-server` feature.
+
+**Alternatives considered**:
+- Hand-rolled JSON-RPC framing over `axum` — rejected: MCP 1.0 has enough surface area (capabilities negotiation, resource templating, content types, error codes) that reimplementing it would be net negative on maintenance.
+- Use the Python or TypeScript reference MCP servers and shell out — rejected: pulling another runtime into the omnibus process is heavier than adopting a Rust crate.
+
+**Notes**: Pin the version. PR #669 (and lesson [[L012]]) flag unpinned git dependencies as a reproducibility hazard; `rmcp` is on crates.io so a numeric pin is sufficient.
+
+## R-002: Which transport?
+
+**Decision**: HTTP with Streamable HTTP transport (`StreamableHttpService` over `axum`), exposed at `/mcp` on a configurable address and port (default `127.0.0.1:4341`).
+
+**Alternatives considered**:
+- **stdio transport** — the most common MCP transport and the simplest. Rejected because the omnibus process already owns stdio for tracing/logging; a second consumer of stdin/stdout would race with logs and break interactive use.
+- **WebSocket transport** — rejected because `rmcp` did not ship a stable WebSocket server at the time of implementation, and HTTP/SSE is already widely supported by MCP clients (Claude Code, MCP Inspector).
+
+**Consequence**: Clients that only speak stdio (Claude Desktop at the time of writing) need a thin adapter or the `processes/mcp_standalone/` binary. This is documented in the module README.
+
+## R-003: How is the API surface kept in sync between REST and MCP?
+
+**Decision**: A single `pub const ROUTES: &[RouteDefinition]` in `rest_blockfrost/src/routes.rs` is the source of truth. The REST module mounts handlers from it; the MCP module derives tools and resources from it.
+
+**Alternatives considered**:
+- Maintain two parallel registries — rejected: doubles the maintenance cost and guarantees drift.
+- Generate routes from `axum` router metadata at runtime — rejected: `axum` does not preserve URI parameter names or human-readable descriptions, both of which MCP needs.
+- Macro-driven generation from the handler function signatures — rejected as over-engineering for ~60 entries; the explicit table is greppable and reviewable.
+
+**Notes**: The handler reuse here is what removes the duplication lesson [[L006]] warns about — both surfaces share the same `handle_*` functions.
+
+## R-004: Tools vs. resources — pick one, or expose both?
+
+**Decision**: Expose every route as both a tool and a resource.
+
+**Rationale**:
+- **Tools** (`get_epoch_information`) are easier for the model to call directly with structured arguments and are how Claude Code and Copilot prefer to interact.
+- **Resources** (`blockfrost://epochs/latest`) give browse-style clients and resource-aware UIs a uniform addressing scheme.
+- Both views are cheap to derive from the same `RouteDefinition`, so exposing both is essentially free.
+
+**Alternatives considered**:
+- Tools only — rejected: a real cost only for resource-oriented clients but no win for tool-oriented ones.
+- Resources only — rejected: tools are the de-facto MCP interaction model today.
+
+## R-005: How are tool input schemas generated?
+
+**Decision**: Derive a JSON schema for each tool from `RouteDefinition.param_names` plus the `HandlerType` flag:
+- Every entry in `param_names` becomes a required string parameter.
+- `HandlerType::WithQuery` adds an optional `query` parameter for the request's query string.
+
+**Rationale**: The REST handlers take their path parameters as strings and accept arbitrary query strings, so a string-typed schema is honest about what the handler will accept. Inventing tighter types (numeric `slot`, hex-encoded `hash`) would have to be specified per route, which the registry does not currently model — keep that ambition for a follow-up rather than blocking the MVP.
+
+## R-006: Default port?
+
+**Decision**: 4341 (one above the existing REST port 4340).
+
+**Notes**: Arbitrary, but consistent with the REST module's port and unlikely to clash with anything documented in this repo. PR #595 explicitly flagged this as a reviewer question — no objection was raised.
+
+## R-007: How does the listener interact with module init?
+
+**Decision**: The listener is spawned in a `tokio::spawn` task; `init` returns `Ok(())` immediately after the spawn.
+
+**Rationale**:
+- Caryatid module init is expected to be fast — blocking it on `axum::serve` would prevent other modules from initializing.
+- The spawned task takes ownership of all the values it needs; nothing in the module body holds onto the listener.
+- A failure inside the task is logged via `tracing::error!`. The wider process continues running; the operator notices via logs.
+
+**Trade-off**: A late bind failure (port in use, address unparseable) surfaces as an `error` log rather than aborting the process. This is acceptable for an opt-in development feature. A production-grade rework would surface the bind result back to the caller before reporting "started".
+
+## R-008: Where do per-request logs go?
+
+**Decision**: `tracing::info!` at the entry of `list_resources`, `read_resource`, `list_tools`, and `call_tool`, with the relevant URI / tool name in the message.
+
+**Rationale**: This server is operator-facing and used for debugging AI workflows; info-level visibility on every request is appropriate during the prototype phase. A future polish task can demote routine calls to debug once the surface is mature.
+
+## R-009: Security posture
+
+**Decision**: Bind `127.0.0.1` by default, no authentication, no rate limiting. Document explicitly that production deployments need network-level isolation.
+
+**Alternatives considered**:
+- Add a shared-secret header check — deferred: not in PR #595's scope; the spec marks adding auth as an explicit reviewer question.
+- Require TLS — deferred for the same reason; `axum` supports it but the operational story (cert management) is out of scope here.
+
+## R-010: Standalone binary
+
+**Decision**: Reserve `processes/mcp_standalone/` for a future stdio-transport binary aimed at clients (Claude Desktop) that cannot use HTTP. The directory currently contains only a `Cargo.toml`.
+
+**Notes**: Worth keeping as a deliberate placeholder rather than deleting — the README points at it and the standalone test script exists for the eventual implementation.

--- a/specs/586-mcp-server/spec.md
+++ b/specs/586-mcp-server/spec.md
@@ -1,0 +1,117 @@
+# Feature Specification: MCP Server for AI Queries
+
+**Feature Branch**: `586-mcp-server`
+**Created**: 2026-05-12 (retroactive — feature shipped in PR #595, merged from `cet/mcp_prototype`)
+**Status**: Implemented (spec written after implementation as a speckit reference example)
+**Input**: User description: "Add a Model Context Protocol (MCP) server to the running node so AI clients can query Cardano blockchain data using the Blockfrost-compatible API surface that Acropolis already exposes."
+
+> **Note**: This spec is reverse-engineered from GitHub issue #586, PR #595, the
+> `modules/mcp_server/` source, and `modules/rest_blockfrost/src/routes.rs`. It
+> is preserved as a worked example of the speckit workflow on an existing
+> feature; the prose in this document is what the spec *should* have said
+> before code was written.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Query Blockchain via an MCP-Capable AI Client (Priority: P1)
+
+As an Acropolis user with an MCP-capable AI client (Claude Code, VS Code Copilot, MCP Inspector), I want the running node to expose its Blockfrost-compatible API as MCP tools and resources so that I can ask natural-language questions about live chain state without learning the REST API or shelling out to `curl`.
+
+**Why this priority**: This is the whole feature. Without it nothing else has value. Everything below is an enabler or refinement of this single capability.
+
+**Independent Test**: Run the omnibus with `[module.mcp-server] enabled = true`, connect Claude Code via `.vscode/mcp.json`, ask "what is the current epoch?" and observe a correct answer derived from a `get_epoch_information` tool call.
+
+**Acceptance Scenarios**:
+
+1. **Given** the omnibus is running with the MCP server enabled, **When** an MCP client opens an HTTP/SSE session to `/mcp` on the configured port, **Then** the server completes the MCP handshake and reports `resources` and `tools` capabilities.
+2. **Given** a connected client, **When** the client issues `tools/list`, **Then** the server returns one tool per registered Blockfrost route, each with a JSON-schema description of its parameters.
+3. **Given** a connected client, **When** the client issues `tools/call` with `name = "get_epoch_information"` and `arguments = { "number": "latest" }`, **Then** the server returns the same JSON payload the REST endpoint would have returned for `/epochs/latest`.
+
+---
+
+### User Story 2 - Resource-Style Browsing of Endpoints (Priority: P2)
+
+As an AI client author or human exploring the API, I want each Blockfrost endpoint also exposed as an MCP resource with a stable `blockfrost://` URI template so that clients which prefer resource browsing (rather than tool calling) can list and read endpoints uniformly.
+
+**Why this priority**: Tool calling alone (US1) is enough to deliver value; resources are a usability win for clients with different UX models, but the feature is shippable without them.
+
+**Independent Test**: From a connected client, call `resources/list`, then `resources/read` on `blockfrost://epochs/latest`, and verify the returned JSON matches `tools/call` for `get_epoch_information(number=latest)`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a connected MCP client, **When** the client issues `resources/list`, **Then** the server returns one resource per registered route, each with a URI template, name, description, and `application/json` MIME type.
+2. **Given** a known resource URI like `blockfrost://pools/{pool_id}`, **When** the client issues `resources/read` with the template variable substituted, **Then** the server dispatches the request to the matching Blockfrost handler and returns the JSON result.
+
+---
+
+### User Story 3 - Zero-Duplication Maintenance (Priority: P2)
+
+As an Acropolis contributor adding a new Blockfrost endpoint, I want a single place to declare the endpoint so that the REST server and the MCP server both pick it up automatically with no duplicated handler wiring.
+
+**Why this priority**: Drives long-term maintainability. Independently demonstrable by adding a new route and observing both surfaces gain it without any MCP-side code change.
+
+**Independent Test**: Add a new `RouteDefinition` entry to `routes.rs`, rebuild, and verify the new endpoint shows up in both the REST path table and in the MCP `tools/list` and `resources/list` output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new `RouteDefinition` is appended to `ROUTES`, **When** the omnibus is rebuilt, **Then** the REST module mounts the route and the MCP module advertises a corresponding tool and resource without any other code change.
+2. **Given** a route is removed from `ROUTES`, **When** the omnibus is rebuilt, **Then** the route disappears from both surfaces.
+
+---
+
+### User Story 4 - Opt-In Deployment (Priority: P3)
+
+As a node operator, I want the MCP server to be off by default and bind to localhost when enabled, so that adding the module does not expose a new network surface on existing deployments and so that I can opt in deliberately.
+
+**Why this priority**: Operational safety. Important for adoption but does not gate the demo or the MVP.
+
+**Independent Test**: Build the omnibus without changing config, confirm port 4341 is not bound. Then set `enabled = true`, restart, confirm the server listens on `127.0.0.1:4341` only.
+
+**Acceptance Scenarios**:
+
+1. **Given** the default omnibus configuration, **When** the process starts, **Then** the MCP module logs that it is disabled and binds no port.
+2. **Given** `[module.mcp-server] enabled = true` with no other overrides, **When** the process starts, **Then** the server binds to `127.0.0.1:4341` and not to a public interface.
+3. **Given** `address` and `port` are set in configuration, **When** the process starts, **Then** the server binds to that address and port instead of the defaults.
+
+---
+
+### Edge Cases
+
+- What happens when a client reads a resource URI that does not match any registered route? The server MUST return a structured MCP error (not a panic) identifying the unrecognized URI.
+- What happens when a tool is called with missing or wrongly-typed arguments? The server MUST return a structured MCP error referencing the offending parameter rather than crashing or silently substituting defaults.
+- What happens when the underlying Blockfrost handler returns an error (e.g., upstream query timeout)? The server MUST surface the error to the MCP client as a tool-call/resource-read error with the underlying message.
+- What happens when the configured port is already in use? Startup MUST fail loudly with a clear error; the rest of the node MUST continue to run since the server is spawned in a background task.
+- What happens when multiple MCP clients connect concurrently? Each session MUST be isolated; one client's request MUST NOT block or corrupt another's.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST expose every endpoint registered in the shared routes registry as both an MCP tool and an MCP resource.
+- **FR-002**: The system MUST source endpoint metadata (path, URI template, name, description, parameters) from a single shared registry — the REST and MCP surfaces MUST NOT maintain independent copies.
+- **FR-003**: The system MUST implement the MCP capabilities `resources` and `tools`, and respond correctly to `resources/list`, `resources/read`, `tools/list`, and `tools/call`.
+- **FR-004**: The system MUST reuse the existing Blockfrost request-handling logic to service MCP requests — it MUST NOT reimplement query logic.
+- **FR-005**: The system MUST be opt-in via a configuration flag, defaulting to disabled.
+- **FR-006**: The system MUST default to binding `127.0.0.1` and a non-privileged port when enabled, and MUST honour operator-provided `address`/`port` overrides.
+- **FR-007**: The system MUST return MCP-protocol errors (not panics or unhandled exceptions) for malformed requests, unknown URIs, unknown tool names, and handler failures.
+- **FR-008**: The system MUST run as an Acropolis module under the same Caryatid lifecycle as other modules, and MUST run its HTTP listener in a background task so it does not block module initialization.
+- **FR-009**: The system MUST advertise itself to MCP clients with a stable server name and the module's package version.
+- **FR-010**: The system MUST log the bound address, the resource count, and the tool count at startup, and MUST log each `tools/call` and `resources/read` invocation at info level.
+- **FR-011**: The system MUST support multiple concurrent MCP sessions over HTTP without cross-session interference.
+
+### Key Entities
+
+- **RouteDefinition**: The single source of truth for one Blockfrost endpoint. Holds: REST path template, MCP URI template, topic pattern (for internal message routing), human-readable name and description, handler type (path-only vs. path+query), handler function name, and the ordered list of parameter names extracted from the path. Lives in `rest_blockfrost` so the REST module owns the registry and the MCP module consumes it.
+- **MCP Tool**: A callable function exposed to AI clients. Derived 1:1 from a `RouteDefinition`. Has a snake_case name (e.g. `get_epoch_information`), a JSON-schema input derived from `param_names` and `handler_type`, and a description copied from the route.
+- **MCP Resource**: A readable URI exposed to AI clients. Derived 1:1 from a `RouteDefinition`. Has the `blockfrost://...` URI template, the route's name and description, and an `application/json` MIME type.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With `enabled = true`, Claude Code can connect using the documented `.vscode/mcp.json` configuration and successfully execute at least one tool call end-to-end on the first attempt.
+- **SC-002**: A `tools/list` response contains at least one entry for every Blockfrost route registered in `ROUTES` — the current count is 63 — with no duplicates and no missing entries.
+- **SC-003**: A `resources/list` response contains the same set of endpoints as `tools/list`, with stable `blockfrost://`-scheme URI templates.
+- **SC-004**: Adding one new `RouteDefinition` to `ROUTES` and rebuilding causes both the REST and MCP surfaces to expose the new endpoint, with no code edits in `modules/mcp_server/`.
+- **SC-005**: With `enabled = false` (the default), the node binds no additional port and the MCP module produces a single startup log line indicating it is disabled.
+- **SC-006**: A complex multi-call workflow — for example, "list pools, then for the top 5 fetch info and block counts, then summarise efficiency" — completes end-to-end from a connected AI client driving the server.

--- a/specs/586-mcp-server/tasks.md
+++ b/specs/586-mcp-server/tasks.md
@@ -1,0 +1,152 @@
+---
+description: "Implementation task list for the MCP server feature"
+---
+
+# Tasks: MCP Server for AI Queries
+
+**Input**: Design documents from `/specs/586-mcp-server/`
+**Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/mcp-protocol.md
+
+**Tests**: Manual / script-driven integration tests only. No automated Rust test suite was written in PR #595; that is a polish task. Tasks listed under "(OPTIONAL)" reflect what the feature *should* have if it were re-done.
+
+**Organization**: Tasks are grouped by the user stories in `spec.md` so each story can be implemented and demoed independently.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: User story this task belongs to (US1–US4)
+- File paths are relative to the repository root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [x] T001 Add `modules/mcp_server/` as a new workspace member in the root `Cargo.toml`.
+- [x] T002 Create `modules/mcp_server/Cargo.toml` with dependencies on `acropolis_common`, `acropolis_module_rest_blockfrost`, `caryatid_sdk`, `axum`, `tokio`, `rmcp = "0.8"` (features: `server`, `transport-streamable-http-server`), `tracing`, `serde_json`, `anyhow`, `config`.
+- [x] T003 Stub the module: `modules/mcp_server/src/mcp_server.rs` with the `#[module(...)]` macro, a `MCPServer` struct, and an `init` that reads `enabled/address/port` from config but does nothing else yet.
+
+**Checkpoint**: `cargo build -p acropolis_module_mcp_server` succeeds; the omnibus is not yet aware of the module.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+These tasks introduce the shared registry that every user story depends on.
+
+- [x] T004 [P] Add `modules/rest_blockfrost/src/routes.rs` with `pub enum HandlerType`, `pub struct RouteDefinition`, and `pub const ROUTES: &[RouteDefinition]` (initially empty).
+- [x] T005 [P] Re-export `routes` from `modules/rest_blockfrost/src/lib.rs` so the MCP crate can consume `ROUTES` and `RouteDefinition`.
+- [x] T006 Migrate every existing REST endpoint into a `RouteDefinition` entry in `ROUTES`. Group entries with `// ==================== <section> ====================` separators. End state: 63 entries covering accounts, blocks, governance (DReps + proposals), pools, epochs, assets, addresses, transactions.
+- [x] T007 Refactor the existing REST router to mount handlers from `ROUTES` instead of duplicated wiring.
+- [x] T008 Register `MCPServer` in `processes/omnibus/src/main.rs` via the standard `::register(&mut process)` call.
+- [x] T009 Add `[module.mcp-server]` blocks to `processes/omnibus/omnibus.toml` and `processes/omnibus/omnibus-local.toml` with `enabled = true` for local development and the defaults documented in `quickstart.md`.
+
+**Checkpoint**: `make build` succeeds; the omnibus starts with the MCP module loaded but the server still does nothing.
+
+---
+
+## Phase 3: User Story 1 — Query Blockchain via an MCP-Capable AI Client (Priority: P1) 🎯 MVP
+
+**Goal**: Get `tools/list` and `tools/call` working end-to-end so an AI client can query the chain.
+
+**Independent Test**: `quickstart.md` step 3 (MCP Inspector) calls `tools/call get_epoch_information { number: "latest" }` and gets the expected payload.
+
+### Implementation for User Story 1
+
+- [x] T010 [US1] Implement `modules/mcp_server/src/server.rs::AcropolisMCPServer` holding `Arc<Context<Message>>` and `Arc<Config>`, plus a `run(address, port)` method that builds the rmcp `StreamableHttpService`, mounts it on an `axum::Router` at `/mcp`, and serves it with `axum::serve`.
+- [x] T011 [US1] Implement `ServerHandler::get_info` returning the server identity laid out in `data-model.md` and `contracts/mcp-protocol.md`.
+- [x] T012 [P] [US1] Implement `modules/mcp_server/src/tools.rs::get_all_tools()` — iterate `ROUTES`, derive the tool name (snake-case + `get_` prefix), build the JSON-schema for `param_names` and the optional `query` field for `WithQuery` handlers.
+- [x] T013 [P] [US1] Implement `tools::list_tools_result()` wrapping the tool list in an MCP `ListToolsResult`.
+- [x] T014 [US1] Implement `tools::handle_tool_call(context, config, name, arguments)` — look up the route by tool name, validate arguments, dispatch into the existing `rest_blockfrost` handler, wrap the JSON result.
+- [x] T015 [US1] Wire `ServerHandler::list_tools` and `ServerHandler::call_tool` in `server.rs` to delegate to `tools.rs`.
+- [x] T016 [US1] Update `mcp_server.rs::init` to spawn `AcropolisMCPServer::run` in `tokio::spawn` when `enabled = true`; log startup lines per the logging contract.
+
+**Checkpoint**: With `make run` and `enabled = true`, MCP Inspector lists 63 tools and a `get_epoch_information` call returns live data.
+
+---
+
+## Phase 4: User Story 2 — Resource-Style Browsing (Priority: P2)
+
+**Goal**: Expose every route as an MCP resource alongside the tool form.
+
+**Independent Test**: `resources/list` and `resources/read blockfrost://epochs/latest` both succeed against the running server.
+
+### Implementation for User Story 2
+
+- [x] T017 [P] [US2] Implement `modules/mcp_server/src/resources.rs::get_all_resources()` returning the same `ROUTES` view typed for resource listing (URI template, name, description).
+- [x] T018 [P] [US2] Implement `resources::handle_resource(context, config, uri)` — match `uri` against every `mcp_uri_template`, extract `param_names`, dispatch through the same handler path tools use.
+- [x] T019 [US2] Wire `ServerHandler::list_resources` and `ServerHandler::read_resource` in `server.rs` to delegate to `resources.rs`, wrapping responses in `TextResourceContents` with `application/json`.
+
+**Checkpoint**: `tools/list` and `resources/list` describe the same set of endpoints.
+
+---
+
+## Phase 5: User Story 3 — Zero-Duplication Maintenance (Priority: P2)
+
+**Goal**: Prove that adding/removing a `RouteDefinition` automatically propagates to both surfaces.
+
+**Independent Test**: Append a new `RouteDefinition` to `ROUTES`, rebuild, and verify it appears in both `tools/list` (new tool name) and `resources/list` (new URI template) without any other code change.
+
+### Implementation for User Story 3
+
+- [x] T020 [US3] Audit the REST router from T007 to confirm it has no parallel hand-rolled route table; everything must go through `ROUTES`.
+- [x] T021 [US3] Document the contract for adding a new endpoint in `modules/mcp_server/README.md` (one paragraph + a pointer to `routes.rs`).
+- [ ] T022 [US3] (OPTIONAL) Add a compile-time test or `build.rs` assertion that every `mcp_uri_template` placeholder appears in `param_names`. Lesson [[L014]] argues for keeping checklists and reality in sync — this is the programmatic version.
+
+---
+
+## Phase 6: User Story 4 — Opt-In Deployment (Priority: P3)
+
+**Goal**: Make the server safe to enable on existing deployments and document the operator path.
+
+**Independent Test**: Two boots — defaults bind no port; `enabled = true` binds `127.0.0.1:4341`. Operator overrides `address`/`port` and observes the new bind.
+
+### Implementation for User Story 4
+
+- [x] T023 [US4] In `mcp_server.rs::init`, return early after logging `MCP server is disabled in configuration` when `enabled = false` (the default).
+- [x] T024 [US4] Honour `address` and `port` from `[module.mcp-server]` with defaults `127.0.0.1` and `4341`. Use `acropolis_common::configuration::get_*` helpers.
+- [x] T025 [US4] Add `.vscode/mcp.json` pointing Claude Code / Copilot at `http://localhost:4341/mcp`.
+- [x] T026 [US4] Write `modules/mcp_server/README.md` covering: overview, configuration block, VS Code / Claude Desktop usage, available tools, and the test-script entry points.
+
+**Checkpoint**: A fresh checkout with default config builds and runs without binding port 4341; flipping `enabled = true` cleanly starts the server.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+These are the gaps PR #595 itself flagged. Track them as follow-ups.
+
+- [ ] T027 [P] Add a Rust integration test that boots the omnibus, performs `tools/list` / `tools/call` over HTTP, and asserts the response matches the registry.
+- [ ] T028 [P] Add a unit test verifying every `RouteDefinition` derives a unique tool name and a non-empty input schema (defends against name collisions when new endpoints are added).
+- [ ] T029 Decide on production posture (auth, rate limit, TLS) and either implement or document the operator-side path. See [[research]] R-009.
+- [ ] T030 Demote per-request `tracing::info!` logs to `debug!` once the surface is stable (see R-008).
+- [ ] T031 Implement `processes/mcp_standalone/` as a real stdio-transport binary for Claude Desktop users (currently a Cargo stub).
+- [ ] T032 (OPTIONAL) Run the spec through `/speckit.analyze` once tasks are merged to validate cross-artifact consistency.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup. Blocks every user story because `ROUTES` is the data backbone.
+- **User Stories**:
+  - **US1 (P1)**: Depends on Phase 2 only. The MVP.
+  - **US2 (P2)**: Depends on Phase 2; integrates cleanly with US1.
+  - **US3 (P2)**: Depends on Phase 2; verifies the design intent rather than adding new surface area.
+  - **US4 (P3)**: Depends on US1 being functional so the gating logic has something to gate.
+- **Polish (Phase 7)**: Depends on the user stories that are in scope being complete.
+
+### Parallel opportunities
+
+- T004 and T005 are independent of each other (different files) and can run in parallel.
+- T012, T013, T017, T018 are independent and can be implemented in parallel by different developers.
+- The smoke-test scripts can be drafted in parallel with code as long as the MCP endpoint contract from `contracts/mcp-protocol.md` is stable.
+
+---
+
+## Notes
+
+- Every `[x]` task above is checked because the work landed in PR #595 (`cet/mcp_prototype`). The few unchecked items are the polish items the PR itself called out.
+- This tasks list is illustrative: re-running `/speckit.tasks` against today's `spec.md` and `plan.md` would regenerate something structurally similar but the IDs would differ.
+- Lessons [[L013]] (don't ship unfilled templates) and [[L014]] (checklists must match reality) shaped how this tasks file is written: every task entry is concrete, references a real file path, and reflects what shipped.


### PR DESCRIPTION
## Summary
- Commit existing spec artifacts for the MCP server feature (`specs/586-mcp-server/`): spec, plan, research, data model, contracts, quickstart, tasks
- Append lessons L012–L019 to `.specify/memory/lessons.md` (drawn from PR #669 review), and bump the database header

## Test plan
- [x] Documentation-only change — confirm no build/test impact
- [x] Verify `lessons.md` header counts and `last_updated` match the appended entries